### PR TITLE
Require password confirmation to set trusted hosts via session auth

### DIFF
--- a/plugins/CoreAdminHome/API.php
+++ b/plugins/CoreAdminHome/API.php
@@ -28,6 +28,7 @@ use Piwik\Metrics\Formatter;
 use Piwik\Period\Factory;
 use Piwik\Piwik;
 use Piwik\Request as PiwikRequest;
+use Piwik\Request\AuthenticationToken;
 use Piwik\Segment;
 use Piwik\Scheduler\Scheduler;
 use Piwik\SettingsServer;
@@ -98,15 +99,24 @@ class API extends \Piwik\Plugin\API
 
     /**
      * @param string[] $trustedHosts
+     * @param string|null $passwordConfirmation Current user's password confirmation when required by session auth.
      * @return true
      * @internal
      */
-    public function setTrustedHosts($trustedHosts): bool
-    {
+    public function setTrustedHosts(
+        $trustedHosts,
+        #[\SensitiveParameter]
+        ?string $passwordConfirmation = null
+    ): bool {
         Piwik::checkUserHasSuperUserAccess();
 
         if (!Controller::isGeneralSettingsAdminEnabled()) {
             throw new Exception('General settings admin is not enabled');
+        }
+
+        // check password confirmation only when using session auth
+        if (StaticContainer::get(AuthenticationToken::class)->isSessionToken()) {
+            $this->confirmCurrentUserPassword($passwordConfirmation);
         }
 
         if (!empty($trustedHosts)) {

--- a/plugins/CoreAdminHome/tests/Integration/TrustedHostsApiTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/TrustedHostsApiTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreAdminHome\tests\Integration;
+
+use Piwik\Access;
+use Piwik\Auth;
+use Piwik\Container\StaticContainer;
+use Piwik\Plugins\CoreAdminHome\API;
+use Piwik\Request\AuthenticationToken;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group CoreAdminHome
+ * @group TrustedHostsApiTest
+ * @group API
+ * @group Plugins
+ */
+class TrustedHostsApiTest extends IntegrationTestCase
+{
+    /**
+     * @var API
+     */
+    private $api;
+
+    protected static function beforeTableDataCached()
+    {
+        parent::beforeTableDataCached();
+
+        Fixture::createSuperUser(false);
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->api = API::getInstance();
+
+        Access::getInstance()->setSuperUserAccess(false);
+        $auth = StaticContainer::get(Auth::class);
+        $auth->setLogin(Fixture::ADMIN_USER_LOGIN);
+        $auth->setPassword(Fixture::ADMIN_USER_PASSWORD);
+        Access::getInstance()->reloadAccess($auth);
+    }
+
+    public function tearDown(): void
+    {
+        $this->useTokenAuth();
+
+        parent::tearDown();
+    }
+
+    public function testSetTrustedHostsThrowsIfNoPasswordConfirmationGivenForSessionAuth()
+    {
+        $this->useSessionAuth();
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ConfirmWithReAuthentication');
+
+        $this->api->setTrustedHosts(['example.org']);
+    }
+
+    public function testSetTrustedHostsThrowsIfPasswordConfirmationWrongForSessionAuth()
+    {
+        $this->useSessionAuth();
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_CurrentPasswordNotCorrect');
+
+        $this->api->setTrustedHosts(['example.org'], 'wrongpassword');
+    }
+
+    public function testSetTrustedHostsAcceptsCorrectPasswordConfirmationForSessionAuth()
+    {
+        $this->useSessionAuth();
+
+        // an empty list of hosts is not saved, so this only verifies the password confirmation passes
+        self::assertTrue($this->api->setTrustedHosts([], Fixture::ADMIN_USER_PASSWORD));
+    }
+
+    public function testSetTrustedHostsDoesNotRequirePasswordConfirmationForTokenAuth()
+    {
+        $this->useTokenAuth();
+
+        self::assertTrue($this->api->setTrustedHosts([]));
+    }
+
+    private function useSessionAuth(): void
+    {
+        $_POST['token_auth'] = Fixture::getTokenAuth();
+        $_POST['force_api_session'] = 1;
+        StaticContainer::getContainer()->set(AuthenticationToken::class, new AuthenticationToken());
+    }
+
+    private function useTokenAuth(): void
+    {
+        unset($_POST['token_auth'], $_POST['force_api_session']);
+        StaticContainer::getContainer()->set(AuthenticationToken::class, new AuthenticationToken());
+    }
+}


### PR DESCRIPTION
Changing the trusted hosts on the General settings page already requires re-authentication, because it goes through `CorePluginsAdmin.setSystemSettings`. The `CoreAdminHome.setTrustedHosts` API method only checked super user access, so a session-authenticated request could change the value without confirming the password. It now asks for `passwordConfirmation` when the request uses session auth, following the same pattern as `UsersManager.addUser`. Requests authenticated with a real token auth are unaffected, so existing automation keeps working.

Added `TrustedHostsApiTest` covering the missing, wrong and correct password cases for session auth plus the token auth case.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules