### PR TITLE
Do not treat API.getBulkRequest as a read-only method

### DIFF
--- a/core/Access.php
+++ b/core/Access.php
@@ -43,6 +43,15 @@ use Piwik\Session\SessionAuth;
 class Access
 {
     /**
+     * API methods that follow the read-only naming convention but dispatch further API methods,
+     * and therefore must never be treated as read-only. Compared case insensitively, so entries
+     * have to be lower case.
+     *
+     * @var string[]
+     */
+    private const DISPATCHER_API_METHODS = ['api.getbulkrequest'];
+
+    /**
      * Array of idsites available to the current user, indexed by permission level
      * @see getSitesIdWith*()
      *
@@ -164,7 +173,7 @@ class Access
 
         $isApiRequest = Piwik::getModule() === 'API' && (Piwik::getAction() === 'index' || !Piwik::getAction());
         $apiMethod = Request::getMethodIfApiRequest(null);
-        $isGetApiRequest = !empty($apiMethod) && 1 === substr_count($apiMethod, '.') && strpos($apiMethod, '.get') > 0;
+        $isGetApiRequest = self::isReadOnlyApiMethod($apiMethod);
 
         $token = StaticContainer::get(AuthenticationToken::class);
 
@@ -201,6 +210,31 @@ class Access
         }
 
         return true;
+    }
+
+    /**
+     * Returns true if the given API method may be authenticated with a session token that was not
+     * provided securely, ie. one that reached us as a URL parameter. That channel is restricted to
+     * requests which do not change state.
+     *
+     * Read-only is inferred from the `Plugin.getSomething` naming convention, so the test describes
+     * how a method is named rather than what it does. A dispatcher such as API.getBulkRequest
+     * matches the convention but executes arbitrary nested methods with the caller's privileges,
+     * which would defeat the restriction, so dispatchers are excluded explicitly.
+     *
+     * @param string|null $apiMethod API method in `Plugin.method` notation.
+     */
+    public static function isReadOnlyApiMethod(?string $apiMethod): bool
+    {
+        if (empty($apiMethod)) {
+            return false;
+        }
+
+        if (in_array(strtolower($apiMethod), self::DISPATCHER_API_METHODS, true)) {
+            return false;
+        }
+
+        return 1 === substr_count($apiMethod, '.') && strpos($apiMethod, '.get') > 0;
     }
 
     public function getRawSitesWithSomeViewAccess($login)

--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Plugins\API;
 
+use Piwik\Access;
 use Piwik\API\Proxy;
 use Piwik\API\Request;
 use Piwik\ArchiveProcessor\Rules;
@@ -23,6 +24,7 @@ use Piwik\DataTable\Filter\ColumnDelete;
 use Piwik\Date;
 use Piwik\Http\BadRequestException;
 use Piwik\IP;
+use Piwik\NoAccessException;
 use Piwik\Period;
 use Piwik\Piwik;
 use Piwik\Plugin\SettingsProvider;
@@ -580,6 +582,11 @@ class API extends \Piwik\Plugin\API
         $rootIsSessionToken = $authToken->isSessionToken();
         $rootTokenAuth = $authToken->getAuthToken();
 
+        // A session token that reached us as a URL parameter only authorizes requests which do not
+        // change state. Sub-requests inherit that token from the root request instead of passing
+        // through Access again, so the restriction has to be carried down here.
+        $nestedMethodsMustBeReadOnly = $rootIsSessionToken && !$authToken->wasTokenAuthProvidedSecurely();
+
         $result = [];
         foreach ($urls as $url) {
             $nestedRequest = \Piwik\Request::fromQueryString($url);
@@ -592,12 +599,16 @@ class API extends \Piwik\Plugin\API
             $params += $queryParameters;
 
             $method = $params['method'] ?? '';
+            $method = !empty($method) && is_string($method)
+                ? preg_replace('/[^\w\.]+/', '', Common::sanitizeInputValue($method))
+                : '';
 
-            if (
-                !empty($method) && is_string($method) &&
-                preg_replace('/[^\w\.]+/', '', Common::sanitizeInputValue($method)) === 'API.getBulkRequest'
-            ) {
+            if ($method === 'API.getBulkRequest') {
                 continue;
+            }
+
+            if ($nestedMethodsMustBeReadOnly && !Access::isReadOnlyApiMethod($method)) {
+                throw new NoAccessException(Piwik::translate('Login_TokenAuthenticationFailedInsecure'));
             }
 
             $req = new Request($params);

--- a/tests/PHPUnit/Integration/AccessTest.php
+++ b/tests/PHPUnit/Integration/AccessTest.php
@@ -671,6 +671,41 @@ class AccessTest extends IntegrationTestCase
         self::assertStringContainsString('<result>' . Version::VERSION . '</result>', $response);
     }
 
+    /**
+     * @dataProvider getReadOnlyApiMethods
+     */
+    public function testIsReadOnlyApiMethod($apiMethod, $expected)
+    {
+        $this->assertSame($expected, Access::isReadOnlyApiMethod($apiMethod));
+    }
+
+    public function getReadOnlyApiMethods()
+    {
+        return [
+            // dispatchers match the naming convention but execute arbitrary nested methods
+            ['API.getBulkRequest', false],
+            ['api.getbulkrequest', false],
+            ['API.GETBULKREQUEST', false],
+
+            // genuine read-only methods
+            ['API.get', true],
+            ['API.getMatomoVersion', true],
+            ['UsersManager.getUsers', true],
+            ['SitesManager.getSitesWithAtLeastViewAccess', true],
+
+            // state changing methods
+            ['SitesManager.setGlobalExcludedIps', false],
+            ['CoreAdminHome.setTrustedHosts', false],
+            ['UsersManager.addUser', false],
+
+            // malformed input
+            [null, false],
+            ['', false],
+            ['NotAnApiMethod', false],
+            ['Some.Nested.getThing', false],
+        ];
+    }
+
     private function switchUser($user)
     {
         $mock = $this->createPiwikAuthMockInstance();


### PR DESCRIPTION
## What this fixes

`core/Access.php` restricts what a session token may authenticate when it arrives as a URL query parameter rather than through a secure channel: only read-only methods. The test is a naming heuristic, not a test of what the method does:

```php
// core/Access.php
$isGetApiRequest = !empty($apiMethod) && 1 === substr_count($apiMethod, '.') && strpos($apiMethod, '.get') > 0;

if ($isApiRequest && $token->isSessionToken() && ($token->wasTokenAuthProvidedSecurely() || $isGetApiRequest)) {
```

`API.getBulkRequest` passes it — one dot, and `strpos('API.getBulkRequest', '.get') === 3` — but it is a dispatcher that executes arbitrary nested API methods with the caller's privileges. Wrapping a state-changing method in it runs that method through a channel the code deliberately restricts to reads.

The existing `checkNestedRequestAuthMatchesRoot()` does not cover this. It rejects a sub-request that *supplies* `force_api_session` / `token_auth` differing from the root, and the nested call supplies neither — it inherits both via `$params += $queryParameters` in `getBulkRequest()`, so the sub-request never re-enters the `Access` gate at all.

## Reproduction

With a valid session cookie and the session token in the URL, the direct call is refused:

```
GET /index.php?module=API&method=SitesManager.setGlobalExcludedIps&excludedIps=1.1.1.1
    &force_api_session=1&token_auth=<session token>&format=json

-> HTTP 401  {"result":"error","message":"Unable to authenticate with the provided token. ..."}
```

The same call nested in a bulk request is accepted, and the write is applied:

```
GET /index.php?module=API&method=API.getBulkRequest&force_api_session=1&token_auth=<session token>
    &urls[0]=method%3DSitesManager.setGlobalExcludedIps%26excludedIps%3D2.2.2.2&format=json

-> HTTP 200  [{"value":true}]
```

A genuine read method through the same channel (`SitesManager.getSitesWithAtLeastViewAccess`) returns 200 both before and after this patch, so the branch keeps doing what it was written to do.

Verified by execution on 5.12.0 and confirmed still present on `5.x-dev`.

## The change

Two layers, both small:

1. **`Access::isReadOnlyApiMethod()`** — the naming heuristic moves out of `reloadAccess()` into one named, testable place, and dispatcher methods are excluded from it. The heuristic itself is deliberately unchanged; see "Not addressed here" below.

2. **`getBulkRequest()` carries the restriction down.** When the root request authenticated with a session token that was not provided securely, each nested method must itself be read-only, otherwise the bulk request is refused. This mirrors the neighbouring `checkNestedRequestAuthMatchesRoot()` and is what keeps the restriction intact if another dispatcher-style method is added later.

The refusal reuses `Login_TokenAuthenticationFailedInsecure`, so the nested call now fails with the same message the direct call already produces. No new translation keys.

While touching the loop, the `method` parameter is normalised once instead of twice, so the read-only check and the existing self-recursion check cannot diverge on padded input.

## Tests

`AccessTest::testIsReadOnlyApiMethod()` with a data provider covering the dispatcher (including case variants), genuine readers, state-changing methods, and malformed input.

## Not addressed here

The underlying assumption — "the name contains `.get`, therefore it is a read" — is still in place, and it would also accept a future method named e.g. `Something.getsomething` that writes. Replacing it with an explicit read-only allowlist or an attribute on the API method is the better long-term fix, but it is a much larger change with a real chance of breaking third-party plugins, so it is left out of this PR. The second layer above limits the blast radius in the meantime. Happy to follow up on that separately if you would like it.

## Context

Reported to the Matomo security programme as HackerOne #3897362 and closed as informative, on the grounds that the restriction guards against accidental state changes through URL parameters rather than forming a security boundary. That assessment is not being contested here; this is offered as the hardening change that was invited in the closing comment.

One detail may be worth weighing when deciding how much this matters. The closure rested on the observation that the same user can invoke the same methods via POST, which holds whenever the actor controls the request method. `Session::getSameSiteCookieValue()` returns `Lax` by default, and under `SameSite=Lax` a cross-site actor driving a logged-in user's browser gets the opposite pairing: a top-level GET navigation sends the session cookie, a cross-site POST does not. In that specific shape — which is the one the URL-parameter restriction appears aimed at — GET is the only available channel and POST is precisely the unavailable one. I have not built a proof of concept for that scenario and am not claiming it as a vulnerability, only noting it as a reason the restriction may be worth more than defence in depth.

## Tooling disclosure

Prepared with AI assistance (Claude). Every cited line was verified by direct read against `5.x-dev`, the patch applies cleanly to a pristine checkout, all three touched files parse, and the data provider expectations were executed against the real function rather than assumed.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules