### PR TITLE
Anonymise installation host before sending to update-check API

### DIFF
--- a/plugins/CoreUpdater/ReleaseChannel.php
+++ b/plugins/CoreUpdater/ReleaseChannel.php
@@ -38,11 +38,10 @@ abstract class ReleaseChannel extends BaseReleaseChannel
     /**
      * Anonymises an installation URL for the update check API.
      *
-     * Returns an empty string when the URL has no host, the host has always been
-     * excluded from update-check stats (no-dot hosts like `localhost`,
-     * `example.org`, malformed URLs), or the host is a private/reserved IP
-     * (excluded server-side historically too). Otherwise returns the SHA-256
-     * of the lowercased host (IPv6 brackets stripped).
+     * Returns an empty string when the URL has no host, the host is `example.org`,
+     * the host has no dot (e.g. `localhost`), or the host is any IP address (IPv4
+     * or IPv6, public or private — IP-shaped installs are not counted). Otherwise
+     * returns the SHA-256 of the lowercased host.
      *
      * The hash input is the host alone, not the full URL: `api_update_check.host`
      * on the API side has stored just the parsed host since 2016, so a backfilled
@@ -62,6 +61,7 @@ abstract class ReleaseChannel extends BaseReleaseChannel
 
         $host = strtolower($parts['host']);
         if (strlen($host) > 1 && $host[0] === '[' && substr($host, -1) === ']') {
+            // strip IPv6 brackets so FILTER_VALIDATE_IP can detect the address
             $host = substr($host, 1, -1);
         }
 
@@ -78,12 +78,8 @@ abstract class ReleaseChannel extends BaseReleaseChannel
             return true;
         }
 
-        $ipFlags = FILTER_VALIDATE_IP;
-        if (filter_var($host, $ipFlags)) {
-            // IP host: exclude private/reserved ranges (dev/test installs, never
-            // counted in update-check stats historically); public IPs are kept
-            // and hashed like any other host.
-            return !filter_var($host, $ipFlags, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE);
+        if (filter_var($host, FILTER_VALIDATE_IP)) {
+            return true;
         }
 
         // Hostname: require at least one dot — `localhost` and similar bare

--- a/plugins/CoreUpdater/ReleaseChannel.php
+++ b/plugins/CoreUpdater/ReleaseChannel.php
@@ -9,17 +9,18 @@
 
 namespace Piwik\Plugins\CoreUpdater;
 
-use Piwik\Common;
 use Piwik\Db;
 use Piwik\Http;
 use Piwik\Plugins\Marketplace\Api\Client;
-use Piwik\Plugins\SitesManager\API;
 use Piwik\UpdateCheck\ReleaseChannel as BaseReleaseChannel;
 use Piwik\Url;
 use Piwik\Version;
 
 abstract class ReleaseChannel extends BaseReleaseChannel
 {
+    public const ANONYMISED_URL_IP_LOCAL_PREFIX = 'IP-LOCAL:';
+    public const ANONYMISED_URL_IP_PUBLIC_PREFIX = 'IP-PUBLIC:';
+
     public function getUrlToCheckForLatestAvailableVersion()
     {
         $parameters = array(
@@ -27,9 +28,7 @@ abstract class ReleaseChannel extends BaseReleaseChannel
             'php_version'     => PHP_VERSION,
             'mysql_version'   => Db::get()->getServerVersion(),
             'release_channel' => $this->getId(),
-            'url'             => Url::getCurrentUrlWithoutQueryString(),
-            'trigger'         => Common::getRequestVar('module', '', 'string'),
-            'timezone'        => API::getInstance()->getDefaultTimezone(),
+            'url'             => self::anonymiseUrl(Url::getCurrentUrlWithoutQueryString()),
         );
 
         $url = Client::getApiServiceUrl()
@@ -37,6 +36,66 @@ abstract class ReleaseChannel extends BaseReleaseChannel
             . '?' . Http::buildQuery($parameters);
 
         return $url;
+    }
+
+    /**
+     * Anonymises an installation URL for the update check API.
+     *
+     * Returns:
+     *   - empty string for URLs without a host or with a host we have always excluded
+     *     from update-check stats (no-dot hosts, `example.org`, `localhost`, ...);
+     *   - `IP-LOCAL:` + SHA-256 of the host for private/reserved IP hosts;
+     *   - `IP-PUBLIC:` + SHA-256 of the host for public IP hosts;
+     *   - SHA-256 of the lowercased host otherwise.
+     *
+     * The hash input is the host alone (lowercased, IPv6 brackets stripped). This
+     * matches the historical "one host = one install" semantics of the API
+     * (`api_update_check.host` has always stored just the parsed host, never the
+     * full URL), so backfilled rows and new rows produce identical hashes for the
+     * same install.
+     */
+    public static function anonymiseUrl(string $url): string
+    {
+        if ($url === '') {
+            return '';
+        }
+
+        $parts = @parse_url($url);
+        if ($parts === false || empty($parts['host'])) {
+            return '';
+        }
+
+        $host = strtolower($parts['host']);
+        $hostForIpCheck = (strlen($host) > 1 && $host[0] === '[' && substr($host, -1) === ']')
+            ? substr($host, 1, -1)
+            : $host;
+
+        $isIp = (bool) filter_var($hostForIpCheck, FILTER_VALIDATE_IP);
+
+        if (!$isIp && self::isExcludedHost($hostForIpCheck)) {
+            return '';
+        }
+
+        $hash = hash('sha256', $isIp ? $hostForIpCheck : $host);
+
+        if ($isIp) {
+            $isPublic = (bool) filter_var(
+                $hostForIpCheck,
+                FILTER_VALIDATE_IP,
+                FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
+            );
+            return ($isPublic ? self::ANONYMISED_URL_IP_PUBLIC_PREFIX : self::ANONYMISED_URL_IP_LOCAL_PREFIX) . $hash;
+        }
+
+        return $hash;
+    }
+
+    private static function isExcludedHost(string $host): bool
+    {
+        if ($host === '' || $host === 'example.org' || strpos($host, '.') === false) {
+            return true;
+        }
+        return false;
     }
 
     public function getDownloadUrlWithoutScheme($version)

--- a/plugins/CoreUpdater/ReleaseChannel.php
+++ b/plugins/CoreUpdater/ReleaseChannel.php
@@ -18,9 +18,6 @@ use Piwik\Version;
 
 abstract class ReleaseChannel extends BaseReleaseChannel
 {
-    public const ANONYMISED_URL_IP_LOCAL_PREFIX = 'IP-LOCAL:';
-    public const ANONYMISED_URL_IP_PUBLIC_PREFIX = 'IP-PUBLIC:';
-
     public function getUrlToCheckForLatestAvailableVersion()
     {
         $parameters = array(
@@ -41,18 +38,16 @@ abstract class ReleaseChannel extends BaseReleaseChannel
     /**
      * Anonymises an installation URL for the update check API.
      *
-     * Returns:
-     *   - empty string for URLs without a host or with a host we have always excluded
-     *     from update-check stats (no-dot hosts, `example.org`, `localhost`, ...);
-     *   - `IP-LOCAL:` + SHA-256 of the host for private/reserved IP hosts;
-     *   - `IP-PUBLIC:` + SHA-256 of the host for public IP hosts;
-     *   - SHA-256 of the lowercased host otherwise.
+     * Returns an empty string when the URL has no host, the host has always been
+     * excluded from update-check stats (no-dot hosts like `localhost`,
+     * `example.org`, malformed URLs), or the host is a private/reserved IP
+     * (excluded server-side historically too). Otherwise returns the SHA-256
+     * of the lowercased host (IPv6 brackets stripped).
      *
-     * The hash input is the host alone (lowercased, IPv6 brackets stripped). This
-     * matches the historical "one host = one install" semantics of the API
-     * (`api_update_check.host` has always stored just the parsed host, never the
-     * full URL), so backfilled rows and new rows produce identical hashes for the
-     * same install.
+     * The hash input is the host alone, not the full URL: `api_update_check.host`
+     * on the API side has stored just the parsed host since 2016, so a backfilled
+     * historical row and a fresh ping from the same install produce identical
+     * hashes — cohort/churn queries spanning the cutover keep working.
      */
     public static function anonymiseUrl(string $url): string
     {
@@ -66,36 +61,34 @@ abstract class ReleaseChannel extends BaseReleaseChannel
         }
 
         $host = strtolower($parts['host']);
-        $hostForIpCheck = (strlen($host) > 1 && $host[0] === '[' && substr($host, -1) === ']')
-            ? substr($host, 1, -1)
-            : $host;
+        if (strlen($host) > 1 && $host[0] === '[' && substr($host, -1) === ']') {
+            $host = substr($host, 1, -1);
+        }
 
-        $isIp = (bool) filter_var($hostForIpCheck, FILTER_VALIDATE_IP);
-
-        if (!$isIp && self::isExcludedHost($hostForIpCheck)) {
+        if (self::isExcludedHost($host)) {
             return '';
         }
 
-        $hash = hash('sha256', $isIp ? $hostForIpCheck : $host);
-
-        if ($isIp) {
-            $isPublic = (bool) filter_var(
-                $hostForIpCheck,
-                FILTER_VALIDATE_IP,
-                FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
-            );
-            return ($isPublic ? self::ANONYMISED_URL_IP_PUBLIC_PREFIX : self::ANONYMISED_URL_IP_LOCAL_PREFIX) . $hash;
-        }
-
-        return $hash;
+        return hash('sha256', $host);
     }
 
     private static function isExcludedHost(string $host): bool
     {
-        if ($host === '' || $host === 'example.org' || strpos($host, '.') === false) {
+        if ($host === '' || $host === 'example.org') {
             return true;
         }
-        return false;
+
+        $ipFlags = FILTER_VALIDATE_IP;
+        if (filter_var($host, $ipFlags)) {
+            // IP host: exclude private/reserved ranges (dev/test installs, never
+            // counted in update-check stats historically); public IPs are kept
+            // and hashed like any other host.
+            return !filter_var($host, $ipFlags, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE);
+        }
+
+        // Hostname: require at least one dot — `localhost` and similar bare
+        // names are dev/test installs that have always been excluded.
+        return strpos($host, '.') === false;
     }
 
     public function getDownloadUrlWithoutScheme($version)

--- a/plugins/CoreUpdater/ReleaseChannel.php
+++ b/plugins/CoreUpdater/ReleaseChannel.php
@@ -38,10 +38,14 @@ abstract class ReleaseChannel extends BaseReleaseChannel
     /**
      * Anonymises an installation URL for the update check API.
      *
-     * Returns an empty string when the URL has no host, the host is `example.org`,
-     * the host has no dot (e.g. `localhost`), or the host is any IP address (IPv4
-     * or IPv6, public or private — IP-shaped installs are not counted). Otherwise
-     * returns the SHA-256 of the lowercased host.
+     * Returns an empty string when the URL has no host, when the host is
+     * IP-shaped (any IPv4/IPv6, public or private), or when the host is one
+     * we don't count as a real install: bare no-dot names (`localhost`),
+     * `example.org` (RFC 2606 documentation TLD; the API side has excluded
+     * it since forever, so we mirror it here for continuity), and hosts
+     * ending in a reserved / dev-only suffix (see
+     * {@see self::EXCLUDED_HOST_SUFFIXES}). Otherwise returns the SHA-256
+     * of the lowercased host.
      *
      * The hash input is the host alone, not the full URL: `api_update_check.host`
      * on the API side has stored just the parsed host since 2016, so a backfilled
@@ -72,6 +76,35 @@ abstract class ReleaseChannel extends BaseReleaseChannel
         return hash('sha256', $host);
     }
 
+    /**
+     * Host suffixes that identify non-production installs. Kept as a single
+     * list rather than per-RFC scatter so the client and api.matomo.org
+     * fallback stay in lock-step — the two sides MUST agree, or legacy
+     * clients (which send the raw URL and are hashed server-side) end up
+     * with different exclusion decisions than fresh clients.
+     */
+    private const EXCLUDED_HOST_SUFFIXES = [
+        // RFC 2606 / 6761 — reserved for documentation & testing.
+        '.test',
+        '.example',
+        '.invalid',
+        '.localhost',
+        // RFC 6762 — mDNS "local" names (default on macOS and many home LANs).
+        '.local',
+        // RFC 8375 — residential home network namespace.
+        '.home.arpa',
+        // RFC 7686 — Tor hidden services.
+        '.onion',
+        // RFC 9476 — alternative resolution namespaces.
+        '.alt',
+        // ICANN reservation (2024) — private-use internal DNS.
+        '.internal',
+        // DDEV — the local-dev tool the Matomo team uses; hostnames like
+        // matomo.ddev.site resolve to 127.0.0.1. Registered domain, so no
+        // RFC/PSL check catches it — we exclude explicitly.
+        '.ddev.site',
+    ];
+
     private static function isExcludedHost(string $host): bool
     {
         if ($host === '' || $host === 'example.org') {
@@ -84,7 +117,17 @@ abstract class ReleaseChannel extends BaseReleaseChannel
 
         // Hostname: require at least one dot — `localhost` and similar bare
         // names are dev/test installs that have always been excluded.
-        return strpos($host, '.') === false;
+        if (strpos($host, '.') === false) {
+            return true;
+        }
+
+        foreach (self::EXCLUDED_HOST_SUFFIXES as $suffix) {
+            if (substr($host, -strlen($suffix)) === $suffix) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function getDownloadUrlWithoutScheme($version)

--- a/plugins/CoreUpdater/tests/Integration/ReleaseChannelTest.php
+++ b/plugins/CoreUpdater/tests/Integration/ReleaseChannelTest.php
@@ -57,15 +57,89 @@ class ReleaseChannelTest extends IntegrationTestCase
         $version = Version::VERSION;
         $phpVersion = urlencode(PHP_VERSION);
         $mysqlVersion = Db::get()->getServerVersion();
-        $url = urlencode(Url::getCurrentUrlWithoutQueryString());
+        $anonymisedUrl = ReleaseChannel::anonymiseUrl(Url::getCurrentUrlWithoutQueryString());
 
         $urlToCheck = $this->channel->getUrlToCheckForLatestAvailableVersion();
 
-        $this->assertStringStartsWith("https://api.matomo.org/1.0/getLatestVersion/?piwik_version=$version&php_version=$phpVersion&mysql_version=$mysqlVersion&release_channel=my_channel&url=$url&trigger=&timezone=", $urlToCheck);
+        $this->assertSame(
+            "https://api.matomo.org/1.0/getLatestVersion/?piwik_version=$version&php_version=$phpVersion&mysql_version=$mysqlVersion&release_channel=my_channel&url=$anonymisedUrl",
+            $urlToCheck
+        );
+        $this->assertStringNotContainsString('trigger=', $urlToCheck);
+        $this->assertStringNotContainsString('timezone=', $urlToCheck);
     }
 
     public function testDoesPreferStable()
     {
         $this->assertTrue($this->channel->doesPreferStable());
+    }
+
+    /**
+     * @dataProvider provideAnonymiseUrlCases
+     */
+    public function testAnonymiseUrl(string $input, string $expectedPrefix, bool $expectHash)
+    {
+        $actual = ReleaseChannel::anonymiseUrl($input);
+
+        if ($expectedPrefix === '') {
+            $this->assertSame('', $actual);
+            return;
+        }
+
+        if ($expectedPrefix === 'HASH') {
+            $this->assertRegExp('/^[a-f0-9]{64}$/', $actual);
+            return;
+        }
+
+        $this->assertStringStartsWith($expectedPrefix, $actual);
+        if ($expectHash) {
+            $this->assertRegExp('/^' . preg_quote($expectedPrefix, '/') . '[a-f0-9]{64}$/', $actual);
+        }
+    }
+
+    public function provideAnonymiseUrlCases(): iterable
+    {
+        yield 'empty input' => ['', '', false];
+        yield 'malformed' => ['not a url', '', false];
+        yield 'no host' => ['/relative/path', '', false];
+        yield 'example.org excluded' => ['https://example.org/index.php', '', false];
+        yield 'localhost (no dot) excluded' => ['http://localhost/index.php', '', false];
+        yield 'public hostname produces hash' => ['https://stats.acme.com/matomo/', 'HASH', true];
+        yield 'public IPv4 prefixed IP-PUBLIC' => ['http://8.8.8.8/index.php', ReleaseChannel::ANONYMISED_URL_IP_PUBLIC_PREFIX, true];
+        yield 'private IPv4 prefixed IP-LOCAL' => ['http://192.168.1.1/index.php', ReleaseChannel::ANONYMISED_URL_IP_LOCAL_PREFIX, true];
+        yield 'reserved IPv4 (loopback) prefixed IP-LOCAL' => ['http://127.0.0.1/index.php', ReleaseChannel::ANONYMISED_URL_IP_LOCAL_PREFIX, true];
+        yield 'public IPv6 prefixed IP-PUBLIC' => ['http://[2001:4860:4860::8888]/', ReleaseChannel::ANONYMISED_URL_IP_PUBLIC_PREFIX, true];
+        yield 'link-local IPv6 prefixed IP-LOCAL' => ['http://[fe80::1]/', ReleaseChannel::ANONYMISED_URL_IP_LOCAL_PREFIX, true];
+    }
+
+    public function testAnonymiseUrlIsStable()
+    {
+        $url = 'https://stats.acme.com/matomo/index.php';
+        $this->assertSame(ReleaseChannel::anonymiseUrl($url), ReleaseChannel::anonymiseUrl($url));
+    }
+
+    public function testAnonymiseUrlIsCaseInsensitiveOnHost()
+    {
+        $this->assertSame(
+            ReleaseChannel::anonymiseUrl('https://stats.acme.com/matomo/index.php'),
+            ReleaseChannel::anonymiseUrl('HTTPS://Stats.Acme.COM/matomo/index.php')
+        );
+    }
+
+    public function testAnonymiseUrlIgnoresSchemeAndPath()
+    {
+        // Two installs at the same host but different scheme/path collapse to the
+        // same hash, matching the historical "one host = one install" API semantics.
+        $reference = ReleaseChannel::anonymiseUrl('https://stats.acme.com/matomo/');
+        $this->assertSame($reference, ReleaseChannel::anonymiseUrl('http://stats.acme.com/'));
+        $this->assertSame($reference, ReleaseChannel::anonymiseUrl('https://stats.acme.com/analytics/index.php'));
+    }
+
+    public function testAnonymiseUrlHashMatchesHostHash()
+    {
+        $this->assertSame(
+            hash('sha256', 'stats.acme.com'),
+            ReleaseChannel::anonymiseUrl('https://stats.acme.com/matomo/index.php')
+        );
     }
 }

--- a/plugins/CoreUpdater/tests/Integration/ReleaseChannelTest.php
+++ b/plugins/CoreUpdater/tests/Integration/ReleaseChannelTest.php
@@ -98,10 +98,11 @@ class ReleaseChannelTest extends IntegrationTestCase
         yield 'localhost (no dot) excluded' => ['http://localhost/index.php', ''];
         yield 'private IPv4 excluded' => ['http://192.168.1.1/index.php', ''];
         yield 'reserved IPv4 (loopback) excluded' => ['http://127.0.0.1/index.php', ''];
+        yield 'public IPv4 excluded' => ['http://8.8.8.8/index.php', ''];
         yield 'link-local IPv6 excluded' => ['http://[fe80::1]/', ''];
+        yield 'public IPv6 excluded' => ['http://[2001:4860:4860::8888]/', ''];
+        yield 'IPv4-mapped IPv6 excluded (brackets stripped before IP check)' => ['http://[::ffff:192.168.1.1]/', ''];
         yield 'public hostname produces hash' => ['https://stats.acme.com/matomo/', 'HASH'];
-        yield 'public IPv4 produces hash' => ['http://8.8.8.8/index.php', 'HASH'];
-        yield 'public IPv6 produces hash' => ['http://[2001:4860:4860::8888]/', 'HASH'];
     }
 
     public function testAnonymiseUrlIsStable()
@@ -132,14 +133,6 @@ class ReleaseChannelTest extends IntegrationTestCase
         $this->assertSame(
             hash('sha256', 'stats.acme.com'),
             ReleaseChannel::anonymiseUrl('https://stats.acme.com/matomo/index.php')
-        );
-    }
-
-    public function testAnonymiseUrlStripsIpv6BracketsBeforeHashing()
-    {
-        $this->assertSame(
-            hash('sha256', '2001:4860:4860::8888'),
-            ReleaseChannel::anonymiseUrl('http://[2001:4860:4860::8888]/')
         );
     }
 }

--- a/plugins/CoreUpdater/tests/Integration/ReleaseChannelTest.php
+++ b/plugins/CoreUpdater/tests/Integration/ReleaseChannelTest.php
@@ -77,39 +77,31 @@ class ReleaseChannelTest extends IntegrationTestCase
     /**
      * @dataProvider provideAnonymiseUrlCases
      */
-    public function testAnonymiseUrl(string $input, string $expectedPrefix, bool $expectHash)
+    public function testAnonymiseUrl(string $input, string $expected)
     {
         $actual = ReleaseChannel::anonymiseUrl($input);
 
-        if ($expectedPrefix === '') {
-            $this->assertSame('', $actual);
-            return;
-        }
-
-        if ($expectedPrefix === 'HASH') {
+        if ($expected === 'HASH') {
             $this->assertRegExp('/^[a-f0-9]{64}$/', $actual);
             return;
         }
 
-        $this->assertStringStartsWith($expectedPrefix, $actual);
-        if ($expectHash) {
-            $this->assertRegExp('/^' . preg_quote($expectedPrefix, '/') . '[a-f0-9]{64}$/', $actual);
-        }
+        $this->assertSame($expected, $actual);
     }
 
     public function provideAnonymiseUrlCases(): iterable
     {
-        yield 'empty input' => ['', '', false];
-        yield 'malformed' => ['not a url', '', false];
-        yield 'no host' => ['/relative/path', '', false];
-        yield 'example.org excluded' => ['https://example.org/index.php', '', false];
-        yield 'localhost (no dot) excluded' => ['http://localhost/index.php', '', false];
-        yield 'public hostname produces hash' => ['https://stats.acme.com/matomo/', 'HASH', true];
-        yield 'public IPv4 prefixed IP-PUBLIC' => ['http://8.8.8.8/index.php', ReleaseChannel::ANONYMISED_URL_IP_PUBLIC_PREFIX, true];
-        yield 'private IPv4 prefixed IP-LOCAL' => ['http://192.168.1.1/index.php', ReleaseChannel::ANONYMISED_URL_IP_LOCAL_PREFIX, true];
-        yield 'reserved IPv4 (loopback) prefixed IP-LOCAL' => ['http://127.0.0.1/index.php', ReleaseChannel::ANONYMISED_URL_IP_LOCAL_PREFIX, true];
-        yield 'public IPv6 prefixed IP-PUBLIC' => ['http://[2001:4860:4860::8888]/', ReleaseChannel::ANONYMISED_URL_IP_PUBLIC_PREFIX, true];
-        yield 'link-local IPv6 prefixed IP-LOCAL' => ['http://[fe80::1]/', ReleaseChannel::ANONYMISED_URL_IP_LOCAL_PREFIX, true];
+        yield 'empty input' => ['', ''];
+        yield 'malformed' => ['not a url', ''];
+        yield 'no host' => ['/relative/path', ''];
+        yield 'example.org excluded' => ['https://example.org/index.php', ''];
+        yield 'localhost (no dot) excluded' => ['http://localhost/index.php', ''];
+        yield 'private IPv4 excluded' => ['http://192.168.1.1/index.php', ''];
+        yield 'reserved IPv4 (loopback) excluded' => ['http://127.0.0.1/index.php', ''];
+        yield 'link-local IPv6 excluded' => ['http://[fe80::1]/', ''];
+        yield 'public hostname produces hash' => ['https://stats.acme.com/matomo/', 'HASH'];
+        yield 'public IPv4 produces hash' => ['http://8.8.8.8/index.php', 'HASH'];
+        yield 'public IPv6 produces hash' => ['http://[2001:4860:4860::8888]/', 'HASH'];
     }
 
     public function testAnonymiseUrlIsStable()
@@ -140,6 +132,14 @@ class ReleaseChannelTest extends IntegrationTestCase
         $this->assertSame(
             hash('sha256', 'stats.acme.com'),
             ReleaseChannel::anonymiseUrl('https://stats.acme.com/matomo/index.php')
+        );
+    }
+
+    public function testAnonymiseUrlStripsIpv6BracketsBeforeHashing()
+    {
+        $this->assertSame(
+            hash('sha256', '2001:4860:4860::8888'),
+            ReleaseChannel::anonymiseUrl('http://[2001:4860:4860::8888]/')
         );
     }
 }

--- a/plugins/CoreUpdater/tests/Integration/ReleaseChannelTest.php
+++ b/plugins/CoreUpdater/tests/Integration/ReleaseChannelTest.php
@@ -102,7 +102,33 @@ class ReleaseChannelTest extends IntegrationTestCase
         yield 'link-local IPv6 excluded' => ['http://[fe80::1]/', ''];
         yield 'public IPv6 excluded' => ['http://[2001:4860:4860::8888]/', ''];
         yield 'IPv4-mapped IPv6 excluded (brackets stripped before IP check)' => ['http://[::ffff:192.168.1.1]/', ''];
+        // Non-production TLD suffixes — see EXCLUDED_HOST_SUFFIXES.
+        yield '.test excluded (RFC 2606)' => ['http://matomo.test/', ''];
+        yield '.example excluded (RFC 2606)' => ['http://matomo.example/', ''];
+        yield '.invalid excluded (RFC 2606)' => ['http://matomo.invalid/', ''];
+        yield '.localhost excluded (RFC 2606)' => ['http://matomo.localhost/', ''];
+        yield '.local excluded (RFC 6762 mDNS)' => ['http://matomo.local/', ''];
+        yield '.home.arpa excluded (RFC 8375)' => ['http://matomo.home.arpa/', ''];
+        yield '.onion excluded (RFC 7686)' => ['http://exampleofonionservice.onion/', ''];
+        yield '.alt excluded (RFC 9476)' => ['http://matomo.alt/', ''];
+        yield '.internal excluded (ICANN 2024)' => ['http://matomo.internal/', ''];
+        yield '.ddev.site excluded (local dev)' => ['http://matomo.ddev.site/', ''];
+        yield 'multi-level .ddev.site excluded' => ['http://sub.project.ddev.site/', ''];
         yield 'public hostname produces hash' => ['https://stats.acme.com/matomo/', 'HASH'];
+    }
+
+    public function testAnonymiseUrlDoesNotConfuseSuffixWithSubstring()
+    {
+        // `.local` suffix must not match a host that merely contains
+        // "local" mid-label. Guards against a naive strpos-style check.
+        $this->assertRegExp(
+            '/^[a-f0-9]{64}$/',
+            ReleaseChannel::anonymiseUrl('https://foo.notlocal.com/')
+        );
+        $this->assertRegExp(
+            '/^[a-f0-9]{64}$/',
+            ReleaseChannel::anonymiseUrl('https://stats.example.com/')
+        );
     }
 
     public function testAnonymiseUrlIsStable()


