### PR TITLE
Turn a brute force protection login block from an internal server to a client error (500 => 401)

### DIFF
--- a/plugins/Login/Login.php
+++ b/plugins/Login/Login.php
@@ -222,7 +222,8 @@ class Login extends \Piwik\Plugin
         }
 
         if (!$this->hasPerformedBruteForceCheck && !$bruteForce->isAllowedToLogin(IP::getIpFromHeader())) {
-            throw new Exception(Piwik::translate('Login_LoginNotAllowedBecauseBlocked'));
+            $ex = new NoAccessException(Piwik::translate('Login_LoginNotAllowedBecauseBlocked'), 401);
+            throw $ex;
         }
 
         // for performance reasons we make sure to execute it only once per request

--- a/plugins/Login/tests/Integration/CreateAppSpecificTokenAuthBruteForceTest.php
+++ b/plugins/Login/tests/Integration/CreateAppSpecificTokenAuthBruteForceTest.php
@@ -130,6 +130,19 @@ class CreateAppSpecificTokenAuthBruteForceTest extends IntegrationTestCase
         $this->assertNotSame('', $token);
     }
 
+    public function testBeforeLoginCheckBruteForceThrowsWhenIpAddressIsBlacklisted(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '10.55.55.55';
+        $this->settings->blacklistedBruteForceIps->setValue(array('10.55.55.55'));
+
+        $this->expectException(NoAccessException::class);
+        $this->expectExceptionMessage('Login_LoginNotAllowedBecauseBlocked');
+        $this->expectExceptionCode(401);
+
+        $plugin = new LoginPlugin();
+        $plugin->beforeLoginCheckBruteForce();
+    }
+
     public function testBeforeLoginCheckBruteForceThrowsWhenUserLoginIsBlockedUsingEmailInFormLogin(): void
     {
         $this->blockLogin($this->userLogin);


### PR DESCRIPTION
### Description

Previously, a login blocked by brute force protection raised an internal server error (HTTP 500). This PR changes the exception to a more specific class, and the response code to 401, while retaining the error message.

#### Implementation Rationale

An internal server error is indicative of a server-side processing issue. As such, the incidence of 5XX response codes is often used to judge server health. Large counts of 5XX responses may result in automated alerts or instance replacements. They may also lead to aborted red/black deployments.

By contrast, (assuming correct configuration, ) a login blocked by brute force protection is not a server-side issue. It is a client-side issue. It arose due to client behavior, and it can only be "fixed" by the client: The client has to wait, and then re-attempt the login.

The server should thus respond with a 4XX HTTP status code, not with a 5XX status code.

From the limited set of standardized HTTP status codes, "401 Unauthorized" best conveys the meaning of the block. A "403 Forbidden" response would instead indicate that a login succeeded but the authenticated user was not allowed to access a specific resource. A "429 Too Many Requests" might be appropriate for the login attempts themselves but would be ambiguous for requests to other resources.

#### Pain Point / Dog Fooding

We experienced a large percentage of internal server errors due to a dashboard containing a real-time visitor count widget remaining open while brute force protection was triggered separately (i.e. in a separate browser, tab, or even client). The widget kept sending `/index.php?date=…&module=API&format=json&method=Live.getCounters&showColumns=visits%2Cvisitors%2Cactions&lastMinutes=3&idSite=…&period=…` requests with great frequency which all raised 500s. This led to our service health showing as degraded even though it was actually fully operational and running error-free.

#### Prior Art

See https://github.com/matomo-org/matomo/issues/19774 / https://github.com/matomo-org/matomo/pull/21293 for a prior changeset for a similar issue.

#### Test Strategy Rationale

This specific code path seem to have been untested previously. Two public `Login` functions can trigger this exception: `beforeLoginCheckBruteForce` and `beforeCreateAppSpecificTokenAuthCheckBruteForce`. I found that only `CreateAppSpecificTokenAuthBruteForceTest` seems to test the sibling `Login_LoginNotAllowedBecauseUserLoginBlocked` error and have thus extended that test suite to test `Login_LoginNotAllowedBecauseBlocked` accordingly.

#### Backport Potential

The commit can cleanly be cherry-picked into `5.x-dev` and I think it would be a good candidate for backporting.

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

(No AI was involved in creating this PR or making the changes presented herein.)

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
