### PR TITLE
Add DuckAssistBot support to BotTracking

### DIFF
--- a/plugins/BotTracking/BotDetector.php
+++ b/plugins/BotTracking/BotDetector.php
@@ -6,6 +6,7 @@
  * @link    https://matomo.org
  * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
+
 declare(strict_types=1);
 
 namespace Piwik\Plugins\BotTracking;

--- a/plugins/BotTracking/BotDetector.php
+++ b/plugins/BotTracking/BotDetector.php
@@ -6,7 +6,6 @@
  * @link    https://matomo.org
  * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
-
 declare(strict_types=1);
 
 namespace Piwik\Plugins\BotTracking;
@@ -32,6 +31,7 @@ class BotDetector
         'Gemini-Deep-Research'  => self::BOT_TYPE_AI_CHATBOT,
         'Claude-User'           => self::BOT_TYPE_AI_CHATBOT,
         'Perplexity-User'       => self::BOT_TYPE_AI_CHATBOT,
+        'DuckAssistBot'         => self::BOT_TYPE_AI_CHATBOT,
         'Google-GeminiNotebook' => self::BOT_TYPE_AI_CHATBOT,
         'Google-NotebookLM'     => self::BOT_TYPE_AI_CHATBOT,
     ];

--- a/plugins/BotTracking/tests/Integration/Tracker/BotRequestProcessorTest.php
+++ b/plugins/BotTracking/tests/Integration/Tracker/BotRequestProcessorTest.php
@@ -6,7 +6,6 @@
  * @link    https://matomo.org
  * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
-
 declare(strict_types=1);
 
 namespace Piwik\Plugins\BotTracking\tests\Integration\Tracker;
@@ -230,6 +229,7 @@ class BotRequestProcessorTest extends IntegrationTestCase
             ['Gemini-Deep-Research/1.0', 'Gemini-Deep-Research'],
             ['Claude-User/3.0', 'Claude-User'],
             ['Perplexity-User/1.0', 'Perplexity-User'],
+            ['DuckAssistBot/1.2', 'DuckAssistBot'],
             ['Google-NotebookLM/1.0', 'Google-NotebookLM'],
         ];
     }

--- a/plugins/BotTracking/tests/Integration/Tracker/BotRequestProcessorTest.php
+++ b/plugins/BotTracking/tests/Integration/Tracker/BotRequestProcessorTest.php
@@ -6,6 +6,7 @@
  * @link    https://matomo.org
  * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
+
 declare(strict_types=1);
 
 namespace Piwik\Plugins\BotTracking\tests\Integration\Tracker;


### PR DESCRIPTION
Solves #25023

### Description

Add support for `DuckAssistBot` in the BotTracking plugin.

https://duckduckgo.com/duckduckgo-help-pages/results/duckassistbot

This change:

- registers `DuckAssistBot` as an `ai_chatbot` in `BotDetector`
- adds `DuckAssistBot/1.2` to the existing BotTracking integration-test data provider
- verifies that the detected and stored bot name is `DuckAssistBot`

Requests submitted with `recMode=1` are processed only by the bot request pipeline. Without this pattern in `BotDetector`, DuckAssistBot requests are not stored in the BotTracking tables even when they are forwarded through the Tracking API.

No alias or additional processing logic is required.

### Testing

Integration-test coverage was added through `BotRequestProcessorTest::getBotUserAgents()`.

The full test suite was not run in this environment.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [x] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [x] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [x] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [x] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [x] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [x] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [x] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [x] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [x] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [x] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)