### PR DESCRIPTION
## TLDR

**Do not merge until all api changes merged**

Stop the CoreUpdater release-check ping from sending the install's full URL, timezone, or trigger to api.matomo.org. The URL now goes out as `sha256(lowercased host)`, and IP-shaped installs send empty (the server drops the row). No PII leaves the install on the wire.

## Scope

- `ReleaseChannel::getUrlToCheckForLatestAvailableVersion()` no longer sends `trigger` or `timezone`, and rewrites `url` through new `ReleaseChannel::anonymiseUrl()`.
- `ReleaseChannel::anonymiseUrl($url)` — public static helper. Returns `''` for missing/malformed/no-host, `example.org`, no-dot hosts (e.g. `localhost`), and any IP address (IPv4/IPv6, public or private). Otherwise returns the 64-char SHA-256 hex of the lowercased host.
- New `ReleaseChannelTest` data-provider exercises empty/malformed/excluded/IPv4/IPv6/IPv4-mapped/public-host cases, plus stability, case-insensitivity, scheme-and-path-ignored, and an explicit `hash('sha256', 'stats.acme.com')` lock-in.

## Decisions

- **Filtering out some local hosts** - Not useful to have those.
- **Host alone is hashed**, not the full URL
- **No salt.** Both this repo and api.matomo.org are public; a code-level salt isn't secret.
- **`trigger` and `timezone` are dropped from the query string entirely**, not blanked. 
- **No client-side version handshake.** The api.matomo.org sibling PR has a server-side fallback that hashes legacy raw URLs, so old clients continue to work during the rollout.

Ref: DEV-14340

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)