### PR TITLE
Use the report's site id for the referrer anonymisation notice

### DIFF
--- a/plugins/PrivacyManager/DataRounding.php
+++ b/plugins/PrivacyManager/DataRounding.php
@@ -636,9 +636,6 @@ class DataRounding
         try {
             $requestObject = new Request($request);
             $idSite = $requestObject->getParameter('idSite', null);
-            if (is_null($idSite)) {
-                $idSite = $requestObject->getParameter('idsite', null);
-            }
 
             if (!is_array($idSite) && !is_scalar($idSite)) {
                 return [];

--- a/plugins/PrivacyManager/PrivacyManager.php
+++ b/plugins/PrivacyManager/PrivacyManager.php
@@ -207,7 +207,7 @@ class PrivacyManager extends Plugin
     public function onConfigureVisualisation(Plugin\Visualization $view)
     {
         $roundingRequest = [
-            'idSite' => $view->requestConfig->getRequestParam('idSite') ?: $view->requestConfig->getRequestParam('idsite'),
+            'idSite' => $view->requestConfig->getRequestParam('idSite'),
             'segment' => $view->requestConfig->getRequestParam('segment'),
         ];
 
@@ -222,7 +222,7 @@ class PrivacyManager extends Plugin
         }
 
         if ($view->requestConfig->getApiModuleToRequest() === 'Referrers' && !$view->requestConfig->idSubtable) {
-            $idSite = $view->requestConfig->getRequestParam('idsite');
+            $idSite = $view->requestConfig->getRequestParam('idSite');
             if (!is_numeric($idSite) || !$idSite) {
                 $idSite = null;
             } else {

--- a/plugins/PrivacyManager/tests/Integration/ReferrerAnonymisationNoticeTest.php
+++ b/plugins/PrivacyManager/tests/Integration/ReferrerAnonymisationNoticeTest.php
@@ -7,7 +7,7 @@
  * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Plugins\PrivacyManager\tests\Integration\Visualizations;
+namespace Piwik\Plugins\PrivacyManager\tests\Integration;
 
 use Piwik\DataTable;
 use Piwik\Piwik;
@@ -21,6 +21,7 @@ use Piwik\ViewDataTable\Factory as ViewDataTableFactory;
 
 /**
  * @group PrivacyManager
+ * @group Plugins
  */
 class ReferrerAnonymisationNoticeTest extends IntegrationTestCase
 {
@@ -68,10 +69,6 @@ class ReferrerAnonymisationNoticeTest extends IntegrationTestCase
         $view = $this->buildReferrersView();
         (new PrivacyManager())->onConfigureVisualisation($view);
 
-        self::assertStringNotContainsString(
-            $this->notice(ReferrerAnonymizer::EXCLUDE_ALL),
-            (string) $view->config->show_footer_message
-        );
         self::assertSame('', (string) $view->config->show_footer_message);
     }
 
@@ -96,20 +93,16 @@ class ReferrerAnonymisationNoticeTest extends IntegrationTestCase
         self::assertSame('', (string) $view->config->show_footer_message);
     }
 
-    public function testNoticeHandlesMultiSiteRequests(): void
+    public function testNoticeIgnoresSiteSpecificConfigurationForMultiSiteRequests(): void
     {
-        $this->setAnonymisation(ReferrerAnonymizer::EXCLUDE_PATH, null);
-
-        $view = $this->buildReferrersView();
+        $this->setAnonymisation(ReferrerAnonymizer::EXCLUDE_ALL, 1);
 
         $_GET['idSite'] = 'all';
 
+        $view = $this->buildReferrersView();
         (new PrivacyManager())->onConfigureVisualisation($view);
 
-        self::assertStringContainsString(
-            $this->notice(ReferrerAnonymizer::EXCLUDE_PATH),
-            (string) $view->config->show_footer_message
-        );
+        self::assertSame('', (string) $view->config->show_footer_message);
     }
 
     private function setAnonymisation(string $option, ?int $idSite): void

--- a/plugins/PrivacyManager/tests/Integration/Visualizations/ReferrerAnonymisationNoticeTest.php
+++ b/plugins/PrivacyManager/tests/Integration/Visualizations/ReferrerAnonymisationNoticeTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\PrivacyManager\tests\Integration\Visualizations;
+
+use Piwik\DataTable;
+use Piwik\Piwik;
+use Piwik\Plugin\Visualization;
+use Piwik\Plugins\PrivacyManager\Config as PrivacyManagerConfig;
+use Piwik\Plugins\PrivacyManager\PrivacyManager;
+use Piwik\Plugins\PrivacyManager\ReferrerAnonymizer;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\ViewDataTable\Factory as ViewDataTableFactory;
+
+/**
+ * @group PrivacyManager
+ */
+class ReferrerAnonymisationNoticeTest extends IntegrationTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Fixture::createWebsite('2024-01-01 00:00:00');
+        Fixture::createWebsite('2024-01-01 00:00:00');
+
+        $_GET['idSite'] = '1';
+        $_GET['date']   = '2024-01-01';
+        $_GET['period'] = 'day';
+    }
+
+    public function tearDown(): void
+    {
+        unset($_GET['idSite'], $_GET['idsite'], $_GET['date'], $_GET['period']);
+
+        parent::tearDown();
+    }
+
+    public function testNoticeUsesSiteSpecificConfiguration(): void
+    {
+        $this->setAnonymisation(ReferrerAnonymizer::EXCLUDE_ALL, 2);
+
+        $_GET['idSite'] = '2';
+
+        $view = $this->buildReferrersView();
+        (new PrivacyManager())->onConfigureVisualisation($view);
+
+        self::assertStringContainsString(
+            $this->notice(ReferrerAnonymizer::EXCLUDE_ALL),
+            (string) $view->config->show_footer_message
+        );
+    }
+
+    public function testNoticeIgnoresUnrelatedRequestParameters(): void
+    {
+        $this->setAnonymisation(ReferrerAnonymizer::EXCLUDE_ALL, 2);
+
+        $_GET['idSite'] = '1';
+        $_GET['idsite'] = '2';
+
+        $view = $this->buildReferrersView();
+        (new PrivacyManager())->onConfigureVisualisation($view);
+
+        self::assertStringNotContainsString(
+            $this->notice(ReferrerAnonymizer::EXCLUDE_ALL),
+            (string) $view->config->show_footer_message
+        );
+        self::assertSame('', (string) $view->config->show_footer_message);
+    }
+
+    public function testNoticeFallsBackToGlobalConfiguration(): void
+    {
+        $this->setAnonymisation(ReferrerAnonymizer::EXCLUDE_QUERY, null);
+
+        $view = $this->buildReferrersView();
+        (new PrivacyManager())->onConfigureVisualisation($view);
+
+        self::assertStringContainsString(
+            $this->notice(ReferrerAnonymizer::EXCLUDE_QUERY),
+            (string) $view->config->show_footer_message
+        );
+    }
+
+    public function testNoticeNotShownWhenAnonymisationDisabled(): void
+    {
+        $view = $this->buildReferrersView();
+        (new PrivacyManager())->onConfigureVisualisation($view);
+
+        self::assertSame('', (string) $view->config->show_footer_message);
+    }
+
+    public function testNoticeHandlesMultiSiteRequests(): void
+    {
+        $this->setAnonymisation(ReferrerAnonymizer::EXCLUDE_PATH, null);
+
+        $view = $this->buildReferrersView();
+
+        $_GET['idSite'] = 'all';
+
+        (new PrivacyManager())->onConfigureVisualisation($view);
+
+        self::assertStringContainsString(
+            $this->notice(ReferrerAnonymizer::EXCLUDE_PATH),
+            (string) $view->config->show_footer_message
+        );
+    }
+
+    private function setAnonymisation(string $option, ?int $idSite): void
+    {
+        $config = new PrivacyManagerConfig($idSite);
+        $config->anonymizeReferrer = $option;
+    }
+
+    private function notice(string $option): string
+    {
+        return Piwik::translate(
+            'PrivacyManager_InfoSomeReferrerInfoMayBeAnonymized',
+            ReferrerAnonymizer::getAvailableAnonymizationOptions()[$option]
+        );
+    }
+
+    private function buildReferrersView(): Visualization
+    {
+        /** @var Visualization $view */
+        $view = ViewDataTableFactory::build(
+            'table',
+            'Referrers.getWebsites',
+            $controllerAction = 'Referrers.getWebsites',
+            $forceDefault = false,
+            $loadViewDataTableParametersForUser = false
+        );
+        $view->setDataTable(new DataTable());
+
+        // guards against a future change to the factory silently turning every case below into a no-op
+        self::assertSame('Referrers', $view->requestConfig->getApiModuleToRequest());
+
+        return $view;
+    }
+}

--- a/plugins/PrivacyManager/tests/Unit/DataRoundingTest.php
+++ b/plugins/PrivacyManager/tests/Unit/DataRoundingTest.php
@@ -689,6 +689,15 @@ class DataRoundingTest extends \PHPUnit\Framework\TestCase
         $this->assertSame([], $actual);
     }
 
+    public function testExtractRequestedSiteIdsRequiresTheExactIdSiteParameterName(): void
+    {
+        $actual = $this->invokeDataRoundingMethod('extractRequestedSiteIds', [[
+            'idsite' => '3',
+        ]]);
+
+        $this->assertSame([], $actual);
+    }
+
     public function testExtractRequestedSiteIdsReturnsEmptyForBoolean(): void
     {
         $actual = $this->invokeDataRoundingMethod('extractRequestedSiteIds', [[


### PR DESCRIPTION
### Description

The referrer anonymisation notice on Referrers reports showed the global anonymisation setting instead of the one configured for the site being viewed. It now uses the report's site id, and two unused parameter fallbacks are removed.

### Checklist
[✔] I have understood, reviewed, and tested all AI outputs before use
[✔] All AI instructions respect security, IP, and privacy rules
