### PR TITLE
UsersManager: restrict app-specific token creation to the current user when authenticated

### DIFF
--- a/plugins/Login/tests/Integration/CreateAppSpecificTokenAuthBruteForceTest.php
+++ b/plugins/Login/tests/Integration/CreateAppSpecificTokenAuthBruteForceTest.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Plugins\Login\tests\Integration;
 
+use Piwik\Access;
 use Piwik\API\Request;
 use Piwik\Container\StaticContainer;
 use Piwik\NoAccessException;
@@ -94,7 +95,7 @@ class CreateAppSpecificTokenAuthBruteForceTest extends IntegrationTestCase
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Login_LoginNotAllowedBecauseUserLoginBlocked');
 
-        Request::processRequest('UsersManager.createAppSpecificTokenAuth', [
+        $this->createAppSpecificTokenAuthAnonymously([
             'userLogin' => $this->userLogin,
             'passwordConfirmation' => $this->userPassword,
             'description' => 'blocked login test',
@@ -109,7 +110,7 @@ class CreateAppSpecificTokenAuthBruteForceTest extends IntegrationTestCase
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Login_LoginNotAllowedBecauseUserLoginBlocked');
 
-        Request::processRequest('UsersManager.createAppSpecificTokenAuth', [
+        $this->createAppSpecificTokenAuthAnonymously([
             'userLogin' => $this->userEmail,
             'passwordConfirmation' => $this->userPassword,
             'description' => 'blocked email test',
@@ -118,7 +119,7 @@ class CreateAppSpecificTokenAuthBruteForceTest extends IntegrationTestCase
 
     public function testCreateAppSpecificTokenAuthCreatesTokenUsingEmailWhenUserNotBlocked(): void
     {
-        $token = Request::processRequest('UsersManager.createAppSpecificTokenAuth', [
+        $token = $this->createAppSpecificTokenAuthAnonymously([
             'userLogin' => $this->userEmail,
             'passwordConfirmation' => $this->userPassword,
             'description' => 'allowed email test',
@@ -142,6 +143,23 @@ class CreateAppSpecificTokenAuthBruteForceTest extends IntegrationTestCase
 
         $plugin = new LoginPlugin();
         $plugin->beforeLoginCheckBruteForce();
+    }
+
+    /**
+     * Creates a token through the unauthenticated credential-exchange flow (a fresh, anonymous access),
+     * matching how a token is obtained by supplying a user's credentials without an authenticated session.
+     */
+    private function createAppSpecificTokenAuthAnonymously(array $params)
+    {
+        $container = StaticContainer::getContainer();
+        $previousAccess = $container->get('Piwik\Access');
+        $container->set('Piwik\Access', new Access());
+
+        try {
+            return Request::processRequest('UsersManager.createAppSpecificTokenAuth', $params);
+        } finally {
+            $container->set('Piwik\Access', $previousAccess);
+        }
     }
 
     private function blockLogin(string $userLogin): void

--- a/plugins/TwoFactorAuth/tests/Integration/TwoFactorAuthTest.php
+++ b/plugins/TwoFactorAuth/tests/Integration/TwoFactorAuthTest.php
@@ -163,7 +163,7 @@ class TwoFactorAuthTest extends IntegrationTestCase
 
     public function testOnCreateAppSpecificTokenAuthCanAuthenticateWhenUserNotUsesTwoFA()
     {
-        $token = Request::processRequest('UsersManager.createAppSpecificTokenAuth', array(
+        $token = $this->createAppSpecificTokenAuthAnonymously(array(
             'userLogin' => $this->userWithout2Fa,
             'passwordConfirmation' => $this->userPassword,
             'description' => 'twofa test',
@@ -176,7 +176,7 @@ class TwoFactorAuthTest extends IntegrationTestCase
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('UsersManager_CurrentPasswordNotCorrect');
 
-        Request::processRequest('UsersManager.createAppSpecificTokenAuth', array(
+        $this->createAppSpecificTokenAuthAnonymously(array(
             'userLogin' => $this->userWith2Fa,
             'passwordConfirmation' => 'invalidPAssword',
             'description' => 'twofa test',
@@ -188,7 +188,7 @@ class TwoFactorAuthTest extends IntegrationTestCase
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('TwoFactorAuth_MissingAuthCodeAPI');
 
-        Request::processRequest('UsersManager.createAppSpecificTokenAuth', array(
+        $this->createAppSpecificTokenAuthAnonymously(array(
 
             'userLogin' => $this->userWith2Fa,
             'passwordConfirmation' => $this->userPassword,
@@ -202,7 +202,7 @@ class TwoFactorAuthTest extends IntegrationTestCase
         $this->expectExceptionMessage('TwoFactorAuth_InvalidAuthCode');
 
         $_GET['authCode'] = '111222';
-        Request::processRequest('UsersManager.createAppSpecificTokenAuth', array(
+        $this->createAppSpecificTokenAuthAnonymously(array(
             'userLogin' => $this->userWith2Fa,
             'passwordConfirmation' => $this->userPassword,
             'description' => 'twofa test',
@@ -214,7 +214,7 @@ class TwoFactorAuthTest extends IntegrationTestCase
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('TwoFactorAuth_MissingAuthCodeAPI');
 
-        Request::processRequest('UsersManager.createAppSpecificTokenAuth', array(
+        $this->createAppSpecificTokenAuthAnonymously(array(
             'userLogin' => $this->userWith2Fa . '@matomo.org',
             'passwordConfirmation' => $this->userPassword,
             'description' => 'twofa test',
@@ -227,7 +227,7 @@ class TwoFactorAuthTest extends IntegrationTestCase
         $this->expectExceptionMessage('TwoFactorAuth_InvalidAuthCode');
 
         $_GET['authCode'] = '111222';
-        Request::processRequest('UsersManager.createAppSpecificTokenAuth', array(
+        $this->createAppSpecificTokenAuthAnonymously(array(
             'userLogin' => $this->userWith2Fa . '@matomo.org',
             'passwordConfirmation' => $this->userPassword,
             'description' => 'twofa test',
@@ -240,7 +240,7 @@ class TwoFactorAuthTest extends IntegrationTestCase
 
         $_GET['authCode'] = '111222';
         try {
-            Request::processRequest('UsersManager.createAppSpecificTokenAuth', array(
+            $this->createAppSpecificTokenAuthAnonymously(array(
                 'userLogin' => $this->userWith2Fa,
                 'passwordConfirmation' => $this->userPassword,
                 'description' => 'twofa test',
@@ -260,7 +260,7 @@ class TwoFactorAuthTest extends IntegrationTestCase
         $this->assertCount(0, $this->bruteForceDetection->getAll());
 
         try {
-            Request::processRequest('UsersManager.createAppSpecificTokenAuth', array(
+            $this->createAppSpecificTokenAuthAnonymously(array(
                 'userLogin' => $this->userWith2Fa,
                 'passwordConfirmation' => $this->userPassword,
                 'description' => 'twofa test',
@@ -278,7 +278,7 @@ class TwoFactorAuthTest extends IntegrationTestCase
     public function testOnCreateAppSpecificTokenAuthDoesNotRecordFailedAttemptWhenAuthCodeIsValid()
     {
         $_GET['authCode'] = $this->generateValidAuthCode($this->user2faSecret);
-        $token = Request::processRequest('UsersManager.createAppSpecificTokenAuth', array(
+        $token = $this->createAppSpecificTokenAuthAnonymously(array(
             'userLogin' => $this->userWith2Fa,
             'passwordConfirmation' => $this->userPassword,
             'description' => 'twofa test',
@@ -291,7 +291,7 @@ class TwoFactorAuthTest extends IntegrationTestCase
     public function testOnCreateAppSpecificTokenAuthReturnsCorrectTokenWhenProvidingCorrectAuthTokenOnAuthenticationUsingEmail()
     {
         $_GET['authCode'] = $this->generateValidAuthCode($this->user2faSecret);
-        $token = Request::processRequest('UsersManager.createAppSpecificTokenAuth', array(
+        $token = $this->createAppSpecificTokenAuthAnonymously(array(
             'userLogin' => $this->userWith2Fa . '@matomo.org',
             'passwordConfirmation' => $this->userPassword,
             'description' => 'twofa test',
@@ -302,7 +302,7 @@ class TwoFactorAuthTest extends IntegrationTestCase
     public function testOnCreateAppSpecificTokenAuthReturnsCorrectTokenWhenProvidingCorrectAuthTokenOnAuthentication()
     {
         $_GET['authCode'] = $this->generateValidAuthCode($this->user2faSecret);
-        $token = Request::processRequest('UsersManager.createAppSpecificTokenAuth', array(
+        $token = $this->createAppSpecificTokenAuthAnonymously(array(
             'userLogin' => $this->userWith2Fa,
             'passwordConfirmation' => $this->userPassword,
             'description' => 'twofa test',
@@ -358,6 +358,23 @@ class TwoFactorAuthTest extends IntegrationTestCase
     {
         $code = new \TwoFactorAuthenticator();
         return $code->getCode($secret);
+    }
+
+    /**
+     * Creates a token through the unauthenticated credential-exchange flow (a fresh, anonymous access).
+     * The tests verify obtaining a token by supplying a user's credentials without an authenticated session.
+     */
+    private function createAppSpecificTokenAuthAnonymously(array $params)
+    {
+        $container = StaticContainer::getContainer();
+        $previousAccess = $container->get('Piwik\Access');
+        $container->set('Piwik\Access', new Access());
+
+        try {
+            return Request::processRequest('UsersManager.createAppSpecificTokenAuth', $params);
+        } finally {
+            $container->set('Piwik\Access', $previousAccess);
+        }
     }
 
     private function setCurrentUser(string $login): void

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -1532,6 +1532,12 @@ class API extends \Piwik\Plugin\API
             }
         }
 
+        // An unauthenticated request may exchange a user's credentials for that user's token. When the request is
+        // already authenticated, the token may only be created for the current user, regardless of role.
+        if (!Piwik::isUserIsAnonymous() && $userLogin !== Piwik::getCurrentUserLogin()) {
+            throw new NoAccessException(Piwik::translate('UsersManager_ExceptionCreateTokenForOtherUser'));
+        }
+
         if (empty($user) || !$this->passwordVerifier->isPasswordCorrect($userLogin, $passwordConfirmation)) {
             if (empty($user)) {
                 /**

--- a/plugins/UsersManager/lang/en.json
+++ b/plugins/UsersManager/lang/en.json
@@ -46,6 +46,7 @@
         "ExceptionMultipleRoleSet": "Only one role can be set but multiple have been set. Use only one of: %s",
         "ExceptionAnonymousNoCapabilities": "You cannot grant any capability to the 'anonymous' user.",
         "ExceptionAnonymousAccessNotPossible": "You can only set access %1$s or %2$s access to the 'anonymous' user.",
+        "ExceptionCreateTokenForOtherUser": "You can only create an authentication token for your own account.",
         "ExceptionDeleteDoesNotExist": "User '%s' doesn't exist therefore it can't be deleted.",
         "ExceptionDeleteOnlyUserWithSuperUserAccess": "Deleting user '%s' is not possible.",
         "ExceptionEditAnonymous": "The anonymous user cannot be edited or deleted. It is used by Matomo to define a user that has not logged in yet. For example, you can make your statistics public by granting the 'view' access to the 'anonymous' user.",

--- a/plugins/UsersManager/tests/Integration/APITest.php
+++ b/plugins/UsersManager/tests/Integration/APITest.php
@@ -1742,6 +1742,52 @@ class APITest extends IntegrationTestCase
         return $ids;
     }
 
+    public function testCreateAppSpecificTokenAuthCanBeCreatedForOwnAccount()
+    {
+        $this->addUserWithAccess('viewUser', 'view', 1);
+        $this->setCurrentUser('viewUser', 'view', 1);
+
+        $token = $this->api->createAppSpecificTokenAuth('viewUser', 'password', 'own-token');
+
+        $user = $this->model->getUserByTokenAuth($token);
+        self::assertSame('viewUser', $user['login']);
+    }
+
+    public function testCreateAppSpecificTokenAuthCannotBeCreatedForAnotherAccountByNonSuperUser()
+    {
+        // a low-privileged user that only has view access
+        $this->addUserWithAccess('viewUser', 'view', 1);
+        $this->setCurrentUser('viewUser', 'view', 1);
+
+        self::expectException(NoAccessException::class);
+
+        // an authenticated user must not be able to mint a token associated with a different account
+        $this->api->createAppSpecificTokenAuth($this->login, 'password', 'cross-account-token');
+    }
+
+    public function testCreateAppSpecificTokenAuthCannotBeCreatedForAnotherAccountEvenBySuperUser()
+    {
+        // a super user is authenticated as a different account than the targeted one
+        FakeAccess::$superUser = true;
+        FakeAccess::$identity = 'theSuperUser';
+
+        self::expectException(NoAccessException::class);
+
+        $this->api->createAppSpecificTokenAuth($this->login, $this->password, 'cross-account-token');
+    }
+
+    public function testCreateAppSpecificTokenAuthCanBeCreatedByAnonymousProvidingValidCredentials()
+    {
+        // simulate an unauthenticated (anonymous) request, e.g. exchanging credentials for a token
+        FakeAccess::$superUser = false;
+        FakeAccess::$identity = 'anonymous';
+
+        $token = $this->api->createAppSpecificTokenAuth($this->login, $this->password, 'credential-exchange');
+
+        $user = $this->model->getUserByTokenAuth($token);
+        self::assertSame($this->login, $user['login']);
+    }
+
     public function provideContainerConfig()
     {
         return [

--- a/plugins/UsersManager/tests/System/ApiTest.php
+++ b/plugins/UsersManager/tests/System/ApiTest.php
@@ -9,6 +9,8 @@
 
 namespace Piwik\Plugins\UsersManager\tests\System;
 
+use Piwik\Access;
+use Piwik\Container\StaticContainer;
 use Piwik\Date;
 use Piwik\API\Request;
 use Piwik\Piwik;
@@ -136,7 +138,7 @@ class ApiTest extends SystemTestCase
         $this->api->updateUser('login6', $password);
         API::$UPDATE_USER_REQUIRE_PASSWORD_CONFIRMATION = true;
         $this->model->deleteAllTokensForUser('login6');
-        $token = $this->api->createAppSpecificTokenAuth('login6', $password, 'test');
+        $token = $this->createAppSpecificTokenAuthAnonymously('login6', $password, 'test');
         $this->assertMd5($token);
 
         $user = $this->model->getUserByTokenAuth($token);
@@ -146,7 +148,7 @@ class ApiTest extends SystemTestCase
     public function testCreateAppSpecificTokenAuth()
     {
         $this->model->deleteAllTokensForUser('login1');
-        $token = $this->api->createAppSpecificTokenAuth('login1', 'password', 'test');
+        $token = $this->createAppSpecificTokenAuthAnonymously('login1', 'password', 'test');
         $this->assertMd5($token);
 
         $user = $this->model->getUserByTokenAuth($token);
@@ -156,7 +158,7 @@ class ApiTest extends SystemTestCase
     public function testCreateAppSpecificTokenAuthCanLoginByEmail()
     {
         $this->model->deleteAllTokensForUser('login1');
-        $token = $this->api->createAppSpecificTokenAuth('login1@example.com', 'password', 'test');
+        $token = $this->createAppSpecificTokenAuthAnonymously('login1@example.com', 'password', 'test');
         $this->assertMd5($token);
 
         $user = $this->model->getUserByTokenAuth($token);
@@ -169,7 +171,7 @@ class ApiTest extends SystemTestCase
         $this->expectExceptionMessage('The current password you entered is not correct.');
 
         $this->model->deleteAllTokensForUser('login1');
-        $this->api->createAppSpecificTokenAuth('login1', 'foooooo', 'test');
+        $this->createAppSpecificTokenAuthAnonymously('login1', 'foooooo', 'test');
     }
 
     public function testCreateAppSpecificTokenAuthWithExpireDate()
@@ -178,7 +180,7 @@ class ApiTest extends SystemTestCase
 
         $expiryDate = (new \DateTime())->modify('+1 day');
 
-        $token = $this->api->createAppSpecificTokenAuth('login1', 'password', 'test', $expiryDate->format('Y-m-d H:i:s'));
+        $token = $this->createAppSpecificTokenAuthAnonymously('login1', 'password', 'test', $expiryDate->format('Y-m-d H:i:s'));
         $this->assertMd5($token);
 
         $tokens = $this->model->getAllNonSystemTokensForLogin('login1');
@@ -192,7 +194,7 @@ class ApiTest extends SystemTestCase
     {
         $expireInHours = 48;
         $this->model->deleteAllTokensForUser('login1');
-        $token = $this->api->createAppSpecificTokenAuth('login1', 'password', 'test', null, $expireInHours);
+        $token = $this->createAppSpecificTokenAuthAnonymously('login1', 'password', 'test', null, $expireInHours);
         $this->assertMd5($token);
 
         $tokens = $this->model->getAllNonSystemTokensForLogin('login1');
@@ -203,6 +205,25 @@ class ApiTest extends SystemTestCase
         $dateExpired = Date::factory($tokens[0]['date_expired']);
         $dateExpired->isLater(Date::now()->addHour($expireInHours - 1));
         $dateExpired->isEarlier(Date::now()->addHour($expireInHours + 1));
+    }
+
+    /**
+     * Creates a token through the unauthenticated credential-exchange flow (a fresh, anonymous access).
+     * This mirrors providing credentials to obtain a token without an already authenticated session, which is
+     * how these token mechanics are exercised here now that an authenticated request may only create a token
+     * for the current user.
+     */
+    private function createAppSpecificTokenAuthAnonymously(...$args)
+    {
+        $container = StaticContainer::getContainer();
+        $previousAccess = $container->get('Piwik\Access');
+        $container->set('Piwik\Access', new Access());
+
+        try {
+            return $this->api->createAppSpecificTokenAuth(...$args);
+        } finally {
+            $container->set('Piwik\Access', $previousAccess);
+        }
     }
 
     private function assertMd5($string)

--- a/tests/PHPUnit/System/TrackerTest.php
+++ b/tests/PHPUnit/System/TrackerTest.php
@@ -9,8 +9,10 @@
 
 namespace Piwik\Tests\System;
 
+use Piwik\Access;
 use Piwik\API\Request;
 use Piwik\Common;
+use Piwik\Container\StaticContainer;
 use Piwik\Db;
 use Piwik\Log\Logger;
 use Piwik\Log\LoggerInterface;
@@ -82,12 +84,21 @@ class TrackerTest extends IntegrationTestCase
     {
         \Piwik\Filesystem::deleteAllCacheOnUpdate();
 
-        $token = Request::processRequest('UsersManager.createAppSpecificTokenAuth', [
-            'userLogin'            => Fixture::ADMIN_USER_LOGIN,
-            'passwordConfirmation' => Fixture::ADMIN_USER_PASSWORD,
-            'description'          => 'secure one',
-            'secureOnly'           => true,
-        ]);
+        // obtain a token through the unauthenticated credential-exchange flow (a fresh, anonymous access)
+        $container = StaticContainer::getContainer();
+        $previousAccess = $container->get('Piwik\Access');
+        $container->set('Piwik\Access', new Access());
+
+        try {
+            $token = Request::processRequest('UsersManager.createAppSpecificTokenAuth', [
+                'userLogin'            => Fixture::ADMIN_USER_LOGIN,
+                'passwordConfirmation' => Fixture::ADMIN_USER_PASSWORD,
+                'description'          => 'secure one',
+                'secureOnly'           => true,
+            ]);
+        } finally {
+            $container->set('Piwik\Access', $previousAccess);
+        }
 
         $this->issueBulkTrackingRequest($token, true, 2, 0);
     }


### PR DESCRIPTION
### Description

Creating an app-specific token already requires knowing the targeted account's password, as the password confirmation is verified against that account. The existing behaviour is therefore safe on its own.

As an additional safeguard, an already authenticated request may now only create a token for the current user, regardless of role. Unauthenticated requests can still exchange a user's credentials for that user's token.

The existing token tests are updated to use the unauthenticated credential exchange flow accordingly.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
