### PR TITLE
Show percentages on the subpages of a searched report

### DIFF
--- a/plugins/CoreHome/templates/_dataTableCell.twig
+++ b/plugins/CoreHome/templates/_dataTableCell.twig
@@ -7,7 +7,8 @@
        href='{% if row.getMetadata('url')|slice(0,4) not in ['http','ftp:'] %}http://{% endif %}{{ row.getMetadata('url')|rawSafeDecoded }}'>
 {% endif %}
 
-{% set totals = dataTable.getMetadata('totals') %}
+{#- an embedded subtable has no totals of its own, so it relates its rows to the report totals -#}
+{% set totals = dataTable.getMetadata('totals')|default(reportTotals|default) %}
 {% set labelColumn   = columns_to_display|first %}
 {% set reportLabel   = row.getColumn(labelColumn)|truncate(40)|rawSafeDecoded %}
 {#- the totals row is not part of the report rows, so its percentage would always be 100% -#}

--- a/plugins/CoreHome/tests/UI/DataTable_spec.js
+++ b/plugins/CoreHome/tests/UI/DataTable_spec.js
@@ -375,6 +375,37 @@ describe('DataTable', function () {
     expect(subtableCell.hover).to.match(/^[\d,.]+$/);
   });
 
+  it('should show percentages on the subpages of a recursively searched hierarchical report', async function () {
+    // a recursive search keeps the page hierarchy and embeds the matching subpages into the report,
+    // instead of loading them through a request of their own like expanding a row does
+    const searchedUrl = "?module=Widgetize&action=iframe&moduleToWidgetize=Actions"
+      + "&actionToWidgetize=getPageUrls&idSite=1&period=year&date=2012-08-09&viewDataTable=table"
+      + "&flat=0&filter_column_recursive=label&filter_pattern_recursive=one.html"
+      + "&show_percentage_values=1";
+
+    await page.goto(searchedUrl);
+    await page.waitForNetworkIdle();
+    await page.waitForSelector('tbody tr.level1', { visible: true });
+
+    const rows = await page.evaluate(() => ['level0', 'level1']
+      .map((levelClass) => {
+        const row = document.querySelector(`tbody tr.${levelClass}`);
+        // the first metric column is nb_hits, one of the columns a report total is calculated for
+        const cell = row.querySelector('td.column');
+
+        return {
+          label: row.querySelector('td.label span.value').textContent.trim(),
+          value: cell.querySelector('span.value').textContent.trim(),
+          hover: cell.querySelector('span.ratio').textContent.trim(),
+        };
+      }));
+
+    // the searched page and the subpage it matched both relate to the pageviews of the whole report,
+    // 556, so their percentages stay comparable, and both keep their absolute value on hover
+    expect(rows[0]).to.deep.equal({ label: 'page', value: '4.5%', hover: '25' });
+    expect(rows[1]).to.deep.equal({ label: '/one.html', value: '4%', hover: '22' });
+  });
+
   it('should show percentages on comparison rows as well as on their parent row', async function () {
     const comparingUrl = "?module=Widgetize&action=iframe&moduleToWidgetize=Referrers"
       + "&actionToWidgetize=getWebsites&idSite=1&period=year&date=2012-01-12&viewDataTable=table"

--- a/plugins/CoreVisualizations/Visualizations/HtmlTable.php
+++ b/plugins/CoreVisualizations/Visualizations/HtmlTable.php
@@ -91,8 +91,7 @@ class HtmlTable extends Visualization
         }
 
         if ($this->dataTable->getRowsCount()) {
-            $siteTotalRow = $this->getSiteSummary() ? $this->getSiteSummary()->getFirstRow() : null;
-            $this->assignTemplateVar('siteTotalRow', $siteTotalRow);
+            $this->assignTemplateVar('siteTotalRow', $this->getSiteTotalRow());
         }
 
         if ($this->isPivoted()) {
@@ -329,14 +328,11 @@ class HtmlTable extends Visualization
 
         $totals = $this->dataTable->getMetadata('totalsUnformatted');
 
-        $siteSummary = $this->getSiteSummary();
-        $siteTotalRow = $siteSummary ? ($siteSummary->getFirstRow() ?: null) : null;
-
         $this->setRowPercentagesRecursively(
             $this->dataTable,
             $this->report->getMetrics(),
             $totals,
-            $siteTotalRow,
+            $this->getSiteTotalRow(),
             $columnNamesToIndices,
             $formatter
         );
@@ -349,9 +345,12 @@ class HtmlTable extends Visualization
      * The rows of an embedded subtable relate to the total of the whole report, just like the parent
      * row they belong to, and like the rows of a subtable that is opened by clicking a row.
      *
+     * Recurses over getRows() rather than through DataTable::filterSubtables(), which skips the
+     * summary row, because the table renders the subtable of a summary row like any other.
+     *
      * @param array<string, string> $metrics The metrics of the report, indexed by column name.
      * @param array<string, mixed>|false $totals The unformatted report totals, indexed by column name.
-     * @param array<string, int> $columnNamesToIndices
+     * @param array<string, int> $columnNamesToIndices The ID of each metric that has one, indexed by column name.
      */
     private function setRowPercentagesRecursively(
         DataTable $table,
@@ -426,6 +425,16 @@ class HtmlTable extends Visualization
     protected function shouldShowDimensions()
     {
         return $this->requestConfig->show_dimensions || Common::getRequestVar('show_dimensions', '');
+    }
+
+    /**
+     * Returns the row holding the totals of the whole site, which not every site summary has.
+     */
+    private function getSiteTotalRow(): ?Row
+    {
+        $siteSummary = $this->getSiteSummary();
+
+        return $siteSummary ? ($siteSummary->getFirstRow() ?: null) : null;
     }
 
     private function getSiteSummary()

--- a/plugins/CoreVisualizations/Visualizations/HtmlTable.php
+++ b/plugins/CoreVisualizations/Visualizations/HtmlTable.php
@@ -160,6 +160,10 @@ class HtmlTable extends Visualization
 
         $this->assignFilteredTotalsRowVars();
 
+        // a subtable a recursive search embedded has no totals of its own, so the report totals stay
+        // available to the rows of every hierarchy level the table renders
+        $this->assignTemplateVar('reportTotals', $this->dataTable->getMetadata('totals'));
+
         // Note: This needs to be done last, as it depends on the final columns to display
         $this->config->report_supports_percentage_values = $this->supportsPercentageValues();
     }
@@ -326,10 +330,39 @@ class HtmlTable extends Visualization
         $totals = $this->dataTable->getMetadata('totalsUnformatted');
 
         $siteSummary = $this->getSiteSummary();
-        $siteTotalRow = $siteSummary ? $siteSummary->getFirstRow() : null;
+        $siteTotalRow = $siteSummary ? ($siteSummary->getFirstRow() ?: null) : null;
 
-        foreach ($this->dataTable->getRows() as $row) {
-            foreach ($this->report->getMetrics() as $column => $translation) {
+        $this->setRowPercentagesRecursively(
+            $this->dataTable,
+            $this->report->getMetrics(),
+            $totals,
+            $siteTotalRow,
+            $columnNamesToIndices,
+            $formatter
+        );
+    }
+
+    /**
+     * Sets the percentage metadata of every row of a table, and of the subtables a recursive search
+     * embedded into it, so a searched report shows percentages at each of its hierarchy levels.
+     *
+     * The rows of an embedded subtable relate to the total of the whole report, just like the parent
+     * row they belong to, and like the rows of a subtable that is opened by clicking a row.
+     *
+     * @param array<string, string> $metrics The metrics of the report, indexed by column name.
+     * @param array<string, mixed>|false $totals The unformatted report totals, indexed by column name.
+     * @param array<string, int> $columnNamesToIndices
+     */
+    private function setRowPercentagesRecursively(
+        DataTable $table,
+        array $metrics,
+        $totals,
+        ?Row $siteTotalRow,
+        array $columnNamesToIndices,
+        NumberFormatter $formatter
+    ): void {
+        foreach ($table->getRows() as $row) {
+            foreach ($metrics as $column => $translation) {
                 // Try to check the column by it's index (not possible for all metrics, like custom columns)
                 $indexColumn = !empty($columnNamesToIndices[$column]) ? $columnNamesToIndices[$column] : null;
 
@@ -355,6 +388,11 @@ class HtmlTable extends Visualization
                         $row->setMetadata($siteTotalPercentage, $rowPercentage);
                     }
                 }
+            }
+
+            $subtable = $row->getSubtable();
+            if ($subtable) {
+                $this->setRowPercentagesRecursively($subtable, $metrics, $totals, $siteTotalRow, $columnNamesToIndices, $formatter);
             }
         }
     }


### PR DESCRIPTION
### Description

Fixes DEV-20657.

With **Show percentages** enabled, searching a hierarchical report showed the matching subpages as absolute values while their parent row showed a percentage.

A recursive search embeds the matching subpages into the report instead of loading them through a request of their own the way expanding a row does. Those embedded rows got no percentage metadata, and the cell found no report totals on the subtable it was rendering, so they fell back to the absolute value.

Subpages now use the same denominator as their parent row — the total of the whole report, as a subtable opened by clicking already does — and keep their absolute value on hover.

### How to test

1. Go to **Behaviour > Pages** on a site with nested pages.
2. Open the cog menu below the table and enable **Show percentages**.
3. Search the table for a term that matches a **subpage**, not a top-level page.
4. Check that the parent row **and** the subpage rows under it all show a percentage, and that hovering a cell shows the absolute value.
5. Hover a parent cell and a subpage cell — both tooltips should quote the same report total.

Before this change, step 4 showed a percentage on the parent row only; subpage rows showed a plain number with no hover value at all.

Worth a quick check that percentages still behave when expanding a row by clicking it, and on a comparison, since both share this code path.

### Tests

New UI test in `plugins/CoreHome/tests/UI/DataTable_spec.js`, alongside the existing percentage tests:

```
ddev matomo:console tests:run-ui DataTable
```
Checklist
[✔] I have understood, reviewed, and tested all AI outputs before use
[✔] All AI instructions respect security, IP, and privacy rules