### PR TITLE
fix: [Bug] Fix nonce validation race condition due to concurrent PHP session ...

### DIFF
--- a/core/Session/SaveHandler/DbTable.php
+++ b/core/Session/SaveHandler/DbTable.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Session\SaveHandler;
 
+use Piwik\Common;
 use Piwik\Db;
 use Piwik\DbHelper;
 use Exception;
@@ -29,6 +30,10 @@ class DbTable implements \SessionHandlerInterface
 
     public const TABLE_NAME = 'session';
     public const TOKEN_HASH_ALGO = 'sha512';
+
+    private const MAX_MERGE_ATTEMPTS = 3;
+
+    private array $dataAtReadTime = [];
 
     /**
      * @param array $config
@@ -87,11 +92,20 @@ class DbTable implements \SessionHandlerInterface
     public function read($id)
     {
         $id = $this->hashSessionId($id);
+        $result = $this->fetchData($id);
+
+        $this->dataAtReadTime[$id] = $result;
+
+        return $result;
+    }
+
+    private function fetchData(string $hashedId): string
+    {
         $sql = 'SELECT ' . $this->config['dataColumn'] . ' FROM `' . $this->config['name'] . '`'
             . ' WHERE ' . $this->config['primary'] . ' = ?'
             . ' AND ' . $this->config['modifiedColumn'] . ' + ' . $this->config['lifetimeColumn'] . ' >= ?';
 
-        $result = $this->fetchOne($sql, [$id, time()]);
+        $result = $this->fetchOne($sql, [$hashedId, time()]);
 
         if (!$result) {
             $result = '';
@@ -140,6 +154,51 @@ class DbTable implements \SessionHandlerInterface
     {
         $id = $this->hashSessionId($id);
 
+        if (!array_key_exists($id, $this->dataAtReadTime)) {
+            $this->save($id, $data);
+
+            return true;
+        }
+
+        $dataAtReadTime = $this->dataAtReadTime[$id];
+
+        if ($dataAtReadTime !== '' && $data === $dataAtReadTime) {
+            $this->refreshExpiration($id);
+
+            return true;
+        }
+
+        for ($attempt = 0; $attempt < self::MAX_MERGE_ATTEMPTS; $attempt++) {
+            $storedData = $this->fetchData($id);
+
+            if ($storedData === '' || $storedData === $dataAtReadTime) {
+                break;
+            }
+
+            $mergedData = $this->mergeSessionData($dataAtReadTime, $storedData, $data);
+
+            if ($mergedData === null) {
+                break;
+            }
+
+            if ($mergedData === $storedData) {
+                $this->refreshExpiration($id);
+
+                return true;
+            }
+
+            if ($this->replaceData($id, $storedData, $mergedData)) {
+                return true;
+            }
+        }
+
+        $this->save($id, $data);
+
+        return true;
+    }
+
+    private function save(string $hashedId, $data): void
+    {
         $sql = 'INSERT INTO ' . $this->config['name']
             . ' (' . $this->config['primary'] . ','
             . $this->config['modifiedColumn'] . ','
@@ -151,9 +210,108 @@ class DbTable implements \SessionHandlerInterface
             . $this->config['lifetimeColumn'] . ' = ?,'
             . $this->config['dataColumn'] . ' = ?';
 
-        $this->query($sql, [$id, time(), $this->maxLifetime, $data, time(), $this->maxLifetime, $data]);
+        $this->query($sql, [$hashedId, time(), $this->maxLifetime, $data, time(), $this->maxLifetime, $data]);
+    }
 
-        return true;
+    private function refreshExpiration(string $hashedId): void
+    {
+        $sql = 'UPDATE ' . $this->config['name']
+            . ' SET ' . $this->config['modifiedColumn'] . ' = ?,'
+            . $this->config['lifetimeColumn'] . ' = ?'
+            . ' WHERE ' . $this->config['primary'] . ' = ?';
+
+        $this->query($sql, [time(), $this->maxLifetime, $hashedId]);
+    }
+
+    private function replaceData(string $hashedId, string $expectedData, string $data): bool
+    {
+        $sql = 'UPDATE ' . $this->config['name']
+            . ' SET ' . $this->config['modifiedColumn'] . ' = ?,'
+            . $this->config['lifetimeColumn'] . ' = ?,'
+            . $this->config['dataColumn'] . ' = ?'
+            . ' WHERE ' . $this->config['primary'] . ' = ?'
+            . ' AND ' . $this->config['dataColumn'] . ' = ?';
+
+        $statement = Db::query($sql, [time(), $this->maxLifetime, $data, $hashedId, $expectedData]);
+
+        return $statement->rowCount() > 0;
+    }
+
+    private function mergeSessionData(string $dataAtReadTime, string $storedData, $data): ?string
+    {
+        $valuesAtReadTime = $this->unserializeSessionData($dataAtReadTime);
+        $storedValues = $this->unserializeSessionData($storedData);
+        $values = $this->unserializeSessionData(is_string($data) ? $data : '');
+
+        if ($valuesAtReadTime === null || $storedValues === null || $values === null) {
+            return null;
+        }
+
+        return serialize($this->mergeChangedValues($valuesAtReadTime, $storedValues, $values));
+    }
+
+    private function mergeChangedValues(array $valuesAtReadTime, array $storedValues, array $values): array
+    {
+        $merged = $storedValues;
+
+        foreach ($values as $key => $value) {
+            $existedAtReadTime = array_key_exists($key, $valuesAtReadTime);
+
+            if ($existedAtReadTime && $valuesAtReadTime[$key] === $value) {
+                continue;
+            }
+
+            if (
+                $existedAtReadTime
+                && is_array($value)
+                && is_array($valuesAtReadTime[$key])
+                && isset($storedValues[$key])
+                && is_array($storedValues[$key])
+            ) {
+                $merged[$key] = $this->mergeChangedValues($valuesAtReadTime[$key], $storedValues[$key], $value);
+                continue;
+            }
+
+            $merged[$key] = $value;
+        }
+
+        foreach ($valuesAtReadTime as $key => $value) {
+            if (!array_key_exists($key, $values)) {
+                unset($merged[$key]);
+            }
+        }
+
+        return $merged;
+    }
+
+    private function unserializeSessionData(string $data): ?array
+    {
+        if ($data === '') {
+            return null;
+        }
+
+        $values = Common::safe_unserialize($data);
+
+        if (!is_array($values) || $this->containsObject($values)) {
+            return null;
+        }
+
+        return $values;
+    }
+
+    private function containsObject(array $values): bool
+    {
+        foreach ($values as $value) {
+            if (is_object($value)) {
+                return true;
+            }
+
+            if (is_array($value) && $this->containsObject($value)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -165,6 +323,8 @@ class DbTable implements \SessionHandlerInterface
     public function destroy($id): bool
     {
         $id = $this->hashSessionId($id);
+
+        unset($this->dataAtReadTime[$id]);
 
         $sql = 'DELETE FROM `' . $this->config['name'] . '` WHERE ' . $this->config['primary'] . ' = ?';
 

--- a/tests/PHPUnit/Integration/Session/SaveHandler/DbTableTest.php
+++ b/tests/PHPUnit/Integration/Session/SaveHandler/DbTableTest.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Tests\Integration\Session\SaveHandler;
 
+use Piwik\Common;
 use Piwik\Session;
 use Piwik\Session\SaveHandler\DbTable;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
@@ -33,5 +34,63 @@ class DbTableTest extends IntegrationTestCase
         $result = $this->testInstance->read('testid');
 
         $this->assertEquals('testdata', $result);
+    }
+
+    public function testWriteKeepsValuesStoredByAnOverlappingRequest()
+    {
+        $this->testInstance->write('testid', serialize(['user.name' => 'admin']));
+
+        $slowRequest = new DbTable(Session::getDbTableConfig());
+        $slowRequest->read('testid');
+
+        $nonceRequest = new DbTable(Session::getDbTableConfig());
+        $nonceRequest->read('testid');
+        $nonceRequest->write('testid', serialize([
+            'user.name' => 'admin',
+            'Feedback.sendFeedback' => ['nonce' => 'thenonce'],
+            '__ZF' => ['Feedback.sendFeedback' => ['ENT' => ['nonce' => 100]]],
+        ]));
+
+        $slowRequest->write('testid', serialize([
+            'user.name' => 'admin',
+            'session.info' => ['expiration' => 100],
+        ]));
+
+        $storedValues = Common::safe_unserialize($this->testInstance->read('testid'));
+
+        $this->assertSame([
+            'user.name' => 'admin',
+            'Feedback.sendFeedback' => ['nonce' => 'thenonce'],
+            '__ZF' => ['Feedback.sendFeedback' => ['ENT' => ['nonce' => 100]]],
+            'session.info' => ['expiration' => 100],
+        ], $storedValues);
+    }
+
+    public function testWriteAppliesValuesRemovedByTheCurrentRequest()
+    {
+        $this->testInstance->write('testid', serialize([
+            'user.name' => 'admin',
+            'Feedback.sendFeedback' => ['nonce' => 'thenonce'],
+        ]));
+
+        $discardingRequest = new DbTable(Session::getDbTableConfig());
+        $discardingRequest->read('testid');
+
+        $otherRequest = new DbTable(Session::getDbTableConfig());
+        $otherRequest->read('testid');
+        $otherRequest->write('testid', serialize([
+            'user.name' => 'admin',
+            'Feedback.sendFeedback' => ['nonce' => 'thenonce'],
+            'session.info' => ['expiration' => 100],
+        ]));
+
+        $discardingRequest->write('testid', serialize(['user.name' => 'admin']));
+
+        $storedValues = Common::safe_unserialize($this->testInstance->read('testid'));
+
+        $this->assertSame([
+            'user.name' => 'admin',
+            'session.info' => ['expiration' => 100],
+        ], $storedValues);
     }
 }


### PR DESCRIPTION
Fixes #24477

## Root cause

DB session save handler overwrites session data with a stale snapshot (last-write-wins)

## Changes

- Piwik\Session\SaveHandler\DbTable now remembers the session payload it read at the start of the request and, on write, applies only the values this request actually changed on top of the session data currently stored. Unchanged sessions only refresh modified/lifetime instead of rewriting the data column, changed sessions are stored with a three-way merge (recursive per key, honouring keys the request removed) via a compare-and-swap UPDATE with a bounded retry, and any non-mergeable payload (unparsable data, objects in the session, no read snapshot) falls back to the previous plain write. Regression tests were added to the existing DbTable integration test.