### PR TITLE
Return non-zero exit code from plugin:install-or-update on failure

### DIFF
--- a/plugins/CorePluginsAdmin/Commands/InstallPlugin.php
+++ b/plugins/CorePluginsAdmin/Commands/InstallPlugin.php
@@ -42,6 +42,7 @@ class InstallPlugin extends ConsoleCommand
         }
 
         $pluginNames = $input->getArgument('plugin');
+        $hasFailure = false;
 
         foreach ($pluginNames as $pluginName) {
             try {
@@ -49,11 +50,12 @@ class InstallPlugin extends ConsoleCommand
                 $output->writeln(sprintf("Installed or updated plugin <info>%s</info>", $pluginName));
             } catch (\Piwik\Plugins\CorePluginsAdmin\PluginInstallerException $e) {
                 $output->writeln(sprintf("<error>Unable to install or update plugin %s. %s</error>", $pluginName, $e->getMessage()));
+                $hasFailure = true;
                 continue;
             }
         }
 
-        return self::SUCCESS;
+        return $hasFailure ? self::FAILURE : self::SUCCESS;
     }
 
     private function installPlugin(string $pluginName): void


### PR DESCRIPTION
### Description

Returns an exit code of 1 for `plugin:install-or-update` if the command fails. This is useful if you run `plugin:install-or-update` from a script/automation. This fixes the GitHub Issue #24957.  Change tested as follows:

Before:

```shell
$ ./console plugin:install-or-update Bandwidth
Unable to install or update plugin Bandwidth. There was an error reading the response from the Marketplace. Please try again later.

$ echo $?
0
```

After:

```shell
$ ./console plugin:install-or-update Bandwidth
Unable to install or update plugin Bandwidth. There was an error reading the response from the Marketplace. Please try again later.

$ echo $?
1
```

### Checklist

- [x] I have understood, reviewed, and tested all AI outputs before use
- [x] All AI instructions respect security, IP, and privacy rules

### Review

- [x] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [x] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [x] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [x] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [x] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
