### PR TITLE
Document that a failing custom migration costs the plugin its activation

### DIFF
--- a/core/Updater/Migration/Custom.php
+++ b/core/Updater/Migration/Custom.php
@@ -14,6 +14,11 @@ use Piwik\Updater\Migration;
 /**
  * Create a custom migration that can execute any callback.
  *
+ * A migration that throws fails the update, and a plugin not bundled with core is then deactivated
+ * so the rest of the update can finish. Let errors escape from a callback the plugin cannot work
+ * without; have one doing best-effort work catch its own, rather than cost the plugin its
+ * activation.
+ *
  * @api
  */
 class Custom extends Migration


### PR DESCRIPTION
### Description

`Migration\Custom` runs arbitrary plugin code as part of an update, and its failure is unforgiving: `shouldIgnoreError()` returns `false` unconditionally, so any exception fails the update, and core then deactivates the plugin if it is not bundled. Nothing at the call site hints at that, and unlike `Migration\Db\Sql` — which takes `$errorCodesToIgnore` — there is no way to say a step is best effort.

This is not hypothetical. A plugin update recently included a step the plugin does not need in order to work. The step failed on some installations, and each of those lost the entire plugin until it was re-enabled by hand. The work was optional; the consequence was not.

This adds a short note to the class docblock, which is where someone looks at the moment they take that risk. It documents existing behaviour and asks authors to decide deliberately: let errors escape when the plugin genuinely cannot work without the step, and catch them when it can.

Comment only, no functional change.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
