### PR TITLE
Harden database setup value handling

### DIFF
--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -718,9 +718,14 @@ class Mysql implements SchemaInterface
      */
     public function getDefaultCollationForCharset(string $charset): string
     {
-        $result = $this->getDb()->fetchRow('SHOW CHARACTER SET WHERE `Charset` = ?', [$charset]);
+        if (!DbHelper::isValidCharset($charset)) {
+            return '';
+        }
 
-        return $result['Default collation'] ?? '';
+        $result = $this->getDb()->fetchRow('SHOW CHARACTER SET WHERE `Charset` = ?', [$charset]);
+        $collation = $result['Default collation'] ?? '';
+
+        return DbHelper::isValidCollation($collation) ? $collation : '';
     }
 
     public function getDefaultPort(): int

--- a/core/DbHelper.php
+++ b/core/DbHelper.php
@@ -250,6 +250,27 @@ class DbHelper
     }
 
     /**
+     * @internal
+     */
+    public static function isValidCharset(string $charset): bool
+    {
+        return self::isValidDatabaseEncodingName($charset);
+    }
+
+    /**
+     * @internal
+     */
+    public static function isValidCollation(string $collation): bool
+    {
+        return self::isValidDatabaseEncodingName($collation);
+    }
+
+    private static function isValidDatabaseEncodingName(string $name): bool
+    {
+        return preg_match('/^[a-zA-Z][a-zA-Z0-9_]{0,63}$/D', $name) === 1;
+    }
+
+    /**
      * Returns sql queries to convert all installed tables to utf8mb4
      *
      * @return array

--- a/core/Updates/5.2.0-b2.php
+++ b/core/Updates/5.2.0-b2.php
@@ -14,6 +14,7 @@ use Piwik\Config;
 use Piwik\Container\StaticContainer;
 use Piwik\DataAccess\ArchiveTableCreator;
 use Piwik\Db;
+use Piwik\DbHelper;
 use Piwik\Updater;
 use Piwik\Updater\Migration\Factory as MigrationFactory;
 use Piwik\Updates;
@@ -69,6 +70,10 @@ class Updates_5_2_0_b2 extends Updates
             }
 
             $userTableCollation = $userTableStatus['Collation'];
+            if (!is_string($userTableCollation) || !DbHelper::isValidCollation($userTableCollation)) {
+                return null;
+            }
+
             $connectionCollation = $db->fetchOne('SELECT @@collation_connection');
 
             if ($userTableCollation === $connectionCollation) {

--- a/plugins/CoreUpdater/Commands/ConvertToUtf8mb4.php
+++ b/plugins/CoreUpdater/Commands/ConvertToUtf8mb4.php
@@ -160,6 +160,9 @@ class ConvertToUtf8mb4 extends ConsoleCommand
                 return null;
             }
             $userTableCollation = $userTableStatus['Collation'];
+            if (!is_string($userTableCollation) || !DbHelper::isValidCollation($userTableCollation)) {
+                return null;
+            }
 
             $archiveTable = ArchiveTableCreator::getLatestArchiveTableInstalled(ArchiveTableCreator::NUMERIC_TABLE);
             if (null === $archiveTable) {

--- a/plugins/Installation/FormDatabaseSetup.php
+++ b/plugins/Installation/FormDatabaseSetup.php
@@ -13,7 +13,6 @@ use Exception;
 use HTML_QuickForm2_DataSource_Array;
 use HTML_QuickForm2_Factory;
 use HTML_QuickForm2_Rule;
-use Piwik\Config;
 use Piwik\Db;
 use Piwik\Db\Adapter;
 use Piwik\DbHelper;
@@ -91,13 +90,8 @@ class FormDatabaseSetup extends QuickForm2
 
         $this->addElement('submit', 'submit', array('value' => Piwik::translate('General_Next') . ' »', 'class' => 'btn'));
 
-        $defaultDatabaseType = Config::getInstance()->database['type'];
-        $this->addElement( 'hidden', 'type')->setLabel('Database engine');
-
-
         $defaults = array(
             'host'          => '127.0.0.1',
-            'type'          => $defaultDatabaseType,
             'tables_prefix' => 'matomo_',
             'schema'        => 'Mysql',
             'port'          => '3306',
@@ -168,7 +162,7 @@ class FormDatabaseSetup extends QuickForm2
             'adapter'       => $adapter,
             'port'          => Db\Schema::getDefaultPortForSchema($schema),
             'schema'        => $schema,
-            'type'          => $this->getSubmitValue('type'),
+            'type'          => 'InnoDB',
             'enable_ssl'    => false
         );
 

--- a/tests/PHPUnit/Integration/DbHelperTest.php
+++ b/tests/PHPUnit/Integration/DbHelperTest.php
@@ -135,6 +135,11 @@ class DbHelperTest extends IntegrationTestCase
         self::assertSame('', DbHelper::getDefaultCollationForCharset('invalid'));
     }
 
+    public function testGetDefaultCollationForInvalidCharsetName(): void
+    {
+        self::assertSame('', DbHelper::getDefaultCollationForCharset("utf8mb4'"));
+    }
+
     private function assertDbExists($dbName)
     {
         $dbs = Db::fetchAll("SHOW DATABASES");

--- a/tests/PHPUnit/Unit/DbHelperTest.php
+++ b/tests/PHPUnit/Unit/DbHelperTest.php
@@ -148,6 +148,33 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @dataProvider getDatabaseEncodingNameTestData
+     */
+    public function testDatabaseEncodingNameValidation(string $name, bool $expected): void
+    {
+        self::assertSame($expected, DbHelper::isValidCharset($name));
+        self::assertSame($expected, DbHelper::isValidCollation($name));
+    }
+
+    public function getDatabaseEncodingNameTestData(): iterable
+    {
+        yield 'charset' => ['utf8mb4', true];
+        yield 'collation' => ['utf8mb4_0900_ai_ci', true];
+        yield 'MariaDB collation' => ['uca1400_ai_ci', true];
+        yield 'uppercase' => ['UTF8MB4_GENERAL_CI', true];
+        yield 'maximum length' => ['a' . str_repeat('_', 63), true];
+        yield 'empty' => ['', false];
+        yield 'starts with a number' => ['8bit', false];
+        yield 'starts with an underscore' => ['_utf8mb4', false];
+        yield 'too long' => ['a' . str_repeat('_', 64), false];
+        yield 'contains whitespace' => ['utf8mb4 general ci', false];
+        yield 'contains a quote' => ["utf8mb4_general_ci'", false];
+        yield 'contains a semicolon' => ['utf8mb4_general_ci;', false];
+        yield 'contains a backtick' => ['utf8mb4_general_ci`', false];
+        yield 'contains a null byte' => ["utf8mb4_general_ci\0", false];
+    }
+
+    /**
      * @dataProvider getMaxExecutionTimeTestData
      */
     public function testAddMaxExecutionTimeHintToQuery($expected, $query, $timeLimit, $schema): void


### PR DESCRIPTION
Security hardening for database setup: validates detected charset and collation names, and uses InnoDB directly for new installations. Invalid detected encoding names are ignored. Includes coverage for encoding validation.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules