### PR TITLE
Optimise screenshots for the users manager UI tests

### DIFF
--- a/plugins/UsersManager/tests/UI/IgnoreCookie_spec.js
+++ b/plugins/UsersManager/tests/UI/IgnoreCookie_spec.js
@@ -12,31 +12,47 @@ describe("IgnoreCookie", function () {
 
     var userSettingsUrl = "?module=UsersManager&action=userSettings";
 
+    async function getIgnoreCookieText() {
+        return page.evaluate(() => $('.ignoreCookieSettings').text().replace(/\s+/g, ' ').trim());
+    }
+
     it('should show ignore cookie setting on user settings page', async function () {
         await page.goto(userSettingsUrl);
-        expect(await page.screenshotSelector('.ignoreCookieSettings')).to.matchImage('loaded');
+        await page.waitForSelector('.ignoreCookieSettings', { visible: true });
+
+        const text = await getIgnoreCookieText();
+        expect(text).to.contain('Your visits are not ignored');
+        expect(text).to.contain('Click here to set a cookie');
     });
 
     it('should set an ignore cookie and reload the page correctly when clicking ignore link', async function () {
       await page.click('.ignoreCookieSettings a');
       await page.waitForNetworkIdle();
+      await page.waitForSelector('.ignoreCookieSettings', { visible: true });
 
       var cookies = await page.cookies();
       var ignoreCookie = cookies.filter((cookie) => cookie.name === 'matomo_ignore');
 
       expect(ignoreCookie.length).to.eq(1);
-      expect(await page.screenshotSelector('.ignoreCookieSettings')).to.matchImage('ignored');
+
+      const text = await getIgnoreCookieText();
+      expect(text).to.contain('Your visits are ignored');
+      expect(text).to.contain('Click here to delete the cookie');
     });
 
     it('should remove ignore cookie and reload the page correctly when clicking ignore link again', async function () {
       await page.click('.ignoreCookieSettings a');
       await page.waitForNetworkIdle();
+      await page.waitForSelector('.ignoreCookieSettings', { visible: true });
 
       var cookies = await page.cookies();
       var ignoreCookie = cookies.filter((cookie) => cookie.name === 'matomo_ignore');
 
       expect(ignoreCookie.length).to.eq(0);
-      expect(await page.screenshotSelector('.ignoreCookieSettings')).to.matchImage('reset');
+
+      const text = await getIgnoreCookieText();
+      expect(text).to.contain('Your visits are not ignored');
+      expect(text).to.contain('Click here to set a cookie');
     });
 
     it('should fail when directly opening the ignore cookie action without a nonce', async function () {

--- a/plugins/UsersManager/tests/UI/UserSettings_spec.js
+++ b/plugins/UsersManager/tests/UI/UserSettings_spec.js
@@ -154,6 +154,13 @@ describe("UserSettings", function () {
         await page.waitForNetworkIdle();
         await page.waitForTimeout(200);
 
+        // No password-confirm modal should appear when a token was just created,
+        // because the recent re-auth grace window covers the delete.
+        const passwordModalVisible = await page.evaluate(
+            () => $('.confirm-password-modal.modal.open:visible').length
+        );
+        expect(passwordModalVisible).to.eq(0);
+
         const remainingRows = await getAuthTokenRowCount();
         expect(remainingRows).to.eq(0);
     });
@@ -223,9 +230,11 @@ describe("UserSettings", function () {
         await page.type('#passwordConfirmation', superUserPassword);
         await page.click('#userSettingsTable .btn');
         await page.waitForNetworkIdle();
-        await page.waitForSelector('#notificationContainer .notification', { visible: true });
-
-        const notificationText = await page.evaluate(() => $('#notificationContainer').text());
-        expect(notificationText).to.contain('already using this password');
+        // The controller throws on password reuse, which renders the standalone
+        // error template (full page), not a #notificationContainer notification.
+        await page.waitForFunction(
+            () => document.body.innerText.indexOf('already using this password') !== -1,
+            { timeout: 10000 }
+        );
     });
 });

--- a/plugins/UsersManager/tests/UI/UserSettings_spec.js
+++ b/plugins/UsersManager/tests/UI/UserSettings_spec.js
@@ -20,7 +20,7 @@ describe("UserSettings", function () {
 
     async function getAuthTokenDescriptions() {
         return page.evaluate(() => $('table.listAuthTokens tbody tr:has(.creationDate)').map(function () {
-            return $(this).find('td:nth-child(2)').text().trim();
+            return $(this).find('td:nth-child(2)').html().trim();
         }).get());
     }
 
@@ -92,6 +92,11 @@ describe("UserSettings", function () {
 
         const descriptions = await getAuthTokenDescriptions();
         expect(descriptions.some((d) => d.indexOf('test description') !== -1)).to.eq(true);
+
+        const matchingRow = descriptions.find((d) => d.indexOf('test description') !== -1);
+        expect(matchingRow).to.contain('&lt;img');
+        expect(matchingRow).to.not.match(/<img\b/i);
+        expect(matchingRow).to.not.match(/<script\b/i);
     });
 
     it('should not ask for password when trying to add a second token in quick succession', async function () {

--- a/plugins/UsersManager/tests/UI/UserSettings_spec.js
+++ b/plugins/UsersManager/tests/UI/UserSettings_spec.js
@@ -24,6 +24,15 @@ describe("UserSettings", function () {
         }).get());
     }
 
+    async function getAuthTokenRows() {
+        return page.evaluate(() => $('table.listAuthTokens tbody tr:has(.creationDate)').map(function () {
+            return {
+                description: $(this).find('td:nth-child(2)').html().trim(),
+                expiry: $(this).find('td:nth-child(5)').text().trim(),
+            };
+        }).get());
+    }
+
     before(async function() {
         await page.webpage.setViewport({
             width: 1250,
@@ -146,8 +155,10 @@ describe("UserSettings", function () {
         });
         await page.waitForTimeout(100);
 
-        const descriptions = await getAuthTokenDescriptions();
-        expect(descriptions.some((d) => d.indexOf('no expiration token') !== -1)).to.eq(true);
+        const rows = await getAuthTokenRows();
+        const noExpiryRow = rows.find((r) => r.description.indexOf('no expiration token') !== -1);
+        expect(noExpiryRow, 'no-expiration token row should be present').to.not.eq(undefined);
+        expect(noExpiryRow.expiry).to.eq('Never');
     });
 
     it('should delete all tokens without password confirmation right after one was created', async function () {

--- a/plugins/UsersManager/tests/UI/UserSettings_spec.js
+++ b/plugins/UsersManager/tests/UI/UserSettings_spec.js
@@ -90,10 +90,6 @@ describe("UserSettings", function () {
         await page.click('[vue-entry="UsersManager.AddNewTokenSuccess"] .btn');
         await page.waitForNetworkIdle();
         await page.waitForSelector('.listAuthTokens', { visible: true });
-        await page.evaluate(() => { // give table headers constant width so the screenshot stays the same
-            $('table.listAuthTokens th').css('width', '16%'); // five columns + actions
-        });
-        await page.waitForTimeout(100);
 
         const descriptions = (await getAuthTokenRows()).map((r) => r.description);
         expect(descriptions.some((d) => d.indexOf('test description') !== -1)).to.eq(true);
@@ -146,10 +142,6 @@ describe("UserSettings", function () {
     it('should show new token without expire date on security page', async function () {
         await page.goto(userSecurityUrl);
         await page.waitForSelector('.listAuthTokens', { visible: true });
-        await page.evaluate(() => { // give table headers constant width so the screenshot stays the same
-            $('table.listAuthTokens th').css('width', '16%'); // five columns + actions
-        });
-        await page.waitForTimeout(100);
 
         const rows = await getAuthTokenRows();
         const noExpiryRow = rows.find((r) => r.description.indexOf('no expiration token') !== -1);

--- a/plugins/UsersManager/tests/UI/UserSettings_spec.js
+++ b/plugins/UsersManager/tests/UI/UserSettings_spec.js
@@ -223,8 +223,9 @@ describe("UserSettings", function () {
         await page.type('#passwordConfirmation', superUserPassword);
         await page.click('#userSettingsTable .btn');
         await page.waitForNetworkIdle();
+        await page.waitForSelector('#notificationContainer .notification', { visible: true });
 
-        const bodyText = await page.evaluate(() => document.body.innerText);
-        expect(bodyText).to.contain('already using this password');
+        const notificationText = await page.evaluate(() => $('#notificationContainer').text());
+        expect(notificationText).to.contain('already using this password');
     });
 });

--- a/plugins/UsersManager/tests/UI/UserSettings_spec.js
+++ b/plugins/UsersManager/tests/UI/UserSettings_spec.js
@@ -13,6 +13,17 @@ describe("UserSettings", function () {
     var userSettingsUrl = "?module=UsersManager&action=userSettings";
     var userSecurityUrl = "?module=UsersManager&action=userSecurity";
 
+    async function getAuthTokenRowCount() {
+        // Exclude the empty-state row (which has no .creationDate cell).
+        return page.evaluate(() => $('table.listAuthTokens tbody tr:has(.creationDate)').length);
+    }
+
+    async function getAuthTokenDescriptions() {
+        return page.evaluate(() => $('table.listAuthTokens tbody tr:has(.creationDate)').map(function () {
+            return $(this).find('td:nth-child(2)').text().trim();
+        }).get());
+    }
+
     before(async function() {
         await page.webpage.setViewport({
             width: 1250,
@@ -33,23 +44,41 @@ describe("UserSettings", function () {
     it('should ask for password when trying to add token', async function () {
         await page.click('.addNewToken');
         await page.waitForNetworkIdle();
-        await page.waitForSelector('.loginSection');
-        expect(await page.screenshotSelector('.loginSection')).to.matchImage('add_token_check_password');
+        await page.waitForSelector('.loginSection', { visible: true });
+
+        const passwordVisible = await page.evaluate(() => $('#login_form_password:visible').length === 1);
+        const submitVisible = await page.evaluate(() => $('#login_form_submit:visible').length === 1);
+        expect(passwordVisible).to.eq(true);
+        expect(submitVisible).to.eq(true);
     });
 
     it('should accept correct password', async function () {
         await page.type('#login_form_password', superUserPassword);
         await page.click('#login_form_submit');
         await page.waitForNetworkIdle();
-        await page.waitForSelector('.addTokenForm');
-        expect(await page.screenshotSelector('.admin')).to.matchImage('add_token');
+        await page.waitForSelector('.addTokenForm', { visible: true });
+
+        const formState = await page.evaluate(() => ({
+            descriptionVisible: $('.addTokenForm input[id=description]:visible').length === 1,
+            hasExpirationVisible: $('.addTokenForm #has_expiration').length === 1,
+            submitVisible: $('.addTokenForm input[type=submit]:visible').length === 1,
+        }));
+        expect(formState.descriptionVisible).to.eq(true);
+        expect(formState.hasExpirationVisible).to.eq(true);
+        expect(formState.submitVisible).to.eq(true);
     });
 
     it('should create new token with default expiration date', async function () {
         await page.type('.addTokenForm input[id=description]', 'test description<img src=j&#X41vascript:alert("xss fail")>');
         await page.click('.addTokenForm .btn');
         await page.waitForNetworkIdle();
-        expect(await page.screenshotSelector('.admin')).to.matchImage('add_token_success');
+        await page.waitForFunction(
+            () => $('.admin').text().indexOf('Token successfully generated') !== -1,
+            { timeout: 30000 }
+        );
+
+        const successText = await page.evaluate(() => $('.admin').text());
+        expect(successText).to.contain('Please store your token securely');
     });
 
     it('should show new token with default expire date on security page', async function () {
@@ -60,7 +89,9 @@ describe("UserSettings", function () {
             $('table.listAuthTokens th').css('width', '16%'); // five columns + actions
         });
         await page.waitForTimeout(100);
-        expect(await page.screenshotSelector('.admin')).to.matchImage('load_security_new_token');
+
+        const descriptions = await getAuthTokenDescriptions();
+        expect(descriptions.some((d) => d.indexOf('test description') !== -1)).to.eq(true);
     });
 
     it('should not ask for password when trying to add a second token in quick succession', async function () {
@@ -71,8 +102,10 @@ describe("UserSettings", function () {
         await page.waitForSelector('.listAuthTokens', { visible: true });
         await page.click('.addNewToken');
         await page.waitForNetworkIdle();
-        await page.waitForSelector('.addTokenForm');
-        expect(await page.screenshotSelector('.admin')).to.matchImage('add_token_no_password');
+        await page.waitForSelector('.addTokenForm', { visible: true });
+
+        const loginSectionVisible = await page.evaluate(() => $('.loginSection:visible').length > 0);
+        expect(loginSectionVisible).to.eq(false);
     });
 
     it('should show a date picker with a shorter configured expire interval when clicked into the date field', async function () {
@@ -94,7 +127,10 @@ describe("UserSettings", function () {
         await page.click('.addTokenForm #has_expiration');
         await page.click('.addTokenForm .btn');
         await page.waitForNetworkIdle();
-        expect(await page.screenshotSelector('.admin')).to.matchImage('add_token_no_expiration_success');
+        await page.waitForFunction(
+            () => $('.admin').text().indexOf('Token successfully generated') !== -1,
+            { timeout: 30000 }
+        );
     });
 
     it('should show new token without expire date on security page', async function () {
@@ -104,14 +140,18 @@ describe("UserSettings", function () {
             $('table.listAuthTokens th').css('width', '16%'); // five columns + actions
         });
         await page.waitForTimeout(100);
-        expect(await page.screenshotSelector('.admin')).to.matchImage('load_security_new_token_no_expiration');
+
+        const descriptions = await getAuthTokenDescriptions();
+        expect(descriptions.some((d) => d.indexOf('no expiration token') !== -1)).to.eq(true);
     });
 
     it('should delete all tokens without password confirmation right after one was created', async function () {
         await page.click('button.delete-all-tokens');
         await page.waitForNetworkIdle();
         await page.waitForTimeout(200);
-        expect(await page.screenshotSelector('.admin')).to.matchImage('load_security_no_tokens');
+
+        const remainingRows = await getAuthTokenRowCount();
+        expect(remainingRows).to.eq(0);
     });
 
     it('should show user settings page with all theme mode options', async function () {
@@ -133,7 +173,9 @@ describe("UserSettings", function () {
         await page.click('#newsletterSignupBtn input');
         await page.waitForNetworkIdle();
         await page.waitForFunction(() => !$('#newsletterSignup').is(':visible'));
-        expect(await page.screenshotSelector('.pageWrap')).to.matchImage('signup_success');
+
+        const isNewsletterVisible = await page.evaluate(() => $('#newsletterSignup').is(':visible'));
+        expect(isNewsletterVisible).to.eq(false);
     });
 
     it('should not prompt user to subscribe to newsletter again', async function () {
@@ -141,8 +183,6 @@ describe("UserSettings", function () {
         await page.goto(userSettingsUrl);
         const isNewsletterVisible = await page.evaluate(() => $('#newsletterSignup').is(':visible'));
         expect(isNewsletterVisible, 'newsletter signup should stay hidden after signup').to.equal(false);
-
-        expect(await page.screenshotSelector('.admin')).to.matchImage('already_signed_up');
     });
 
     it('should ask for password confirmation when changing email', async function () {
@@ -151,10 +191,14 @@ describe("UserSettings", function () {
         });
         await page.waitForTimeout(100);
         await page.click('#userSettingsTable .matomo-save-button .btn');
+        await page.waitForSelector('.modal.open', { visible: true });
         await page.waitForTimeout(500); // wait for animation
 
-        let pageWrap = await page.$('.modal.open');
-        expect(await pageWrap.screenshot()).to.matchImage('asks_confirmation');
+        const modalText = await page.evaluate(() => $('.modal.open').text().replace(/\s+/g, ' ').trim());
+        expect(modalText).to.contain('Please re-authenticate to confirm this change');
+
+        const passwordInputVisible = await page.evaluate(() => $('.modal.open #currentUserPassword:visible').length === 1);
+        expect(passwordInputVisible).to.eq(true);
     });
 
     it('should load error when wrong password specified', async function () {
@@ -162,9 +206,10 @@ describe("UserSettings", function () {
         btnNo = await page.jQuery('.modal.open .modal-action:not(.modal-no)');
         await btnNo.click();
         await page.waitForNetworkIdle();
+        await page.waitForSelector('#notificationContainer .notification', { visible: true });
 
-        let pageWrap = await page.$('#notificationContainer');
-        expect(await pageWrap.screenshot()).to.matchImage('wrong_password_confirmed');
+        const notificationText = await page.evaluate(() => $('#notificationContainer').text());
+        expect(notificationText).to.contain('The current password you entered is not correct');
     });
 
     it('should not allow to set the current password as new password', async function () {
@@ -173,6 +218,9 @@ describe("UserSettings", function () {
         await page.type('#passwordBis', superUserPassword);
         await page.type('#passwordConfirmation', superUserPassword);
         await page.click('#userSettingsTable .btn');
-        expect(await page.screenshot({ fullPage: true })).to.matchImage('password_reuse');
+        await page.waitForNetworkIdle();
+
+        const bodyText = await page.evaluate(() => document.body.innerText);
+        expect(bodyText).to.contain('already using this password');
     });
 });

--- a/plugins/UsersManager/tests/UI/UserSettings_spec.js
+++ b/plugins/UsersManager/tests/UI/UserSettings_spec.js
@@ -18,13 +18,9 @@ describe("UserSettings", function () {
         return page.evaluate(() => $('table.listAuthTokens tbody tr:has(.creationDate)').length);
     }
 
-    async function getAuthTokenDescriptions() {
-        return page.evaluate(() => $('table.listAuthTokens tbody tr:has(.creationDate)').map(function () {
-            return $(this).find('td:nth-child(2)').html().trim();
-        }).get());
-    }
-
     async function getAuthTokenRows() {
+        // Description is read via .html() so XSS-escape assertions (&lt;img) can run on
+        // the rendered cell; expiry is the column shown either as a date or "Never".
         return page.evaluate(() => $('table.listAuthTokens tbody tr:has(.creationDate)').map(function () {
             return {
                 description: $(this).find('td:nth-child(2)').html().trim(),
@@ -99,7 +95,7 @@ describe("UserSettings", function () {
         });
         await page.waitForTimeout(100);
 
-        const descriptions = await getAuthTokenDescriptions();
+        const descriptions = (await getAuthTokenRows()).map((r) => r.description);
         expect(descriptions.some((d) => d.indexOf('test description') !== -1)).to.eq(true);
 
         const matchingRow = descriptions.find((d) => d.indexOf('test description') !== -1);

--- a/plugins/UsersManager/tests/UI/UsersManager_spec.js
+++ b/plugins/UsersManager/tests/UI/UsersManager_spec.js
@@ -191,15 +191,29 @@ describe("UsersManager", function () {
     });
 
     it('should select all rows in search when link in table is clicked', async function () {
+        // Before click: header checkbox is on, so the row reads
+        // "The N displayed users are selected. Click to select all M."
+        const before = await page.evaluate(() => ({
+            rowText: $('.pagedUsersList .select-all-row').text().replace(/\s+/g, ' ').trim(),
+            linkText: $('.pagedUsersList .toggle-select-all-in-search').text().replace(/\s+/g, ' ').trim(),
+        }));
+        expect(before.rowText.toLowerCase()).to.contain('displayed users are selected');
+        const totalMatch = before.linkText.match(/(\d+)/);
+        expect(totalMatch, 'before-click link should contain the total matching count').to.not.eq(null);
+        const totalEntries = totalMatch[1];
+
         await page.click('.toggle-select-all-in-search');
         await page.mouse.move(0, 0);
         await page.waitForTimeout(100);
 
-        const selectAllRowText = await page.evaluate(() => $('.pagedUsersList .select-all-row').text().replace(/\s+/g, ' ').trim());
-        // After clicking, the link toggles to a "deselect" / clear-selection prompt
-        expect(selectAllRowText.length).to.be.greaterThan(0);
-        const linkText = await page.evaluate(() => $('.toggle-select-all-in-search').text().trim());
-        expect(linkText.length).to.be.greaterThan(0);
+        // After click: row reads "All M users are selected. Click to select the N displayed users."
+        const visibleLogins = await getVisibleUserLogins();
+        const after = await page.evaluate(() => ({
+            rowText: $('.pagedUsersList .select-all-row').text().replace(/\s+/g, ' ').trim(),
+            linkText: $('.pagedUsersList .toggle-select-all-in-search').text().replace(/\s+/g, ' ').trim(),
+        }));
+        expect(after.rowText).to.match(new RegExp(`All\\s+${totalEntries}\\s+users are selected`));
+        expect(after.linkText).to.contain(String(visibleLogins.length));
     });
 
     it('should deselect all rows in search except for displayed rows when link in table is clicked again', async function () {
@@ -581,7 +595,7 @@ describe("UsersManager", function () {
         // The three rows previously selected (indices 0, 3, 8) should now be admin.
         const roles = await getVisibleSiteRoles();
         const adminCount = Object.values(roles).filter((role) => role === 'string:admin').length;
-        expect(adminCount).to.be.greaterThan(0);
+        expect(adminCount).to.eq(3);
     });
 
     it('should filter the permissions when the filters are used', async function () {

--- a/plugins/UsersManager/tests/UI/UsersManager_spec.js
+++ b/plugins/UsersManager/tests/UI/UsersManager_spec.js
@@ -52,6 +52,17 @@ describe("UsersManager", function () {
         }, rowSelector);
     }
 
+    // Returns the per-row access level shown in the manage-users access column,
+    // excluding superuser rows (whose select is disabled and not part of bulk ops).
+    async function getVisibleAccessLevels() {
+        return page.evaluate(() => {
+            return $('#manageUsersTable tbody tr').map(function () {
+                const sel = $(this).find('.access-cell li[role="option"][aria-selected="true"]').text().trim();
+                return sel || null;
+            }).get().filter((v) => v && v.toLowerCase() !== 'superuser');
+        });
+    }
+
     before(async function() {
         await page.webpage.setViewport({
             width: 1250,
@@ -152,6 +163,10 @@ describe("UsersManager", function () {
             $('select[name=access-level-filter]').val('string:').change();
             $('select[name=status-level-filter]').val('string:').change();
         });
+        await page.waitForNetworkIdle();
+        await page.waitForSelector('.pagedUsersList:not(.loading)');
+
+        const beforeAccess = await getVisibleAccessLevels();
 
         await page.evaluate(() => $('th.role_header .siteSelector a.title').click());
         await page.waitForNetworkIdle();
@@ -161,9 +176,15 @@ describe("UsersManager", function () {
         });
         await page.waitForNetworkIdle();
         await page.waitForTimeout(500);
+        await page.waitForSelector('.pagedUsersList:not(.loading)');
 
         const selectedSite = await page.evaluate(() => $('th.role_header .siteSelector .title').text().trim());
         expect(selectedSite.toLowerCase()).to.contain('relentless');
+
+        // The access column should refresh to per-user access for the relentless site,
+        // which differs from the default site's pattern given the ManyUsers fixture.
+        const afterAccess = await getVisibleAccessLevels();
+        expect(afterAccess).to.not.deep.equal(beforeAccess);
     });
 
     it('should select rows when individual row select is clicked', async function () {
@@ -258,12 +279,7 @@ describe("UsersManager", function () {
 
         // Bulk role changes do not apply to superusers (their select is disabled), so
         // exclude rows whose access cell shows "Superuser".
-        const accessLevels = await page.evaluate(() => {
-            return $('#manageUsersTable tbody tr').map(function () {
-                const sel = $(this).find('.access-cell li[role="option"][aria-selected="true"]').text().trim();
-                return sel || null;
-            }).get().filter((v) => v && v.toLowerCase() !== 'superuser');
-        });
+        const accessLevels = await getVisibleAccessLevels();
         expect(accessLevels.length).to.be.greaterThan(0);
         accessLevels.forEach((level) => {
             expect(level.toLowerCase()).to.contain('admin');
@@ -280,12 +296,7 @@ describe("UsersManager", function () {
         await page.waitForNetworkIdle();
         await page.waitForSelector('.pagedUsersList:not(.loading)');
 
-        const accessLevels = await page.evaluate(() => {
-            return $('#manageUsersTable tbody tr').map(function () {
-                const sel = $(this).find('.access-cell li[role="option"][aria-selected="true"]').text().trim();
-                return sel || null;
-            }).get().filter((v) => v && v.toLowerCase() !== 'superuser');
-        });
+        const accessLevels = await getVisibleAccessLevels();
         expect(accessLevels.length).to.be.greaterThan(0);
         accessLevels.forEach((level) => {
             expect(level.toLowerCase()).to.contain('no access');
@@ -506,7 +517,8 @@ describe("UsersManager", function () {
         }));
         expect(allSelectedState.headerChecked).to.eq(true);
         expect(allSelectedState.allBodyChecked).to.eq(true);
-        expect(allSelectedState.selectAllRowText.length).to.be.greaterThan(0);
+        // After clicking the in-row link, the row reads "All N websites are selected. ..."
+        expect(allSelectedState.selectAllRowText).to.match(/All\s+\d+\s+websites are selected/);
     });
 
     it('should add access to all websites when bulk access is used on all websites in search', async function () {
@@ -1017,12 +1029,13 @@ describe("UsersManager", function () {
             await page.waitForSelector('.userEditForm', { visible: true });
 
             const editState = await page.evaluate(() => ({
-                emailDisabled: $('.userEditForm #user_email').is(':disabled')
-                    || $('.userEditForm #user_email[readonly]').length > 0
-                    || $('.userEditForm #user_email').length === 0,
+                emailExists: $('.userEditForm #user_email').length === 1,
+                emailDisabledOrReadonly: $('.userEditForm #user_email').is(':disabled')
+                    || $('.userEditForm #user_email[readonly]').length > 0,
                 basicInfoSaveButton: $('.userEditForm .basic-info-tab .matomo-save-button .btn:visible').length,
             }));
-            expect(editState.emailDisabled).to.eq(true);
+            expect(editState.emailExists).to.eq(true);
+            expect(editState.emailDisabledOrReadonly).to.eq(true);
             // Admins should not have a save button on the basic info tab
             expect(editState.basicInfoSaveButton).to.eq(0);
         });

--- a/plugins/UsersManager/tests/UI/UsersManager_spec.js
+++ b/plugins/UsersManager/tests/UI/UsersManager_spec.js
@@ -133,6 +133,8 @@ describe("UsersManager", function () {
     });
 
     it('should filter by username and access level when the inputs are filled', async function () {
+        const unfilteredLogins = await getVisibleUserLogins();
+
         await page.evaluate(function () {
             $('select[name=access-level-filter]').val('string:view').change();
             $('#user-text-filter').val('ight').change();
@@ -151,10 +153,18 @@ describe("UsersManager", function () {
         expect(filterValues.text).to.eq('ight');
         expect(filterValues.status).to.eq('string:pending');
 
-        // text-filter matches login OR email, so any matching row is fine; just confirm
-        // the filter narrowed the set to at least one row.
-        const visibleLogins = await getVisibleUserLogins();
-        expect(visibleLogins.length).to.be.greaterThan(0);
+        // The text filter matches login OR email; the fixture's pending invitees
+        // (`000pendingUser1` / `zzzpendingUser2`) carry `light`-suffixed emails so
+        // they match both 'ight' and pending. Verify the table actually narrowed
+        // and that every visible row matches the text filter.
+        const visibleEntries = await page.evaluate(() => $('.pagedUsersList tbody tr').map(function () {
+            return $(this).text().toLowerCase();
+        }).get());
+        expect(visibleEntries.length).to.be.greaterThan(0);
+        expect(visibleEntries.length).to.be.lessThan(unfilteredLogins.length);
+        visibleEntries.forEach((rowText) => {
+            expect(rowText).to.contain('ight');
+        });
     });
 
     it('should display access for a different site when the roles for select is changed', async function () {
@@ -268,6 +278,8 @@ describe("UsersManager", function () {
         await page.waitForTimeout(350); // wait for animation
 
         const modalText = await page.evaluate(() => $('.change-user-role-confirm-modal').text().replace(/\s+/g, ' ').trim());
+        expect(modalText.toLowerCase()).to.contain('are you sure');
+        expect(modalText.toLowerCase()).to.contain('selected users');
         expect(modalText.toLowerCase()).to.contain('admin');
     });
 
@@ -754,7 +766,8 @@ describe("UsersManager", function () {
         await page.waitForTimeout(500);
 
         const modalText = await page.evaluate(() => $('.modal.open').text().replace(/\s+/g, ' ').trim());
-        expect(modalText.toLowerCase()).to.contain('superuser');
+        // Uses the AddSuperuserAccessConfirm warning copy, unique to this modal.
+        expect(modalText.toLowerCase()).to.contain('full control over matomo');
 
         const passwordInputExists = await page.evaluate(() => $('.modal.open #currentUserPassword').length === 1);
         expect(passwordInputExists).to.eq(true);
@@ -1028,14 +1041,13 @@ describe("UsersManager", function () {
             await page.waitForNetworkIdle();
             await page.waitForSelector('.userEditForm', { visible: true });
 
+            // UserEditForm renders #user_email only for superusers; admins editing
+            // another user must not see the email field at all (per the form template).
             const editState = await page.evaluate(() => ({
                 emailExists: $('.userEditForm #user_email').length === 1,
-                emailDisabledOrReadonly: $('.userEditForm #user_email').is(':disabled')
-                    || $('.userEditForm #user_email[readonly]').length > 0,
                 basicInfoSaveButton: $('.userEditForm .basic-info-tab .matomo-save-button .btn:visible').length,
             }));
-            expect(editState.emailExists).to.eq(true);
-            expect(editState.emailDisabledOrReadonly).to.eq(true);
+            expect(editState.emailExists).to.eq(false);
             // Admins should not have a save button on the basic info tab
             expect(editState.basicInfoSaveButton).to.eq(0);
         });
@@ -1057,12 +1069,21 @@ describe("UsersManager", function () {
             await page.evaluate(function () {
               $('.access-filter select').val('string:admin').change();
             });
+            await page.waitForNetworkIdle();
+            await page.waitForFunction(() => !$('.userPermissionsEdit').hasClass('loading'));
             await page.waitForTimeout(500); // wait for animation
 
             await page.mouse.move(-10, -10);
 
             const filterValue = await page.evaluate(() => $('.access-filter select').val());
             expect(filterValue).to.eq('string:admin');
+
+            // Every visible site row should reflect the admin filter.
+            const roleValues = await getRoleSelectValues('#sitesForPermission tbody tr:not(.select-all-row)');
+            expect(roleValues.length).to.be.greaterThan(0);
+            roleValues.forEach((role) => {
+                expect(role).to.eq('string:admin');
+            });
       });
 
         it('should show the add existing user modal', async function () {
@@ -1096,10 +1117,10 @@ describe("UsersManager", function () {
             await page.waitForSelector('.pagedUsersList:not(.loading)');
             await page.waitForTimeout(1000); // for opacity to change
 
-            // Filter is set to the new user's email; the user should now appear in
-            // the list (matched by email by the user-text-filter).
-            const rowCount = await page.evaluate(() => $('.pagedUsersList tbody tr td#userLogin').length);
-            expect(rowCount).to.be.greaterThan(0);
+            // Filter is set to the new user's email; the user owning that email
+            // (login `0login3`, fixture-generated) should now appear in the list.
+            const visibleLogins = await getVisibleUserLogins();
+            expect(visibleLogins).to.include('0login3');
         });
 
         it('should add a user by username when a username is entered', async function () {

--- a/plugins/UsersManager/tests/UI/UsersManager_spec.js
+++ b/plugins/UsersManager/tests/UI/UsersManager_spec.js
@@ -32,6 +32,26 @@ describe("UsersManager", function () {
         });
     }
 
+    async function getVisibleUserLogins() {
+        return page.evaluate(() => {
+            return $('.pagedUsersList tbody tr td#userLogin').map(function () {
+                return $(this).text().trim();
+            }).get();
+        });
+    }
+
+    async function getSelectedUserCount() {
+        return page.evaluate(() => $('.pagedUsersList tbody td.select-cell input:checked').length);
+    }
+
+    async function getRoleSelectValues(rowSelector) {
+        return page.evaluate((rowSelector) => {
+            return $(rowSelector).find('.role-select select').map(function () {
+                return $(this).val();
+            }).get();
+        }, rowSelector);
+    }
+
     before(async function() {
         await page.webpage.setViewport({
             width: 1250,
@@ -47,6 +67,11 @@ describe("UsersManager", function () {
         } catch (err) {
             // ignore
         }
+        // Reset plugin load/unload state set by the ActivityLog / Marketplace
+        // variant tests so subsequent UI runs do not inherit a polluted environment.
+        delete testEnvironment.pluginsToLoad;
+        delete testEnvironment.pluginsToUnload;
+        await testEnvironment.save();
     });
 
     it('should display the manage users page correctly', async function () {
@@ -57,34 +82,43 @@ describe("UsersManager", function () {
 
     it('should show password confirmation when signing out a single user', async function () {
         await (await page.jQuery('.signoutuser:eq(0)')).click();
-        const modal = await page.waitForSelector('.modal.open', { visible: true });
+        await page.waitForSelector('.modal.open', { visible: true });
         await page.focus('.modal.open #currentUserPassword');
         await page.waitForTimeout(250);
-        expect(await modal.screenshot()).to.matchImage({
-            imageName: 'signout_single_confirm',
-            comparisonThreshold: 0.025
-        });
+
+        const modalText = await page.evaluate(() => $('.modal.open').text().replace(/\s+/g, ' ').trim());
+        expect(modalText).to.contain('Are you sure you want to sign');
+        expect(modalText).to.contain('out of all active sessions');
+
+        const passwordInputExists = await page.evaluate(() => $('.modal.open #currentUserPassword').length === 1);
+        expect(passwordInputExists).to.eq(true);
     });
 
     it('should show signout success notification when confirmed sign out', async function () {
         await page.type('.modal.open #currentUserPassword', superUserPassword);
         await page.waitForTimeout(250);
         await (await page.jQuery('.confirm-password-modal .confirm-password-btn:visible')).click();
-        await page.waitForTimeout(250);
-        expect(await page.screenshotSelector('.notification-success')).to.matchImage({
-            imageName: 'signout_single_confirmed',
-            comparisonThreshold: 0.025
-        });
+        await page.waitForSelector('.notification-success', { visible: true });
+
+        const notificationText = await page.evaluate(() => $('.notification-success').text());
+        expect(notificationText).to.contain('has been signed out of all active sessions');
     });
 
     it('should change the results page when next is clicked', async function () {
+        const initialLogins = await getVisibleUserLogins();
+
         await (await page.jQuery('.notification-success .close')).click();
         await page.waitForTimeout(250);
         await page.click('.usersListPagination .btn.next');
         await page.mouse.move(-10, -10);
         await page.waitForNetworkIdle();
+        await page.waitForSelector('.pagedUsersList:not(.loading)');
 
-        expect(await page.screenshotSelector('.usersManager')).to.matchImage('next_click');
+        const newLogins = await getVisibleUserLogins();
+        expect(newLogins.length).to.be.greaterThan(0);
+        // No overlap between previous page and current page
+        const overlap = newLogins.filter((login) => initialLogins.indexOf(login) !== -1);
+        expect(overlap).to.deep.equal([]);
     });
 
     it('should filter by username and access level when the inputs are filled', async function () {
@@ -97,7 +131,19 @@ describe("UsersManager", function () {
         await page.waitForNetworkIdle();
         await page.waitForTimeout(1000); // wait for rendering
 
-        expect(await page.screenshotSelector('.usersManager')).to.matchImage('filters');
+        const filterValues = await page.evaluate(() => ({
+            access: $('select[name=access-level-filter]').val(),
+            text: $('#user-text-filter').val(),
+            status: $('select[name=status-level-filter]').val(),
+        }));
+        expect(filterValues.access).to.eq('string:view');
+        expect(filterValues.text).to.eq('ight');
+        expect(filterValues.status).to.eq('string:pending');
+
+        // text-filter matches login OR email, so any matching row is fine; just confirm
+        // the filter narrowed the set to at least one row.
+        const visibleLogins = await getVisibleUserLogins();
+        expect(visibleLogins.length).to.be.greaterThan(0);
     });
 
     it('should display access for a different site when the roles for select is changed', async function () {
@@ -116,7 +162,8 @@ describe("UsersManager", function () {
         await page.waitForNetworkIdle();
         await page.waitForTimeout(500);
 
-        expect(await page.screenshotSelector('.usersManager')).to.matchImage('role_for');
+        const selectedSite = await page.evaluate(() => $('th.role_header .siteSelector .title').text().trim());
+        expect(selectedSite.toLowerCase()).to.contain('relentless');
     });
 
     it('should select rows when individual row select is clicked', async function () {
@@ -126,7 +173,8 @@ describe("UsersManager", function () {
         await page.mouse.move(0, 0);
         await page.waitForTimeout(500); // for checkbox animations
 
-        expect(await page.screenshotSelector('.usersManager')).to.matchImage('rows_selected');
+        const checkedCount = await getSelectedUserCount();
+        expect(checkedCount).to.eq(3);
     });
 
     it('should select all rows when all row select is clicked', async function () {
@@ -134,7 +182,12 @@ describe("UsersManager", function () {
         await page.mouse.move(0, 0);
         await page.waitForTimeout(500); // for checkbox animations
 
-        expect(await page.screenshotSelector('.usersManager')).to.matchImage('all_rows_selected');
+        const visibleLogins = await getVisibleUserLogins();
+        const checkedCount = await getSelectedUserCount();
+        expect(checkedCount).to.eq(visibleLogins.length);
+
+        const headerChecked = await page.evaluate(() => $('th.select-cell input').is(':checked'));
+        expect(headerChecked).to.eq(true);
     });
 
     it('should select all rows in search when link in table is clicked', async function () {
@@ -142,7 +195,11 @@ describe("UsersManager", function () {
         await page.mouse.move(0, 0);
         await page.waitForTimeout(100);
 
-        expect(await page.screenshotSelector('.usersManager')).to.matchImage('all_rows_in_search');
+        const selectAllRowText = await page.evaluate(() => $('.pagedUsersList .select-all-row').text().replace(/\s+/g, ' ').trim());
+        // After clicking, the link toggles to a "deselect" / clear-selection prompt
+        expect(selectAllRowText.length).to.be.greaterThan(0);
+        const linkText = await page.evaluate(() => $('.toggle-select-all-in-search').text().trim());
+        expect(linkText.length).to.be.greaterThan(0);
     });
 
     it('should deselect all rows in search except for displayed rows when link in table is clicked again', async function () {
@@ -150,7 +207,10 @@ describe("UsersManager", function () {
         await page.mouse.move(0, 0);
         await page.waitForTimeout(100);
 
-        expect(await page.screenshotSelector('.usersManager')).to.matchImage('all_rows_deselected');
+        // After deselecting all-in-search, only the displayed page rows remain checked
+        const visibleLogins = await getVisibleUserLogins();
+        const checkedCount = await getSelectedUserCount();
+        expect(checkedCount).to.eq(visibleLogins.length);
     });
 
     it('should show bulk action confirm when bulk change access option used', async function () {
@@ -172,15 +232,28 @@ describe("UsersManager", function () {
         await (await page.jQuery('#bulk-set-access a:contains(Admin)')).click();
         await page.waitForTimeout(350); // wait for animation
 
-        expect(await (await page.$('.change-user-role-confirm-modal')).screenshot()).to.matchImage('bulk_set_access_confirm');
+        const modalText = await page.evaluate(() => $('.change-user-role-confirm-modal').text().replace(/\s+/g, ' ').trim());
+        expect(modalText.toLowerCase()).to.contain('admin');
     });
 
     it('should change access for all rows in search when confirmed', async function () {
         await (await page.jQuery('.change-user-role-confirm-modal .modal-close:not(.modal-no):visible')).click();
         await page.mouse.move(-10, -10);
         await page.waitForNetworkIdle();
+        await page.waitForSelector('.pagedUsersList:not(.loading)');
 
-        expect(await page.screenshotSelector('.usersManager')).to.matchImage('bulk_set_access');
+        // Bulk role changes do not apply to superusers (their select is disabled), so
+        // exclude rows whose access cell shows "Superuser".
+        const accessLevels = await page.evaluate(() => {
+            return $('#manageUsersTable tbody tr').map(function () {
+                const sel = $(this).find('.access-cell li[role="option"][aria-selected="true"]').text().trim();
+                return sel || null;
+            }).get().filter((v) => v && v.toLowerCase() !== 'superuser');
+        });
+        expect(accessLevels.length).to.be.greaterThan(0);
+        accessLevels.forEach((level) => {
+            expect(level.toLowerCase()).to.contain('admin');
+        });
     });
 
     it('should remove access to the currently selected site when the bulk remove access option is clicked', async function () {
@@ -191,8 +264,18 @@ describe("UsersManager", function () {
         await (await page.jQuery('.change-user-role-confirm-modal .modal-close:not(.modal-no):visible')).click();
         await page.mouse.move(-10, -10);
         await page.waitForNetworkIdle();
+        await page.waitForSelector('.pagedUsersList:not(.loading)');
 
-        expect(await page.screenshotSelector('.usersManager')).to.matchImage('bulk_remove_access');
+        const accessLevels = await page.evaluate(() => {
+            return $('#manageUsersTable tbody tr').map(function () {
+                const sel = $(this).find('.access-cell li[role="option"][aria-selected="true"]').text().trim();
+                return sel || null;
+            }).get().filter((v) => v && v.toLowerCase() !== 'superuser');
+        });
+        expect(accessLevels.length).to.be.greaterThan(0);
+        accessLevels.forEach((level) => {
+            expect(level.toLowerCase()).to.contain('no access');
+        });
     });
 
     it('should go back to first page when previous button is clicked', async function () {
@@ -204,24 +287,31 @@ describe("UsersManager", function () {
         await page.waitForNetworkIdle();
         await page.waitForSelector('.pagedUsersList:not(.loading)');
 
+        const middlePageLogins = await getVisibleUserLogins();
+
         await page.click('.usersListPagination .btn.prev');
         await page.waitForNetworkIdle();
 
         await page.mouse.move(-10, -10);
         await page.waitForSelector('.pagedUsersList:not(.loading)');
 
-        expect(await page.screenshotSelector('.usersManager')).to.matchImage('previous');
+        const previousPageLogins = await getVisibleUserLogins();
+        expect(previousPageLogins.length).to.be.greaterThan(0);
+        const overlap = previousPageLogins.filter((login) => middlePageLogins.indexOf(login) !== -1);
+        expect(overlap).to.deep.equal([]);
     });
 
     it('should show password confirmation when deleting a single user', async function () {
         await (await page.jQuery('.deleteuser:eq(0)')).click();
-        const modal = await page.waitForSelector('.modal.open', { visible: true });
+        await page.waitForSelector('.modal.open', { visible: true });
         await page.focus('.modal.open #currentUserPassword');
         await page.waitForTimeout(250);
-        expect(await modal.screenshot()).to.matchImage({
-          imageName: 'delete_single_confirm',
-          comparisonThreshold: 0.025
-        });
+
+        const modalText = await page.evaluate(() => $('.modal.open').text().replace(/\s+/g, ' ').trim());
+        expect(modalText.toLowerCase()).to.contain('are you sure you want to delete');
+
+        const passwordInputVisible = await page.evaluate(() => $('.modal.open #currentUserPassword:visible').length === 1);
+        expect(passwordInputVisible).to.eq(true);
     });
 
   it('should hide the confirmation dialog when cancel is clicked and remove the password if one was entered', async function () {
@@ -245,16 +335,21 @@ describe("UsersManager", function () {
       await page.waitForTimeout(250);
 
       await (await page.jQuery('.deleteuser:eq(0)')).click();
-      const modal = await page.waitForSelector('.modal.open', { visible: true });
+      await page.waitForSelector('.modal.open', { visible: true });
       await page.focus('.modal.open #currentUserPassword');
       await page.waitForTimeout(250);
-      expect(await modal.screenshot()).to.matchImage({
-          imageName: 'delete_single_confirm',
-          comparisonThreshold: 0.025
-      });
+
+      const modalText = await page.evaluate(() => $('.modal.open').text().replace(/\s+/g, ' ').trim());
+      expect(modalText.toLowerCase()).to.contain('are you sure you want to delete');
+
+      const passwordInputValue = await page.evaluate(() => $('.modal.open #currentUserPassword').val());
+      expect(passwordInputValue).to.eq('');
   });
 
     it('should delete a single user when the modal is confirmed is clicked', async function () {
+        const beforeLogins = await getVisibleUserLogins();
+        const targetLogin = beforeLogins[0];
+
         await page.type('.modal.open #currentUserPassword', superUserPassword);
         await (await page.jQuery('.confirm-password-modal .modal-close:not(.modal-no):visible')).click();
         await page.waitForNetworkIdle();
@@ -262,7 +357,8 @@ describe("UsersManager", function () {
         await page.mouse.move(-10, -10);
         await page.waitForSelector('.pagedUsersList:not(.loading)');
 
-        expect(await page.screenshotSelector('.usersManager')).to.matchImage('delete_single');
+        const afterLogins = await getVisibleUserLogins();
+        expect(afterLogins).to.not.include(targetLogin);
     });
 
     it('should show password confirmation when deleting multiple user using bulk action', async function () {
@@ -270,16 +366,21 @@ describe("UsersManager", function () {
 
         await page.click('.bulk-actions.btn');
         await (await page.jQuery('#user-list-bulk-actions a:contains(Delete Users)')).click();
-        const modal = await page.waitForSelector('.modal.open', { visible: true });
+        await page.waitForSelector('.modal.open', { visible: true });
         await page.focus('.modal.open #currentUserPassword');
         await page.waitForTimeout(250);
-        expect(await modal.screenshot()).to.matchImage({
-          imageName: 'delete_bulk_confirm',
-          comparisonThreshold: 0.025
-        });
+
+        const modalText = await page.evaluate(() => $('.modal.open').text().replace(/\s+/g, ' ').trim());
+        expect(modalText.toLowerCase()).to.contain('are you sure you want to delete');
+        expect(modalText.toLowerCase()).to.contain('selected users');
+
+        const passwordInputVisible = await page.evaluate(() => $('.modal.open #currentUserPassword:visible').length === 1);
+        expect(passwordInputVisible).to.eq(true);
     });
 
     it('should delete selected users when delete users bulk action is used', async function () {
+        const beforeLogins = await getVisibleUserLogins();
+
         await page.type('.modal.open #currentUserPassword', superUserPassword);
         await (await page.jQuery('.confirm-password-modal .modal-close:not(.modal-no):visible')).click();
         await page.waitForNetworkIdle();
@@ -287,14 +388,26 @@ describe("UsersManager", function () {
         await page.mouse.move(-10, -10);
         await page.waitForSelector('.pagedUsersList:not(.loading)');
 
-        expect(await page.screenshotSelector('.usersManager')).to.matchImage('delete_bulk_access');
+        const afterLogins = await getVisibleUserLogins();
+        const stillPresent = beforeLogins.filter((login) => afterLogins.indexOf(login) !== -1);
+        expect(stillPresent).to.deep.equal([]);
     });
 
     it('should show the add new user form when the add new user button is clicked', async function () {
         await page.click('.add-user-container .btn');
         await page.waitForNetworkIdle();
+        await page.waitForSelector('.userInviteForm', { visible: true });
 
-        expect(await page.screenshotSelector('.usersManager')).to.matchImage('add_new_user_form');
+        const formState = await page.evaluate(() => ({
+            loginVisible: $('#user_login:visible').length === 1,
+            emailVisible: $('#user_email:visible').length === 1,
+            siteSelectorVisible: $('.userInviteForm .siteSelector:visible').length === 1,
+            saveButtonVisible: $('.userInviteForm .matomo-save-button input:visible').length === 1,
+        }));
+        expect(formState.loginVisible).to.eq(true);
+        expect(formState.emailVisible).to.eq(true);
+        expect(formState.siteSelectorVisible).to.eq(true);
+        expect(formState.saveButtonVisible).to.eq(true);
     });
 
     it('should show confirmation when inviting a user', async function () {
@@ -305,13 +418,15 @@ describe("UsersManager", function () {
         await (await page.jQuery('.userInviteForm .siteSelector .custom_select_ul_list a:eq(1):visible', { waitFor: true })).click();
 
         await page.evaluate(() => $('.userInviteForm .matomo-save-button input').click());
-        const modal = await page.waitForSelector('.modal.open', { visible: true });
+        await page.waitForSelector('.modal.open', { visible: true });
         await page.focus('.modal.open #currentUserPassword');
         await page.waitForTimeout(250);
-        expect(await modal.screenshot()).to.matchImage({
-            imageName: 'invite_confirm',
-            comparisonThreshold: 0.025
-        });
+
+        const modalText = await page.evaluate(() => $('.modal.open').text().replace(/\s+/g, ' ').trim());
+        expect(modalText.toLowerCase()).to.match(/please (re-authenticate|confirm)/);
+
+        const passwordInputExists = await page.evaluate(() => $('.modal.open #currentUserPassword').length === 1);
+        expect(passwordInputExists).to.eq(true);
     });
 
     it('should show the edit user form when user has been invited', async function () {
@@ -319,8 +434,14 @@ describe("UsersManager", function () {
         await (await page.jQuery('.confirm-password-modal .modal-close:not(.modal-no):visible')).click();
         await page.waitForNetworkIdle();
         await page.waitForFunction(() => $('.modal.open').length === 0);
+        await page.waitForSelector('.userEditForm', { visible: true });
 
-        expect(await page.screenshotSelector('.usersManager')).to.matchImage('user_created');
+        const userEditState = await page.evaluate(() => ({
+            login: $('.userEditForm #user_login').val(),
+            email: $('.userEditForm #user_email').val(),
+        }));
+        expect(userEditState.login).to.eq('000newuser');
+        expect(userEditState.email).to.eq('theuser@email.com');
     });
 
     it('should warn about invitation resend when changing email', async function () {
@@ -328,13 +449,11 @@ describe("UsersManager", function () {
         await page.evaluate(() => $('.userEditForm .matomo-save-button input:visible').click());
         await page.waitForTimeout(100);
         await page.waitForFunction(() => $('.modal.open:visible').length)
-        const modal = await page.jQuery('.modal.open:visible');
         await page.focus('.modal.open #currentUserPassword');
         await page.waitForTimeout(250);
-        expect(await modal.screenshot()).to.matchImage({
-          imageName: 'user_invited_change',
-          comparisonThreshold: 0.025
-        });
+
+        const modalText = await page.evaluate(() => $('.modal.open:visible').text().replace(/\s+/g, ' ').trim());
+        expect(modalText).to.contain('Changing the email will invalidate the previous invitation');
     });
 
     it('should show the permissions edit when the permissions tab is clicked', async function () {
@@ -365,10 +484,15 @@ describe("UsersManager", function () {
         await page.waitForTimeout(500);
         await page.mouse.move(0, 0);
 
-        expect(await page.screenshotSelector('.usersManager')).to.matchImage({
-            imageName: 'permissions_all_rows_in_search',
-            comparisonThreshold: 0.0005,
-        });
+        const allSelectedState = await page.evaluate(() => ({
+            headerChecked: $('.userPermissionsEdit th.select-cell input').is(':checked'),
+            allBodyChecked: $('#sitesForPermission tbody tr:not(.select-all-row) td.select-cell input').length > 0
+                && $('#sitesForPermission tbody tr:not(.select-all-row) td.select-cell input:not(:checked)').length === 0,
+            selectAllRowText: $('.userPermissionsEdit tr.select-all-row').text().replace(/\s+/g, ' ').trim(),
+        }));
+        expect(allSelectedState.headerChecked).to.eq(true);
+        expect(allSelectedState.allBodyChecked).to.eq(true);
+        expect(allSelectedState.selectAllRowText.length).to.be.greaterThan(0);
     });
 
     it('should add access to all websites when bulk access is used on all websites in search', async function () {
@@ -384,21 +508,34 @@ describe("UsersManager", function () {
 
         await page.waitForNetworkIdle();
         await page.waitForTimeout(250); // animation
+        await page.waitForFunction(() => !$('.userPermissionsEdit').hasClass('loading'));
 
-        expect(await page.screenshotSelector('.usersManager')).to.matchImage({
-            imageName: 'permissions_all_sites_access',
-            comparisonThreshold: 0.0005,
+        const roleValues = await getRoleSelectValues('#sitesForPermission tbody tr:not(.select-all-row)');
+        expect(roleValues.length).to.be.greaterThan(0);
+        roleValues.forEach((role) => {
+            expect(role).to.eq('string:write');
         });
     });
 
     it('should go to the next results page when the next button is clicked', async function () {
+        const beforeSites = await page.evaluate(() => {
+            return $('#sitesForPermission tbody tr:not(.select-all-row) td:eq(1) span').map(function () {
+                return $(this).text().trim();
+            }).get();
+        });
+
         await page.click('.sites-for-permission-pagination a.next');
         await page.waitForNetworkIdle();
+        await page.waitForFunction(() => !$('.userPermissionsEdit').hasClass('loading'));
 
-        expect(await page.screenshotSelector('.usersManager')).to.matchImage({
-            imageName: 'permissions_next',
-            comparisonThreshold: 0.0005,
+        const afterSites = await page.evaluate(() => {
+            return $('#sitesForPermission tbody tr:not(.select-all-row) td:eq(1) span').map(function () {
+                return $(this).text().trim();
+            }).get();
         });
+        expect(afterSites.length).to.be.greaterThan(0);
+        const overlap = afterSites.filter((site) => beforeSites.indexOf(site) !== -1);
+        expect(overlap).to.deep.equal([]);
     });
 
     it('should remove access to a single site when noaccess is selected', async function () {
@@ -409,11 +546,10 @@ describe("UsersManager", function () {
         await (await page.jQuery('.userPermissionsEdit .change-access-confirm-modal .modal-close:not(.modal-no):visible')).click();
         await page.waitForNetworkIdle();
         await page.waitForTimeout(250); // animation
+        await page.waitForFunction(() => !$('.userPermissionsEdit').hasClass('loading'));
 
-        expect(await page.screenshotSelector('.usersManager')).to.matchImage({
-            imageName: 'permissions_remove_single',
-            comparisonThreshold: 0.0005,
-        });
+        const firstRowRole = await page.evaluate(() => $('#sitesForPermission .role-select select').first().val());
+        expect(firstRowRole).to.eq('string:noaccess');
     });
 
     it('should select multiple rows when individual row selects are clicked', async function () {
@@ -423,10 +559,8 @@ describe("UsersManager", function () {
         await page.mouse.move(-10, -10);
         await page.waitForTimeout(1000); // for checkbox animations
 
-        expect(await (await page.$('.usersManager')).screenshot()).to.matchImage({
-            imageName: 'permissions_select_multiple',
-            comparisonThreshold: 0.0005,
-        });
+        const checkedCount = await page.evaluate(() => $('#sitesForPermission tbody tr:not(.select-all-row) td.select-cell input:checked').length);
+        expect(checkedCount).to.eq(3);
     });
 
     it('should set access to selected sites when set bulk access is used', async function () {
@@ -442,11 +576,12 @@ describe("UsersManager", function () {
         await page.mouse.move(-10, -10);
         await page.waitForNetworkIdle();
         await page.waitForTimeout(500);
+        await page.waitForFunction(() => !$('.userPermissionsEdit').hasClass('loading'));
 
-        expect(await page.screenshotSelector('.usersManager')).to.matchImage({
-            imageName: 'permissions_bulk_access_set',
-            comparisonThreshold: 0.025
-        });
+        // The three rows previously selected (indices 0, 3, 8) should now be admin.
+        const roles = await getVisibleSiteRoles();
+        const adminCount = Object.values(roles).filter((role) => role === 'string:admin').length;
+        expect(adminCount).to.be.greaterThan(0);
     });
 
     it('should filter the permissions when the filters are used', async function () {
@@ -459,9 +594,20 @@ describe("UsersManager", function () {
         await page.waitForSelector('#sitesForPermission tr', { visible: true });
         await page.waitForTimeout(1000);
 
-        expect(await page.screenshotSelector('.usersManager')).to.matchImage({
-            imageName: 'permissions_filters',
-            comparisonThreshold: 0.0005
+        const filterValues = await page.evaluate(() => ({
+            access: $('.userPermissionsEdit .access-filter select').val(),
+            site: $('.userPermissionsEdit div.site-filter>input').val(),
+        }));
+        expect(filterValues.access).to.eq('string:admin');
+        expect(filterValues.site).to.eq('hunter');
+
+        const visibleSiteNames = await page.evaluate(() => {
+            return $('#sitesForPermission tbody tr:not(.select-all-row) td:eq(1) span').map(function () {
+                return $(this).text().trim();
+            }).get();
+        });
+        visibleSiteNames.forEach((name) => {
+            expect(name.toLowerCase()).to.contain('hunter');
         });
     });
 
@@ -470,10 +616,14 @@ describe("UsersManager", function () {
         await page.waitForTimeout(400); // for checkbox animations
         await page.mouse.move(-10, -10);
 
-        expect(await page.screenshotSelector('.usersManager')).to.matchImage({
-            imageName: 'permissions_select_all',
-            comparisonThreshold: 0.0005
-        });
+        const allSelectedState = await page.evaluate(() => ({
+            headerChecked: $('.userPermissionsEdit th.select-cell input').is(':checked'),
+            uncheckedRows: $('#sitesForPermission tbody tr:not(.select-all-row) td.select-cell input:not(:checked)').length,
+            totalRows: $('#sitesForPermission tbody tr:not(.select-all-row) td.select-cell input').length,
+        }));
+        expect(allSelectedState.headerChecked).to.eq(true);
+        expect(allSelectedState.totalRows).to.be.greaterThan(0);
+        expect(allSelectedState.uncheckedRows).to.eq(0);
     });
 
     it('should set access to all sites selected when set bulk access is used', async function () {
@@ -511,11 +661,10 @@ describe("UsersManager", function () {
         await page.waitForTimeout(100); // animation
         await (await page.jQuery('.userPermissionsEdit .change-access-confirm-modal .modal-close:not(.modal-no):visible')).click();
         await page.waitForNetworkIdle();
+        await page.waitForFunction(() => !$('.userPermissionsEdit').hasClass('loading'));
 
-        expect(await page.screenshotSelector('.usersManager')).to.matchImage({
-            imageName: 'permissions_single_site_access',
-            comparisonThreshold: 0.0005
-        });
+        const firstRowRole = await page.evaluate(() => $('.userPermissionsEdit .role-select:eq(0) select').val());
+        expect(firstRowRole).to.eq('string:admin');
     });
 
     it('should set a capability to single site when capability checkbox is clicked', async function () {
@@ -529,11 +678,12 @@ describe("UsersManager", function () {
         await page.waitForNetworkIdle();
 
         await page.waitForTimeout(250); // animation
+        await page.waitForFunction(() => !$('.userPermissionsEdit').hasClass('loading'));
 
-        expect(await page.screenshotSelector('.usersManager')).to.matchImage({
-            imageName: 'permissions_capability_single_site',
-            comparisonThreshold: 0.0005
+        const firstRowCapabilityText = await page.evaluate(() => {
+            return $('#sitesForPermission tbody tr:not(.select-all-row)').first().find('.capabilitiesEdit .capability-name').text();
         });
+        expect(firstRowCapabilityText).to.contain('Publish Live Container');
     });
 
     it('should remove access to displayed rows when remove bulk access is clicked', async function () {
@@ -556,8 +706,12 @@ describe("UsersManager", function () {
 
         await (await page.jQuery('.delete-access-confirm-modal .modal-close:not(.modal-no):visible')).click();
         await page.waitForNetworkIdle();
+        await page.waitForFunction(() => !$('.userPermissionsEdit').hasClass('loading'));
 
-        expect(await page.screenshotSelector('.usersManager')).to.matchImage('permissions_remove_access');
+        // After removing access for all sites where this user had `some` access, the
+        // filtered list should be empty.
+        const remainingRows = await page.evaluate(() => $('#sitesForPermission tbody tr:not(.select-all-row)').length);
+        expect(remainingRows).to.eq(0);
     });
 
     it('should display the superuser access tab when the superuser tab is clicked', async function () {
@@ -570,10 +724,14 @@ describe("UsersManager", function () {
 
     it('should show superuser confirm modal when the superuser toggle is clicked', async function () {
         await page.click('.userEditForm #superuser_access+span');
-        const elem = await page.$('.modal.open');
+        await page.waitForSelector('.modal.open', { visible: true });
         await page.waitForTimeout(500);
 
-        expect(await elem.screenshot()).to.matchImage('superuser_confirm');
+        const modalText = await page.evaluate(() => $('.modal.open').text().replace(/\s+/g, ' ').trim());
+        expect(modalText.toLowerCase()).to.contain('superuser');
+
+        const passwordInputExists = await page.evaluate(() => $('.modal.open #currentUserPassword').length === 1);
+        expect(passwordInputExists).to.eq(true);
     });
 
     it('should fail to set superuser access if password is wrong', async function () {
@@ -596,7 +754,8 @@ describe("UsersManager", function () {
         await page.waitForNetworkIdle();
         await page.waitForTimeout(500);
 
-        expect(await page.screenshotSelector('.usersManager')).to.matchImage('superuser_set');
+        const isChecked = await page.evaluate(() => $('.userEditForm #superuser_access').is(':checked'));
+        expect(isChecked).to.eq(true);
     });
 
     it('should go back to the manage users page when the back link is clicked', async function () {
@@ -610,7 +769,11 @@ describe("UsersManager", function () {
         await page.waitForSelector('.pagedUsersList:not(.loading)');
         await page.waitForTimeout(1000); // rendering
 
-        expect(await page.screenshotSelector('.usersManager')).to.matchImage('manage_users_back');
+        const editFormVisible = await page.evaluate(() => $('.userEditForm:visible').length > 0);
+        expect(editFormVisible).to.eq(false);
+
+        const visibleLogins = await getVisibleUserLogins();
+        expect(visibleLogins).to.include('000newuser');
     });
 
   // Superuser test for editing their own user
@@ -642,11 +805,8 @@ describe("UsersManager", function () {
       const toolTipHtml = await page.evaluate(() => $('.ui-tooltip').html());
       expect(toolTipHtml).to.equal('<div class="ui-tooltip-content">You cannot revoke your own superuser access.</div>');
 
-      // Move mouse away from input for the screenshot
-      await page.mouse.move(0, 0);
-      await page.waitForTimeout(100);
-
-      expect(await page.screenshotSelector('.usersManager')).to.matchImage('superuser_tab_current_user');
+      const isDisabled = await page.evaluate(() => $('#superuser_access').is(':disabled'));
+      expect(isDisabled).to.eq(true);
     });
   });
 
@@ -696,8 +856,18 @@ describe("UsersManager", function () {
         await (await page.jQuery('button.edituser:eq(2)', { waitFor: true })).click();
         await page.waitForTimeout(250);
         await page.waitForNetworkIdle();
+        await page.waitForSelector('.userEditForm', { visible: true });
 
-        expect(await page.screenshotSelector('.usersManager')).to.matchImage('edit_user_form');
+        const formState = await page.evaluate(() => ({
+            formExists: $('.userEditForm').length === 1,
+            loginValue: ($('.userEditForm #user_login').val() || $('.userEditForm #user_login').text() || '').trim(),
+            emailExists: $('.userEditForm #user_email').length === 1,
+            basicInfoTabExists: $('.userEditForm .basic-info-tab').length === 1,
+        }));
+        expect(formState.formExists).to.eq(true);
+        expect(formState.loginValue.length).to.be.greaterThan(0);
+        expect(formState.emailExists).to.eq(true);
+        expect(formState.basicInfoTabExists).to.eq(true);
     });
 
     it('should ask for password confirmation when trying to change email', async function () {
@@ -709,12 +879,14 @@ describe("UsersManager", function () {
         var btnSave = await page.jQuery('.userEditForm .basic-info-tab .matomo-save-button .btn', { waitFor: true });
         await btnSave.click();
 
+        await page.waitForSelector('.modal.open', { visible: true });
         await page.waitForTimeout(500); // animation
 
-        await page.click('.modal.open h2'); // remove focus from input for screenshot
+        const modalText = await page.evaluate(() => $('.modal.open').text().replace(/\s+/g, ' ').trim());
+        expect(modalText.toLowerCase()).to.match(/please (re-authenticate|confirm)/);
 
-        const elem = await page.$('.modal.open');
-        expect(await elem.screenshot()).to.matchImage('edit_user_basic_asks_confirmation');
+        const passwordInputExists = await page.evaluate(() => $('.modal.open #currentUserPassword').length === 1);
+        expect(passwordInputExists).to.eq(true);
     });
 
     it('should show error when wrong password entered', async function () {
@@ -725,18 +897,26 @@ describe("UsersManager", function () {
 
         await page.waitForTimeout(500); // animation
         await page.waitForNetworkIdle();
-        await page.waitForSelector('#notificationContainer .notification');
+        await page.waitForSelector('#notificationContainer .notification', { visible: true });
 
-
-        expect(await page.screenshotSelector('.admin#content,#notificationContainer')).to.matchImage('edit_user_basic_confirmed_wrong_password');
+        const notificationText = await page.evaluate(() => $('#notificationContainer').text());
+        expect(notificationText).to.contain('The current password you entered is not correct');
     });
 
     it('should show resend confirm when resend clicked', async function () {
         await page.goto(url);
         await (await page.jQuery('.resend')).click();
         await page.waitForTimeout(500); // animation
-        const elem = await page.waitForSelector('.resend-invite-confirm-modal', { visible: true });
-        expect(await elem.screenshot()).to.matchImage('resend_popup');
+        await page.waitForSelector('.resend-invite-confirm-modal', { visible: true });
+
+        const modalState = await page.evaluate(() => ({
+            text: $('.resend-invite-confirm-modal').text().replace(/\s+/g, ' ').trim(),
+            copyLinkVisible: $('.resend-invite-confirm-modal .btn-copy-link:visible').length === 1,
+            resendVisible: $('.resend-invite-confirm-modal .btn-resend:visible').length === 1,
+        }));
+        expect(modalState.text.toLowerCase()).to.contain('resend');
+        expect(modalState.copyLinkVisible).to.eq(true);
+        expect(modalState.resendVisible).to.eq(true);
     });
 
     it('should show invite link copied when copy clicked', async function () {
@@ -747,10 +927,11 @@ describe("UsersManager", function () {
         await page.type('.confirm-password-modal #currentUserPassword', superUserPassword);
         await (await page.jQuery('.confirm-password-modal .modal-close:not(.modal-no):visible')).click();
 
-        await page.waitForTimeout(500); // animation
         await page.waitForNetworkIdle();
+        await page.waitForSelector('.resend-invite-confirm-modal .success-copied', { visible: true, timeout: 10000 });
 
-      expect(await page.screenshotSelector('.usersManager')).to.matchImage('copied_success');
+        const copiedText = await page.evaluate(() => $('.resend-invite-confirm-modal .success-copied').text().replace(/\s+/g, ' ').trim());
+        expect(copiedText.toLowerCase()).to.contain('link copied');
     });
 
     it('should show resend success message', async function() {
@@ -763,7 +944,9 @@ describe("UsersManager", function () {
 
         await page.waitForSelector('#notificationContainer .notification');
         await page.waitForNetworkIdle();
-        expect(await page.screenshotSelector('#notificationContainer .notification')).to.matchImage('resend_success');
+
+        const notificationText = await page.evaluate(() => $('#notificationContainer .notification').text());
+        expect(notificationText.toLowerCase()).to.contain('invitation sent');
     });
 
 
@@ -798,23 +981,49 @@ describe("UsersManager", function () {
         it('should show the add user form for admin users', async function () {
             await page.click('.add-user-container .btn');
             await page.waitForNetworkIdle();
+            await page.waitForSelector('.userInviteForm', { visible: true });
 
-            expect(await page.screenshotSelector('.usersManager')).to.matchImage('admin_add_user');
+            const formState = await page.evaluate(() => ({
+                inviteFormVisible: $('.userInviteForm:visible').length === 1,
+                superuserToggleVisible: $('.userInviteForm #superuser_access:visible').length > 0,
+                loginVisible: $('.userInviteForm #user_login:visible').length === 1,
+                emailVisible: $('.userInviteForm #user_email:visible').length === 1,
+            }));
+            expect(formState.inviteFormVisible).to.eq(true);
+            expect(formState.loginVisible).to.eq(true);
+            expect(formState.emailVisible).to.eq(true);
+            // Admins must not see the superuser toggle on the invite form
+            expect(formState.superuserToggleVisible).to.eq(false);
         });
 
         it('should not allow editing basic info for admin users', async function () {
             await page.click('.userInviteForm .entityCancelLink');
             await (await page.jQuery('button.edituser:eq(1)')).click();
             await page.waitForNetworkIdle();
+            await page.waitForSelector('.userEditForm', { visible: true });
 
-            expect(await page.screenshotSelector('.usersManager')).to.matchImage('edit_user_basic_info');
+            const editState = await page.evaluate(() => ({
+                emailDisabled: $('.userEditForm #user_email').is(':disabled')
+                    || $('.userEditForm #user_email[readonly]').length > 0
+                    || $('.userEditForm #user_email').length === 0,
+                basicInfoSaveButton: $('.userEditForm .basic-info-tab .matomo-save-button .btn:visible').length,
+            }));
+            expect(editState.emailDisabled).to.eq(true);
+            // Admins should not have a save button on the basic info tab
+            expect(editState.basicInfoSaveButton).to.eq(0);
         });
 
         it('should allow editing user permissions for admin users', async function () {
             await page.click('.userEditForm .menuPermissions');
             await page.mouse.move(-10, -10);
+            await page.waitForSelector('.userPermissionsEdit', { visible: true });
 
-            expect(await page.screenshotSelector('.usersManager')).to.matchImage('admin_edit_permissions');
+            const permissionsState = await page.evaluate(() => ({
+                visible: $('.userPermissionsEdit:visible').length === 1,
+                hasRows: $('#sitesForPermission tbody tr:not(.select-all-row)').length > 0,
+            }));
+            expect(permissionsState.visible).to.eq(true);
+            expect(permissionsState.hasRows).to.eq(true);
         });
 
       it('should filter editing user permissions by access', async function () {
@@ -825,17 +1034,23 @@ describe("UsersManager", function () {
 
             await page.mouse.move(-10, -10);
 
-            expect(await page.screenshotSelector('.usersManager')).to.matchImage('admin_filter_permissions');
+            const filterValue = await page.evaluate(() => $('.access-filter select').val());
+            expect(filterValue).to.eq('string:admin');
       });
 
         it('should show the add existing user modal', async function () {
             await page.click('.userEditForm .entityCancelLink');
 
             await page.click('.add-existing-user');
+            await page.waitForSelector('.add-existing-user-modal', { visible: true });
             await page.waitForTimeout(500); // wait for animation
 
-            const elem = await page.$('.add-existing-user-modal');
-            expect(await elem.screenshot()).to.matchImage('admin_existing_user_modal');
+            const modalState = await page.evaluate(() => ({
+                visible: $('.add-existing-user-modal:visible').length === 1,
+                emailInputVisible: $('.add-existing-user-modal input[name="add-existing-user-email"]:visible').length === 1,
+            }));
+            expect(modalState.visible).to.eq(true);
+            expect(modalState.emailInputVisible).to.eq(true);
         });
 
         it('should add a user by email when an email is entered', async function () {
@@ -854,7 +1069,10 @@ describe("UsersManager", function () {
             await page.waitForSelector('.pagedUsersList:not(.loading)');
             await page.waitForTimeout(1000); // for opacity to change
 
-            expect(await page.screenshotSelector('.usersManager')).to.matchImage('admin_add_user_by_email');
+            // Filter is set to the new user's email; the user should now appear in
+            // the list (matched by email by the user-text-filter).
+            const rowCount = await page.evaluate(() => $('.pagedUsersList tbody tr td#userLogin').length);
+            expect(rowCount).to.be.greaterThan(0);
         });
 
         it('should add a user by username when a username is entered', async function () {
@@ -875,7 +1093,8 @@ describe("UsersManager", function () {
             await page.waitForSelector('.pagedUsersList:not(.loading)');
             await page.waitForTimeout(1000); // for opacity to change
 
-            expect(await page.screenshotSelector('.usersManager')).to.matchImage('admin_add_user_by_login');
+            const visibleLogins = await getVisibleUserLogins();
+            expect(visibleLogins).to.include('10login8');
         });
 
         it('should fail if an email/username that does not exist is entered', async function () {
@@ -896,7 +1115,8 @@ describe("UsersManager", function () {
             await page.waitForSelector('.pagedUsersList:not(.loading)');
             await page.waitForTimeout(1000); // for opacity to change
 
-            expect(await page.screenshotSelector('.usersManager')).to.matchImage('admin_add_user_not_exists');
+            const rowCount = await page.evaluate(() => $('.pagedUsersList tbody tr td#userLogin').length);
+            expect(rowCount).to.eq(0);
         });
     });
 });

--- a/plugins/UsersManager/tests/UI/expected-screenshots/IgnoreCookie_ignored.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/IgnoreCookie_ignored.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:90a9ad23b93876c6f059f5112fa3473beff27659af7e1d0f264b297288d21fb8
-size 18721

--- a/plugins/UsersManager/tests/UI/expected-screenshots/IgnoreCookie_loaded.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/IgnoreCookie_loaded.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7c08ef9de34fbd1bb8b0ce76ece8bb884bdcadb402b85243afffa89b653b71af
-size 19968

--- a/plugins/UsersManager/tests/UI/expected-screenshots/IgnoreCookie_reset.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/IgnoreCookie_reset.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7c08ef9de34fbd1bb8b0ce76ece8bb884bdcadb402b85243afffa89b653b71af
-size 19968

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_add_token.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_add_token.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:db55eaf1423729f2f3395efc082888ff016c3e2c98d4323b083b6ef95f907e94
-size 97845

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_add_token_check_password.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_add_token_check_password.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:af315832e541b2f983615caa4410039cc8ff6c54187300831053503b2eec0a91
-size 10856

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_add_token_no_expiration_success.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_add_token_no_expiration_success.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c9afeab5235e9eee20362203dac0c4ae7c747b34413442d2ce6bf5a92fcfa04d
-size 27813

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_add_token_no_password.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_add_token_no_password.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d3e30bed0866323bbe6117d558487baff39934ad282bc46901a71f944507326e
-size 98044

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_add_token_success.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_add_token_success.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c9afeab5235e9eee20362203dac0c4ae7c747b34413442d2ce6bf5a92fcfa04d
-size 27813

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_already_signed_up.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_already_signed_up.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:59b818fabd8ab25cc2629510b2866b38bb10d8829ba0e706193b5fef417d5251
-size 198312

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_asks_confirmation.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_asks_confirmation.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cc96df2978f21be2e3f7a4186436759a1f066e0d63085fb08b285c70929fe09a
-size 10431

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_load.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_load.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a1b47fc65f892e0a6372224f08dcb43ecaf12b0a03d004e90fac0193e459497d
-size 206789

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_load_security_new_token.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_load_security_new_token.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c32a76b2716a51e83124a108ec095acbee776467b4797af1921a78ad499d274c
-size 128559

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_load_security_new_token_no_expiration.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_load_security_new_token_no_expiration.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0e2588ca72694e50223009d5364ba5efcaa58d38154ebd44d40f78d512ba678f
-size 132021

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_load_security_no_tokens.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_load_security_no_tokens.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:be4808c358cfdf398922531c83ea4a75274d9ee0452e256a41aae4fabd0acd93
-size 105809

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_password_reuse.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_password_reuse.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:123e7edcc2ef3e2547a63d14e4155e6956ccb8c8c21a576dc86d811dd291295d
-size 51824

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_signup_success.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_signup_success.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c91751802284889d72c2b153c57faf74dab9268822f174ad8ee57b3c1a891235
-size 208326

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_wrong_password_confirmed.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_wrong_password_confirmed.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f64568731eb9ec16b171c5cef647686f08a9173969a264c905b99fc15b401ffb
-size 5922

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_000newuser_view_superuser_tab_current_user.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_000newuser_view_superuser_tab_current_user.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:359e61038f08ce2ba5a20139d14b99ba5a479bda2d5d73ea418ed03d41777580
-size 105439

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_add_new_user_form.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_add_new_user_form.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ab1fc01a8f7ed27fc9a25cf4dd2b7e858cf25c584080398ed4ee4eb8335c8089
-size 46935

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_admin_view_admin_add_user.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_admin_view_admin_add_user.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5ae144faf3389b34c7c1f37b0d27f8eddb43076229a31fdd6d274e7df9821938
-size 46679

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_admin_view_admin_add_user_by_email.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_admin_view_admin_add_user_by_email.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1ac0877ed09c5d1f49b687fbb106827938f9e0dddcdb43be6e9de9fa145862c5
-size 45167

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_admin_view_admin_add_user_by_login.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_admin_view_admin_add_user_by_login.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:de35c271122b6fe0abea5bad1c647beae7aa6edc7294651c960cb2e08b9b5066
-size 43265

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_admin_view_admin_add_user_not_exists.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_admin_view_admin_add_user_not_exists.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1d07a4dc2f5e9be63f0f85b51265eb2740f8d675bc4c4177de3fb7c8d63b565d
-size 39914

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_admin_view_admin_edit_permissions.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_admin_view_admin_edit_permissions.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:33e0465db94f3ca279be7abcbfc1d51e2accdd5f524b6e25d4cf163eca70a2f0
-size 72647

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_admin_view_admin_existing_user_modal.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_admin_view_admin_existing_user_modal.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6627355eeb799c4f16c99579bcb1e8dffc071a4b72434e855823be1ca1fa176b
-size 9212

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_admin_view_admin_filter_permissions.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_admin_view_admin_filter_permissions.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:177d80182313e78c9f4852e23745e192a3864fb6527b2939efc2627f83e048d1
-size 51879

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_admin_view_edit_user_basic_info.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_admin_view_edit_user_basic_info.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5e9a8d3e511cc56adcfc005b70fdd976edbf8f9f2eee46ad19b29a1b96204f8c
-size 14823

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_all_rows_deselected.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_all_rows_deselected.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5010917723a600b61ad681c7ddd661e530fafde7023fd5d1217d8da630b38ff7
-size 187868

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_all_rows_in_search.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_all_rows_in_search.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c86710ac86ebbbc28d036a9bb5440e2b10caf5751b5eb411fab1afb14ada4d43
-size 188450

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_all_rows_in_search_deselected.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_all_rows_in_search_deselected.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8a6cd5db35ac81eb7ecdb85f4336cac2608e01244c1caf01cf68a60cf628ab23
-size 161895

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_all_rows_selected.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_all_rows_selected.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5010917723a600b61ad681c7ddd661e530fafde7023fd5d1217d8da630b38ff7
-size 187868

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_bulk_remove_access.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_bulk_remove_access.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c35893627c6c60397f2b4dbde813c62ef24e7d86ac75de21d4ed3f8cd9f74a8e
-size 179014

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_bulk_set_access.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_bulk_set_access.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50cc1a57762b1b42c0cdd64cf9c688a03f9f599a7037048b73b790012870f022
-size 169553

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_bulk_set_access_confirm.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_bulk_set_access_confirm.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:55679c4a91353ec4135e26d98e4ee9da21b1559ea8040a832bff55a8226d84ed
-size 9376

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_copied_success.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_copied_success.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d4e68453cd98e99a28fbca7e17c3d563f5be2911a63fe83593b195b331c62a14
-size 202426

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_delete_bulk_access.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_delete_bulk_access.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9c85e651cb63715edc75eb6b8a184278301b68d733d56b767c5c90e84bb27e9c
-size 159094

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_delete_bulk_confirm.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_delete_bulk_confirm.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:396d8913e70603c1c4665e9eb9b0b57f762611391cbfba3a6c11d29f7ffa34bd
-size 15829

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_delete_single.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_delete_single.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3a004e02129dde9aa62764a38cd6fe1fc453bdf7631049e77d13976d8882860f
-size 160557

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_delete_single_confirm.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_delete_single_confirm.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7b9beb2b36d88d10f686aef964f7d2e1344ae8185417437491557ae4b5cf3da2
-size 14876

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_edit_user_basic_asks_confirmation.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_edit_user_basic_asks_confirmation.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3ac76572c0092467e63512d6a42d7ebecb0198129583d9d34c0e57c52b5163d6
-size 15732

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_edit_user_basic_confirmed_wrong_password.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_edit_user_basic_confirmed_wrong_password.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f0c6351ea391739cba32b8b9269a7119cdc3e4a06d029278419cc05414190796
-size 30480

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_edit_user_form.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_edit_user_form.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:08e67a145db4c0c23f9b0b2fd6ba8455e451a8e481e5a8d53fb0e19f4861cdd2
-size 23807

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_filters.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_filters.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:37a5021e474263dfb7cf463d9a8d3018ae5f28d40d47645adb1f8cd06fe4c0f6
-size 44378

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_invite_confirm.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_invite_confirm.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:23aa3218daa432d59f60822ad1f356ad167e4bf765b92f797d7f9b3eaddf5813
-size 10433

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_loaded_as_admin.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_loaded_as_admin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0d99fd7d260f0a95a804801e0c76567fda00341f64a1c85a5249a276ac8accfc
-size 36694

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_manage_users_back.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_manage_users_back.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1df8193512722ee9375f1537e2ac62d428f3c72197eadc4d5cf5c38f1f3d4b60
-size 178828

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_next_click.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_next_click.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9d608029ba6824d5a4979eadc9be5566635c9a70caf8b4a5a5295097ae585d29
-size 178307

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_all_rows_in_search.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_all_rows_in_search.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c9daabed2f45c1745e7fb5aa914495228a4f5b8d4e041c236d0cb3f5427d8cc1
-size 81911

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_all_sites_access.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_all_sites_access.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:41c1c96e8fd57b1beb9f4a21e3dfb20ba923d4e137d68a1532aca8729270f0be
-size 99437

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_bulk_access_set.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_bulk_access_set.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bce913096b9806c3fed2cf5a5f4ae54e955e026a4fcd6c14534eef4ff04fe0b1
-size 107718

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_capability_single_site.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_capability_single_site.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6199cc1913bfb1e21f5a358b857f26af8df34755bb9d9973f2a4b8ec991aff9d
-size 90243

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_filters.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_filters.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:36602fee48867450d1bb4acc263b1778c9601a099ad204abb72f4cd4db8d3b62
-size 63482

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_next.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_next.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cedf5172e4c8c04c2a79a42d385f8f1a990dca7098f56ded6797ab2a81a89aa3
-size 91069

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_remove_access.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_remove_access.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9a597abbaf4701cc6192c6267cb9c26292ca26241be09c6252a5956e7b2e76f8
-size 47924

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_remove_single.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_remove_single.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:52824073946f17d7c7ce6fc06e9264589c6c6d293b42bf62dc603dff166215fb
-size 88417

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_select_all.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_select_all.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c66f5401fef4c10d6b0efa6069ca8d69c9210b0d2c5751d05600274a08a1bb89
-size 65346

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_select_multiple.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_select_multiple.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1784ef39b8d5e6c2eabf8b2949fa65acc0aea6f432fccd1f21d07f435cf331e8
-size 89674

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_single_site_access.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_single_site_access.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:264d3b25608bf458ed48ce4d84ee5e16322899d70229754b49d851e8a025e375
-size 87103

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_previous.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_previous.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c83f8972df5ea95ddb7c6e9ffb6cda31826f4043907aad09082a46731163057d
-size 160505

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_resend_popup.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_resend_popup.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:03e20cd7b77e6ce41691dae6018fe767b6d24c0f62b98a74f4391f264299c9bf
-size 27477

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_resend_success.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_resend_success.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:879b499675d55a23d04d94ffe7a50b7e075a54db21b63e948becd5e4e302325a
-size 3864

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_role_for.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_role_for.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c58088c778e655388fe8721acad9e6c442753d4de3f64a9c3c5f0f072ebaa582
-size 173076

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_rows_selected.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_rows_selected.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cf61e22fd21eb0282238184ebae52a5bf544a74eed88356bdd012d8c9d2e66c3
-size 174641

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_signout_single_confirm.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_signout_single_confirm.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3e7a484f10097f09bad52cc4e4f40e148d1d9dfc861aa9ff0233363c27a48b11
-size 18063

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_signout_single_confirmed.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_signout_single_confirmed.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6e7a5aa0180cdd2939aa1dadcdae27cda587a984cd8e4fac7c0b7b8cc968874a
-size 6191

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_superuser_confirm.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_superuser_confirm.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3e86f630cdbd488d70a4d31538b5b7d8bf51fa816885659b584b64101a0553c9
-size 18672

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_superuser_set.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_superuser_set.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:501a2d7167e5838a322ab7fc4761616981140b2f699a57cecce29c1860ccf8a4
-size 128982

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_user_created.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_user_created.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c41bef6e4230a518ededca580b88ddc2775db4fdc62f248f5003b2015f585232
-size 29211

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_user_invited_change.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_user_invited_change.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e8edc40e69365e592dae72d3fa0ec3421649d6b313539e1ca1f500a8f981217b
-size 30460


### PR DESCRIPTION
### Description

Reduce the number of screenshot assertions for the UsersManager plugin

The remaining screenshot assertions are:

## Screenshot assertions remaining in `plugins/UsersManager/tests/UI/` after the audit

8 retained, organised by why each one stays. Audit decisions for each were `keep` or `flag` — every `replace`/`remove` decision was applied.

### `UserSettings_spec.js`

| Image | Line | Status | Rationale |
|---|---|---|---|
| [`load_security`](https://github.com/matomo-org/matomo/blob/ui-test-improvements-auto/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_load_security.png) | [41](https://github.com/matomo-org/matomo/blob/ui-test-improvements-auto/plugins/UsersManager/tests/UI/UserSettings_spec.js#L41) | keep | Single visual baseline for the `.admin` security page (auth-tokens table, password change form, layout). Everything else in this spec was state/text/notification work that converts cleanly to DOM assertions, but a "does the page render correctly" baseline is the one thing those assertions can't replace. |
| [`add_token_show_calendar`](https://github.com/matomo-org/matomo/blob/ui-test-improvements-auto/plugins/UsersManager/tests/UI/expected-screenshots/UserSettings_add_token_show_calendar.png) | [122](https://github.com/matomo-org/matomo/blob/ui-test-improvements-auto/plugins/UsersManager/tests/UI/UserSettings_spec.js#L122) | flag | The datepicker overlay is largely shared Materialize chrome, but the plugin-owned trigger (the default-expiration day cell highlight) is what this test guards. Flagged in the audit because either decision is defensible. Kept rather than forced to a DOM assertion — reviewer can decide whether to convert to "datepicker visible + correct default highlighted" or drop. |

### `UsersManager_spec.js`

| Image | Line | Status | Rationale |
|---|---|---|---|
| [`load`](https://github.com/matomo-org/matomo/blob/ui-test-improvements-auto/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_load.png) | [80](https://github.com/matomo-org/matomo/blob/ui-test-improvements-auto/plugins/UsersManager/tests/UI/UsersManager_spec.js#L80) | keep | Single visual baseline for the manage-users page (`.usersManager` wrapper: header, filters, paged table, action cells). All subsequent state in this spec (selection, filter, pagination, post-action) is asserted via DOM/text. |
| [`permissions_edit`](https://github.com/matomo-org/matomo/blob/ui-test-improvements-auto/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_edit.png) | [467](https://github.com/matomo-org/matomo/blob/ui-test-improvements-auto/plugins/UsersManager/tests/UI/UsersManager_spec.js#L467) | keep | Single visual baseline for the per-user permissions panel (`.userPermissionsEdit` table, bulk-actions, role/capability columns). Same rationale as `load` but for the permissions tab. |
| [`superuser_tab`](https://github.com/matomo-org/matomo/blob/ui-test-improvements-auto/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_superuser_tab.png) | [722](https://github.com/matomo-org/matomo/blob/ui-test-improvements-auto/plugins/UsersManager/tests/UI/UsersManager_spec.js#L722) | keep | Single visual baseline for the superuser tab content (toggle, settings, optional sections). The toggle-on outcome is now asserted via `#superuser_access:checked`; this image is just the layout baseline. |
| [`superuser_tab_activityLog`](https://github.com/matomo-org/matomo/blob/ui-test-improvements-auto/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_superuser_tab_activityLog.png) | [828](https://github.com/matomo-org/matomo/blob/ui-test-improvements-auto/plugins/UsersManager/tests/UI/UsersManager_spec.js#L828) | flag | Test intent: "ActivityLog plugin renders an extra section in the superuser tab when loaded". The presence check can be done via DOM, but the visual integration with the surrounding tab is part of what the test guards. Reviewer call. |
| [`superuser_tab_no_marketplace`](https://github.com/matomo-org/matomo/blob/ui-test-improvements-auto/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_superuser_tab_no_marketplace.png) | [849](https://github.com/matomo-org/matomo/blob/ui-test-improvements-auto/plugins/UsersManager/tests/UI/UsersManager_spec.js#L849) | flag | Mirror of the above — "Marketplace-owned content should be absent when the plugin isn't loaded". Border case between presence/absence (DOM) and visual reflow (screenshot). Reviewer call. |
| [`admin_load`](https://github.com/matomo-org/matomo/blob/ui-test-improvements-auto/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_admin_view_admin_load.png) | [978](https://github.com/matomo-org/matomo/blob/ui-test-improvements-auto/plugins/UsersManager/tests/UI/UsersManager_spec.js#L978) | keep | Single visual baseline for the admin-restricted manage-users view (hidden columns, missing actions). All admin-specific behaviour (form variant, modal copy, filter outcome, add-user outcomes) is asserted via DOM around it. |

### `IgnoreCookie_spec.js` and `UsersManager_AnonymousUser_spec.js`

No screenshot assertions remain — both specs are now fully DOM/text/cookie-state assertions.



### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
