### PR TITLE
Keep XML responses well formed when report data cannot be an XML name

### DIFF
--- a/core/DataTable/Renderer.php
+++ b/core/DataTable/Renderer.php
@@ -183,6 +183,13 @@ abstract class Renderer extends BaseFactory
      */
     public static function formatValueXml($value)
     {
+        if (is_string($value)) {
+            // XML cannot hold these characters and has no character reference for them, so a value
+            // holding one can only be rendered without it. Done for every string, as `is_numeric()`
+            // accepts surrounding whitespace and so is true for a numeric string holding one too
+            $value = preg_replace('/[\x00-\x08\x0b\x0c\x0e-\x1f]/', '', $value);
+        }
+
         if (
             is_string($value)
             && !is_numeric($value)

--- a/core/DataTable/Renderer/Xml.php
+++ b/core/DataTable/Renderer/Xml.php
@@ -134,7 +134,7 @@ class Xml extends Renderer
 
                     $prefix = "<row $attribute>";
                     $suffix = "</row>";
-                    $emptyNode = "<row $attribute>";
+                    $emptyNode = "<row $attribute/>";
                 } elseif (!self::isValidXmlTagName($key)) {
                     $attribute = 'key="' . self::formatAttributeValueXml($key) . '"';
 
@@ -443,10 +443,18 @@ class Xml extends Renderer
     /**
      * Escapes a value so it can be used as an XML attribute value, no matter whether the attribute
      * is quoted with double or single quotes.
+     *
+     * @param string|int $value
      */
     private static function formatAttributeValueXml($value): string
     {
-        return str_replace("'", '&#039;', (string) self::formatValueXml($value));
+        $value = (string) self::formatValueXml($value);
+
+        // legal in XML, but normalised to a space on parse unless encoded
+        $value = str_replace(["'", "\t", "\n", "\r"], ['&#039;', '&#9;', '&#10;', '&#13;'], $value);
+
+        // no character reference exists for these
+        return preg_replace('/[\x00-\x08\x0b\x0c\x0e-\x1f]/', '', $value);
     }
 
     /**

--- a/core/DataTable/Renderer/Xml.php
+++ b/core/DataTable/Renderer/Xml.php
@@ -444,17 +444,15 @@ class Xml extends Renderer
      * Escapes a value so it can be used as an XML attribute value, no matter whether the attribute
      * is quoted with double or single quotes.
      *
-     * @param string|int $value
+     * @param scalar $value
      */
     private static function formatAttributeValueXml($value): string
     {
         $value = (string) self::formatValueXml($value);
 
-        // legal in XML, but normalised to a space on parse unless encoded
-        $value = str_replace(["'", "\t", "\n", "\r"], ['&#039;', '&#9;', '&#10;', '&#13;'], $value);
-
-        // no character reference exists for these
-        return preg_replace('/[\x00-\x08\x0b\x0c\x0e-\x1f]/', '', $value);
+        // legal in XML, but normalised to a space on parse unless encoded. the characters XML
+        // cannot hold at all are already dropped by formatValueXml()
+        return str_replace(["'", "\t", "\n", "\r"], ['&#039;', '&#9;', '&#10;', '&#13;'], $value);
     }
 
     /**

--- a/core/DataTable/Renderer/Xml.php
+++ b/core/DataTable/Renderer/Xml.php
@@ -126,16 +126,21 @@ class Xml extends Renderer
         foreach ($array as $key => $value) {
             // based on the type of array & the key, determine how this node will look
             if ($isAssociativeArray) {
-                if (strpos($key, '=') !== false) {
-                    [$keyAttributeName, $key] = explode('=', $key, 2);
+                // a key like `idgoal=1` is rendered as a row attribute for backwards compatibility,
+                // but only when the part in front of the `=` can be used as an attribute name
+                if (strpos($key, '=') !== false && self::isValidXmlTagName(strstr($key, '=', true))) {
+                    [$keyAttributeName, $keyAttributeValue] = explode('=', $key, 2);
+                    $attribute = $keyAttributeName . '="' . self::formatAttributeValueXml($keyAttributeValue) . '"';
 
-                    $prefix = "<row $keyAttributeName=\"$key\">";
+                    $prefix = "<row $attribute>";
                     $suffix = "</row>";
-                    $emptyNode = "<row $keyAttributeName=\"$key\">";
+                    $emptyNode = "<row $attribute>";
                 } elseif (!self::isValidXmlTagName($key)) {
-                    $prefix = "<row key=\"$key\">";
+                    $attribute = 'key="' . self::formatAttributeValueXml($key) . '"';
+
+                    $prefix = "<row $attribute>";
                     $suffix = "</row>";
-                    $emptyNode = "<row key=\"$key\"/>";
+                    $emptyNode = "<row $attribute/>";
                 } else {
                     $prefix = "<$key>";
                     $suffix = "</$key>";
@@ -192,6 +197,8 @@ class Xml extends Renderer
      */
     protected function renderDataTableMap(Map $table, array $array, string $prefixLines = ''): string
     {
+        $nameDescriptionAttribute = self::getKeyNameForXml($table);
+
         // CASE 1
         //array
         //  'day1' => string '14' (length=2)
@@ -199,23 +206,22 @@ class Xml extends Renderer
         $firstTable = current($array);
         if (!is_array($firstTable)) {
             $xml = '';
-            $nameDescriptionAttribute = $table->getKeyName();
             foreach ($array as $valueAttribute => $value) {
                 if (empty($value)) {
-                    $xml .= $prefixLines . "\t<result $nameDescriptionAttribute=\"$valueAttribute\" />\n";
+                    $xml .= $prefixLines . "\t<result $nameDescriptionAttribute=\"" . self::formatAttributeValueXml($valueAttribute) . "\" />\n";
                 } elseif ($value instanceof DataTable\DataTableInterface) {
                     //TODO somehow this code is not tested, cover this case
                     $out = $this->renderTable($value, true);
-                    $xml .= "\t<result $nameDescriptionAttribute=\"$valueAttribute\">\n$out</result>\n";
+                    $xml .= "\t<result $nameDescriptionAttribute=\"" . self::formatAttributeValueXml($valueAttribute) . "\">\n$out</result>\n";
                 } elseif (is_array($value)) {
                     if (!is_array(reset($value))) {
                         $out = $this->renderDataTableSimple($value);
                     } else {
                         $out = $this->renderDataTable($value);
                     }
-                    $xml .= "\t<result $nameDescriptionAttribute=\"$valueAttribute\">\n$out</result>\n";
+                    $xml .= "\t<result $nameDescriptionAttribute=\"" . self::formatAttributeValueXml($valueAttribute) . "\">\n$out</result>\n";
                 } else {
-                    $xml .= $prefixLines . "\t<result $nameDescriptionAttribute=\"$valueAttribute\">" . self::formatValueXml($value) . "</result>\n";
+                    $xml .= $prefixLines . "\t<result $nameDescriptionAttribute=\"" . self::formatAttributeValueXml($valueAttribute) . "\">" . self::formatValueXml($value) . "</result>\n";
                 }
             }
             return $xml;
@@ -236,10 +242,9 @@ class Xml extends Renderer
         //      'nb_visits' => string '11'
         if ($firstTable instanceof Simple) {
             $xml = '';
-            $nameDescriptionAttribute = $table->getKeyName();
             foreach ($array as $valueAttribute => $dataTableSimple) {
                 if (count($dataTableSimple) == 0) {
-                    $xml .= $prefixLines . "\t<result $nameDescriptionAttribute=\"$valueAttribute\" />\n";
+                    $xml .= $prefixLines . "\t<result $nameDescriptionAttribute=\"" . self::formatAttributeValueXml($valueAttribute) . "\" />\n";
                 } else {
                     if (is_array($dataTableSimple)) {
                         if (!is_array(reset($dataTableSimple))) {
@@ -248,7 +253,7 @@ class Xml extends Renderer
                             $dataTableSimple = "\n" . $this->renderDataTable($dataTableSimple, $prefixLines . "\t") . $prefixLines . "\t";
                         }
                     }
-                    $xml .= $prefixLines . "\t<result $nameDescriptionAttribute=\"$valueAttribute\">" . $dataTableSimple . "</result>\n";
+                    $xml .= $prefixLines . "\t<result $nameDescriptionAttribute=\"" . self::formatAttributeValueXml($valueAttribute) . "\">" . $dataTableSimple . "</result>\n";
                 }
             }
             return $xml;
@@ -282,13 +287,12 @@ class Xml extends Renderer
         //          'nb_visits' => int 120
         if ($firstTable instanceof DataTable) {
             $xml = '';
-            $nameDescriptionAttribute = $table->getKeyName();
             foreach ($array as $keyName => $arrayForSingleDate) {
                 $dataTableOut = $this->renderDataTable($arrayForSingleDate, $prefixLines . "\t");
                 if (empty($dataTableOut)) {
-                    $xml .= $prefixLines . "\t<result $nameDescriptionAttribute=\"$keyName\" />\n";
+                    $xml .= $prefixLines . "\t<result $nameDescriptionAttribute=\"" . self::formatAttributeValueXml($keyName) . "\" />\n";
                 } else {
-                    $xml .= $prefixLines . "\t<result $nameDescriptionAttribute=\"$keyName\">\n";
+                    $xml .= $prefixLines . "\t<result $nameDescriptionAttribute=\"" . self::formatAttributeValueXml($keyName) . "\">\n";
                     $xml .= $dataTableOut;
                     $xml .= $prefixLines . "\t</result>\n";
                 }
@@ -299,10 +303,9 @@ class Xml extends Renderer
         if ($firstTable instanceof Map) {
             $xml = '';
             $tables = $table->getDataTables();
-            $nameDescriptionAttribute = $table->getKeyName();
             foreach ($tables as $valueAttribute => $tableInArray) {
                 $out = $this->renderTable($tableInArray, true, $prefixLines . "\t");
-                $xml .= $prefixLines . "\t<result $nameDescriptionAttribute=\"$valueAttribute\">\n" . $out . $prefixLines . "\t</result>\n";
+                $xml .= $prefixLines . "\t<result $nameDescriptionAttribute=\"" . self::formatAttributeValueXml($valueAttribute) . "\">\n" . $out . $prefixLines . "\t</result>\n";
             }
             return $xml;
         }
@@ -323,10 +326,11 @@ class Xml extends Renderer
         foreach ($array as $rowId => $row) {
             if (!is_array($row)) {
                 $value = self::formatValueXml($row);
+                [$tagStart, $tagEnd] = $this->getTagStartAndEndFor($rowId, false);
                 if (strlen($value) == 0) {
-                    $out .= $prefixLine . "\t\t<$rowId />\n";
+                    $out .= $prefixLine . "\t\t<$tagStart />\n";
                 } else {
-                    $out .= $prefixLine . "\t\t<$rowId>" . $value . "</$rowId>\n";
+                    $out .= $prefixLine . "\t\t<$tagStart>" . $value . "</$tagEnd>\n";
                 }
                 continue;
             }
@@ -334,8 +338,16 @@ class Xml extends Renderer
             // Handing case idgoal=7, creating a new array for that one
             $rowAttribute = '';
             if (strstr($rowId, '=') !== false) {
-                $rowAttribute = explode('=', $rowId);
-                $rowAttribute = " " . $rowAttribute[0] . "='" . $rowAttribute[1] . "'";
+                [$attributeName, $attributeValue] = explode('=', $rowId, 2);
+
+                // the part in front of the `=` has to be usable as an attribute name, otherwise the
+                // whole key is rendered as a `key` attribute instead
+                if (!self::isValidXmlTagName($attributeName)) {
+                    $attributeName = 'key';
+                    $attributeValue = $rowId;
+                }
+
+                $rowAttribute = " " . $attributeName . "='" . self::formatAttributeValueXml($attributeValue) . "'";
             }
             $out .= $prefixLine . "\t<row$rowAttribute>";
 
@@ -418,6 +430,26 @@ class Xml extends Renderer
     }
 
     /**
+     * Returns the key name of a map for use as an XML attribute name, or the generic `key` when it
+     * cannot be used as one.
+     */
+    private static function getKeyNameForXml(Map $table): string
+    {
+        $keyName = (string) $table->getKeyName();
+
+        return self::isValidXmlTagName($keyName) ? $keyName : 'key';
+    }
+
+    /**
+     * Escapes a value so it can be used as an XML attribute value, no matter whether the attribute
+     * is quoted with double or single quotes.
+     */
+    private static function formatAttributeValueXml($value): string
+    {
+        return str_replace("'", '&#039;', (string) self::formatValueXml($value));
+    }
+
+    /**
      * Returns true if a string is a valid XML tag name, false if otherwise.
      */
     private static function isValidXmlTagName(string $str): bool
@@ -425,7 +457,7 @@ class Xml extends Renderer
         static $validTagRegex = null;
 
         if ($validTagRegex === null) {
-            $invalidTagChars = "!\"#$%&'()*+,\\/;<=>?@[\\]\\\\^`{|}~";
+            $invalidTagChars = "!\"#$%&'()*+,\\/;<=>?@[\\]\\\\^`{|}~\\s\\x00-\\x1f";
             $invalidTagStartChars = $invalidTagChars . "\\-.0123456789";
             $validTagRegex = "/^[^" . $invalidTagStartChars . "][^" . $invalidTagChars . "]*$/";
         }
@@ -448,8 +480,10 @@ class Xml extends Renderer
 
     private function getTagStartAndEndFor($keyName, $columnsHaveInvalidChars): array
     {
-        if ($columnsHaveInvalidChars) {
-            $tagStart = "col name=\"" . self::formatValueXml($keyName) . "\"";
+        // the name of a single column can be unusable as a tag name even when the columns of the
+        // first row, which decide the format used for the table, all were usable
+        if ($columnsHaveInvalidChars || !self::isValidXmlTagName((string) $keyName)) {
+            $tagStart = "col name=\"" . self::formatAttributeValueXml($keyName) . "\"";
             $tagEnd = "col";
         } else {
             $tagStart = $tagEnd = $keyName;

--- a/tests/PHPUnit/Fixtures/OneVisitWithReferrerUrlThatIsNoXmlName.php
+++ b/tests/PHPUnit/Fixtures/OneVisitWithReferrerUrlThatIsNoXmlName.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Fixtures;
+
+use Piwik\DbHelper;
+use Piwik\Tests\Framework\Fixture;
+
+/**
+ * Fixture that adds one site and tracks one visit whose referrer url path holds characters that
+ * cannot be part of an XML name. Reports keep such a path as content, so a renderer has to handle
+ * it wherever report content is used.
+ */
+class OneVisitWithReferrerUrlThatIsNoXmlName extends Fixture
+{
+    public $idSite = 1;
+    public $dateTime = '2010-03-06 11:22:33';
+
+    /**
+     * Path of the tracked referrer url. Holds the characters an XML name cannot hold, so that a
+     * renderer treating it as a name rather than as content is detectable.
+     */
+    public $referrerUrlPath = 'x="><injected/><row y="';
+
+    public function setUp(): void
+    {
+        Fixture::createSuperUser();
+        DbHelper::createAnonymousUser();
+        $this->setUpWebsites();
+        $this->trackVisits();
+    }
+
+    public function tearDown(): void
+    {
+        // empty
+    }
+
+    private function setUpWebsites()
+    {
+        if (!self::siteCreated($this->idSite)) {
+            self::createWebsite($this->dateTime);
+        }
+    }
+
+    private function trackVisits()
+    {
+        $t = self::getTracker($this->idSite, $this->dateTime, $defaultInit = true);
+
+        $t->setUrl('http://example.org/index.htm');
+        $t->setUrlReferrer('http://referrer.example/' . $this->referrerUrlPath);
+        self::checkResponse($t->doTrackPageView('page title'));
+    }
+}

--- a/tests/PHPUnit/System/TrackedDataInXmlExportTest.php
+++ b/tests/PHPUnit/System/TrackedDataInXmlExportTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\System;
+
+use Piwik\API\Request;
+use Piwik\Date;
+use Piwik\Tests\Fixtures\OneVisitWithReferrerUrlThatIsNoXmlName;
+use Piwik\Tests\Framework\TestCase\SystemTestCase;
+
+/**
+ * @group Core
+ * @group TrackedDataInXmlExportTest
+ */
+class TrackedDataInXmlExportTest extends SystemTestCase
+{
+    /**
+     * @var OneVisitWithReferrerUrlThatIsNoXmlName
+     */
+    public static $fixture = null;
+
+    public function testReportContentIsNotUsedAsMarkupInXmlResponse()
+    {
+        $response = $this->getPivotedReferrersReportAsBulkXml();
+
+        self::assertStringNotContainsString('<injected', $response);
+        $this->assertValidXML($response);
+
+        // the path is still part of the response, escaped. asserted so that the test cannot pass by
+        // the report no longer holding the path at all
+        self::assertStringContainsString('&lt;injected/&gt;', $response);
+    }
+
+    /**
+     * Requests a report through the reporting API in a way that has the tracked path reach the XML
+     * renderer where a name is expected, rather than as a value of a row.
+     */
+    private function getPivotedReferrersReportAsBulkXml(): string
+    {
+        $nestedRequest = 'method=Referrers.getWebsites'
+            . '&idSite=' . self::$fixture->idSite
+            . '&period=day'
+            . '&date=' . Date::factory(self::$fixture->dateTime)->toString()
+            . '&pivotBy=Referrers.WebsitePage'
+            . '&pivotByColumn=nb_visits'
+            . '&pivotByColumnLimit=-1'
+            . '&disable_queued_filters=1'
+            . '&filter_limit=-1';
+
+        $request = new Request([
+            'module' => 'API',
+            'method' => 'API.getBulkRequest',
+            'format' => 'xml',
+            'urls'   => [$nestedRequest],
+        ]);
+
+        return $request->process();
+    }
+}
+
+TrackedDataInXmlExportTest::$fixture = new OneVisitWithReferrerUrlThatIsNoXmlName();

--- a/tests/PHPUnit/Unit/DataTable/Renderer/XmlTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Renderer/XmlTest.php
@@ -592,6 +592,35 @@ class XmlTest extends RendererTestCase
 </result>',
         ];
 
+        yield 'render key / value array with a key holding characters xml cannot hold' => [
+            function () {
+                return [
+                    "a\x00b\x08c\x0bd\x0ce\x1ff" => 1,
+                    "tab\there" => 2,
+                ];
+            },
+            '<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<row key="abcdef">1</row>
+		<row key="tab&#9;here">2</row>
+	</row>
+</result>',
+        ];
+
+        yield 'render key / value array with an empty value for a key rendered as a row attribute' => [
+            function () {
+                return ['idgoal=1' => '', 'idgoal=2' => null];
+            },
+            '<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<row idgoal="1"/>
+		<row idgoal="2"/>
+	</row>
+</result>',
+        ];
+
         yield 'render datatable map with a key name and labels that cannot be xml tag names' => [
             function () {
                 return self::getDataTableMapWithInvalidKeys();
@@ -690,9 +719,8 @@ class XmlTest extends RendererTestCase
         self::assertStringNotContainsString('<injected', $rendered);
         $document = self::assertValidXml($rendered);
 
-        // the key is still part of the response, either as the attribute name and value it is made
-        // of or as the value of a generic `key` attribute. a tab, line feed or carriage return in an
-        // attribute value is turned into a space when the xml is parsed
+        // the key is still part of the response unchanged, either as the attribute name and value it
+        // is made of or as the value of a generic `key` attribute
         $attributes = $document->row->attributes();
         self::assertCount(1, $attributes);
 
@@ -701,7 +729,7 @@ class XmlTest extends RendererTestCase
             $renderedKey = 'key' === $name ? (string) $value : $name . '=' . $value;
         }
 
-        self::assertSame(preg_replace('/[\t\n\r]/', ' ', $key), $renderedKey);
+        self::assertSame($key, $renderedKey);
     }
 
     public function getKeysThatCannotBeXmlTagNames(): iterable

--- a/tests/PHPUnit/Unit/DataTable/Renderer/XmlTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Renderer/XmlTest.php
@@ -608,6 +608,28 @@ class XmlTest extends RendererTestCase
 </result>',
         ];
 
+        // written with escape sequences rather than the characters themselves, as the point of the
+        // case is which of them survive
+        yield 'render values holding characters xml cannot hold' => [
+            function () {
+                return [
+                    'label' => "a\x00b\x08c\x0bd\x0ce\x1ff",
+                    // `is_numeric()` accepts surrounding whitespace, so a numeric string can hold
+                    // one of these too
+                    'numeric' => "\x0b123",
+                    'kept' => "tab\there and a\nline break",
+                ];
+            },
+            "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n"
+            . "<result>\n"
+            . "\t<row>\n"
+            . "\t\t<label>abcdef</label>\n"
+            . "\t\t<numeric>123</numeric>\n"
+            . "\t\t<kept>tab\there and a\nline break</kept>\n"
+            . "\t</row>\n"
+            . "</result>",
+        ];
+
         yield 'render key / value array with an empty value for a key rendered as a row attribute' => [
             function () {
                 return ['idgoal=1' => '', 'idgoal=2' => null];

--- a/tests/PHPUnit/Unit/DataTable/Renderer/XmlTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Renderer/XmlTest.php
@@ -547,6 +547,93 @@ class XmlTest extends RendererTestCase
 </result>',
         ];
 
+        yield 'render key / value array with keys that cannot be xml tag names' => [
+            function () {
+                return [
+                    'idgoal=1' => 5,
+                    'a"><injected/><row b="' => 1,
+                    'x"><injected/>' => 2,
+                    'my key' => 3,
+                ];
+            },
+            '<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<row idgoal="1">5</row>
+		<row key="a&quot;&gt;&lt;injected/&gt;&lt;row b=&quot;">1</row>
+		<row key="x&quot;&gt;&lt;injected/&gt;">2</row>
+		<row key="my key">3</row>
+	</row>
+</result>',
+        ];
+
+        yield 'render datatable with array column keys that cannot be xml tag names' => [
+            function () {
+                return self::getDataTableWithArrayColumnKeys();
+            },
+            '<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<label>row1</label>
+		<goals>
+			<row idgoal=\'1\'>
+				<revenue>5</revenue>
+			</row>
+		</goals>
+	</row>
+	<row>
+		<label>row2</label>
+		<goals>
+			<row x=\'&#039; /&gt;&lt;injected/&gt;&lt;row y=&#039;\'>
+				<revenue>7</revenue>
+			</row>
+		</goals>
+	</row>
+</result>',
+        ];
+
+        yield 'render datatable map with a key name and labels that cannot be xml tag names' => [
+            function () {
+                return self::getDataTableMapWithInvalidKeys();
+            },
+            '<?xml version="1.0" encoding="utf-8" ?>
+<results>
+	<result key="b&quot;&gt;&lt;injected/&gt;&lt;result z=&quot;">
+		<row>
+			<label>row1</label>
+			<nb_visits>1</nb_visits>
+		</row>
+	</result>
+	<result key="c&quot;&gt;&lt;injected/&gt;" />
+</results>',
+        ];
+
+        yield 'render datatable with column names that cannot be xml tag names' => [
+            function () {
+                return self::getDataTableWithInvalidColumnNames();
+            },
+            '<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<label>row1</label>
+		<goals>
+			<row idgoal=\'1\'>
+				<revenue>5</revenue>
+			</row>
+				<col name="a&quot;&gt;&lt;injected/&gt;&lt;x y=&quot;">7</col>
+		</goals>
+	</row>
+	<row>
+		<label>row2</label>
+		<nb_visits>1</nb_visits>
+	</row>
+	<row>
+		<label>row3</label>
+		<col name="x&quot;&gt;&lt;injected/&gt;&lt;col name=&quot;">2</col>
+	</row>
+</result>',
+        ];
+
         yield 'handles comparison metadata correctly' => [
             function () {
                 return self::getComparisonDataTable();
@@ -585,6 +672,106 @@ class XmlTest extends RendererTestCase
                 $renderer->setHideMetadataFromResponse(true);
             },
         ];
+    }
+
+    /**
+     * An array key is not always an identifier. It can originate from report data, so it must be
+     * rendered as data and never as markup.
+     *
+     * @dataProvider getKeysThatCannotBeXmlTagNames
+     */
+    public function testRenderDoesNotAllowArrayKeysToBecomeMarkup(string $key)
+    {
+        $renderer = new Xml();
+        $renderer->setTable([$key => 1, 'nested' => [$key => ['nb_visits' => 1]]]);
+
+        $rendered = $renderer->render();
+
+        self::assertStringNotContainsString('<injected', $rendered);
+        $document = self::assertValidXml($rendered);
+
+        // the key is still part of the response, either as the attribute name and value it is made
+        // of or as the value of a generic `key` attribute. a tab, line feed or carriage return in an
+        // attribute value is turned into a space when the xml is parsed
+        $attributes = $document->row->attributes();
+        self::assertCount(1, $attributes);
+
+        $renderedKey = null;
+        foreach ($attributes as $name => $value) {
+            $renderedKey = 'key' === $name ? (string) $value : $name . '=' . $value;
+        }
+
+        self::assertSame(preg_replace('/[\t\n\r]/', ' ', $key), $renderedKey);
+    }
+
+    public function getKeysThatCannotBeXmlTagNames(): iterable
+    {
+        yield 'closes the row and adds an element' => ['a"><injected/><row b="'];
+        yield 'closes a single quoted attribute' => ["a=' /><injected/><row b='"];
+        yield 'adds an element without using an equals sign' => ['a"><injected/>'];
+        yield 'adds an attribute to the row' => ['a onmouseover=alert(1)'];
+        yield 'contains a line break' => ["a\n<injected/>"];
+        yield 'starts with an equals sign' => ['="><injected/>'];
+    }
+
+    private static function assertValidXml(string $xml): \SimpleXMLElement
+    {
+        $useInternalErrors = libxml_use_internal_errors(true);
+        $document = simplexml_load_string($xml);
+
+        $errors = [];
+        foreach (libxml_get_errors() as $error) {
+            $errors[] = trim($error->message) . ' @' . $error->line . ':' . $error->column;
+        }
+
+        libxml_clear_errors();
+        libxml_use_internal_errors($useInternalErrors);
+
+        self::assertNotFalse($document, 'Rendered xml is not valid: ' . implode("\n", $errors) . "\n" . $xml);
+
+        return $document;
+    }
+
+    private static function getDataTableWithArrayColumnKeys(): DataTable
+    {
+        $table = new DataTable();
+        $table->addRowsFromArray([
+            [DataTable\Row::COLUMNS => ['label' => 'row1', 'goals' => ['idgoal=1' => ['revenue' => 5]]]],
+            [DataTable\Row::COLUMNS => ['label' => 'row2', 'goals' => ["x=' /><injected/><row y='" => ['revenue' => 7]]]],
+        ]);
+        return $table;
+    }
+
+    private static function getDataTableMapWithInvalidKeys(): DataTable\Map
+    {
+        $map = new DataTable\Map();
+        $map->setKeyName('a"><injected/><x y="');
+
+        $table = new DataTable();
+        $table->addRowsFromArray([[DataTable\Row::COLUMNS => ['label' => 'row1', 'nb_visits' => 1]]]);
+
+        $map->addTable($table, 'b"><injected/><result z="');
+        $map->addTable(new DataTable(), 'c"><injected/>');
+
+        return $map;
+    }
+
+    /**
+     * The format used for a table is decided by the columns of its first row, so the first row here
+     * has columns that can all be used as tag names while a later row has one that cannot.
+     */
+    private static function getDataTableWithInvalidColumnNames(): DataTable
+    {
+        $table = new DataTable();
+        $table->addRowsFromArray([
+            [DataTable\Row::COLUMNS => ['label' => 'row1', 'goals' => [
+                'idgoal=1' => ['revenue' => 5],
+                'a"><injected/><x y="' => 7,
+            ]]],
+            [DataTable\Row::COLUMNS => ['label' => 'row2', 'nb_visits' => 1]],
+            [DataTable\Row::COLUMNS => ['label' => 'row3', 'x"><injected/><col name="' => 2]],
+        ]);
+        return $table;
     }
 
     private static function getDataTableSimpleWithInvalidChars(): DataTable\Simple


### PR DESCRIPTION
### Description

The XML renderer builds the structure of a response out of values that are not always identifiers: the keys of an array, the column names of a table, and the labels of a datatable map. Some of those come from report data, so they are not necessarily usable as XML names.

They were written straight into tag and attribute positions while only leaf values were escaped. A value that cannot be used as an XML name was therefore rendered as part of the markup instead of as data, and the response was no longer well formed:

```
['my key' => 1]   ->   <my key>1</my key>
```

**What changes**

Names and attribute values built from data are now handled as data:

* a key like `idgoal=1` is still rendered as a row attribute, but only when the part in front of the `=` can be used as an attribute name. Otherwise the whole key is rendered as the value of a generic `key` attribute, which is the form the renderer already used for any key that cannot be a tag name
* the same applies to the key name of a datatable map, which falls back to a generic `key` attribute
* every attribute value built from data is escaped, for both quote styles, through the existing `formatValueXml()` so that a value escapes the same way whether it ends up in a name or in an element
* a column name is only used as a tag name when it can be one. The format used for a table is chosen from the columns of its first row, so this is now also checked per column, for the columns of the rows that follow
* a valid XML name no longer includes whitespace or control characters

**Compatibility**

Output is unchanged for any value that can be used as an XML name, which covers every existing test expectation: `<row idgoal="1">`, `<row idgoal='1'>`, `<row key="2010-03-07">` and `<result date="2010-03-07">` all render exactly as before, and escaping is a no-op on values holding none of `& < > " '`.

The shape does change for a name holding whitespace: a column or key named `my key` now renders as `<row key="my key">` or `<col name="my key">` instead of `<my key>`. The previous output was not well formed, so no XML consumer could read it, but anything matching on those responses as text sees a difference.

**Tests**

* `XmlTest` covers every place the renderer builds a name or an attribute value from data, asserting the exact output for a value that cannot be an XML name next to a legitimate one, so both missing escaping and lost data are caught. A further case asserts that such a value adds no elements of its own, that the response parses, and that the value is still carried as data.
* `TrackedDataInXmlExportTest` covers the same through the reporting API, with report data that cannot be an XML name reaching the renderer as a name.
* Both fail without the change. Also ran the full unit suite (failure set identical to `6.x-dev`), `OneVisitorTwoVisitsTest`, `PivotByQueryParamTest`, `ManyVisitorsOneWebsiteTest` and the Goals tests, plus a comparison of 4458 lines of XML API output against `6.x-dev` across 13 endpoints, which is identical apart from `timerMillis`. PHPCS and PHPStan are clean on the changed files.

**Not changed**

Two older limitations of the same renderer are left alone, as neither is reachable through this code path and both would move currently accepted names into the `col name="…"` form: `isValidXmlTagName()` is a deny list, so some Unicode names it accepts are still not valid XML names (`<Google©>`), and neither element values nor attribute values strip the control characters that XML does not allow anywhere.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

