### PR TITLE
Fix Google AI Provider Tool Calling

### DIFF
--- a/plugins/AIProviders/CanonicalMessage.php
+++ b/plugins/AIProviders/CanonicalMessage.php
@@ -50,6 +50,11 @@ namespace Piwik\Plugins\AIProviders;
  *     object as `{}` (stdClass) on the wire to satisfy providers that reject
  *     `[]` for object slots.
  *
+ *     A block may carry additional provider-specific fields (e.g. Google's
+ *     `thoughtSignature`, which Gemini 3 requires echoed back on replay).
+ *     Callers must persist and replay blocks verbatim so such fields survive
+ *     the round trip.
+ *
  *   Tool result block (tool role only):
  *     {
  *         type: 'tool_result',

--- a/plugins/AIProviders/Provider/Google.php
+++ b/plugins/AIProviders/Provider/Google.php
@@ -284,12 +284,17 @@ class Google extends AIProvider
                 // functionCall.args must be a JSON object even when empty;
                 // json_decode collapses `{}` to `[]`, so coerce empty inputs
                 // back to stdClass so json_encode produces `{}` again.
-                $parts[] = [
+                $part = [
                     'functionCall' => [
                         'name' => $name,
                         'args' => $input === [] ? new \stdClass() : $input,
                     ],
                 ];
+                // Gemini 3 rejects replayed functionCall parts without their thoughtSignature.
+                if (is_string($block['thoughtSignature'] ?? null) && $block['thoughtSignature'] !== '') {
+                    $part['thoughtSignature'] = $block['thoughtSignature'];
+                }
+                $parts[] = $part;
             }
         }
 
@@ -472,12 +477,17 @@ class Google extends AIProvider
                 // Google supplies no id; synthesize a deterministic one so the
                 // caller can echo it back and the id => name resolver can
                 // recover the function name on the next turn.
-                $canonical[] = [
+                $toolUse = [
                     'type' => 'tool_use',
                     'id' => sprintf('google-%d-%s', $index, $name),
                     'name' => $name,
                     'input' => $normalizedInput,
                 ];
+                // Keep the part-level thoughtSignature: Gemini 3 requires it back on replay.
+                if (is_string($part['thoughtSignature'] ?? null) && $part['thoughtSignature'] !== '') {
+                    $toolUse['thoughtSignature'] = $part['thoughtSignature'];
+                }
+                $canonical[] = $toolUse;
             }
         }
 

--- a/plugins/AIProviders/tests/Unit/GoogleConverseTest.php
+++ b/plugins/AIProviders/tests/Unit/GoogleConverseTest.php
@@ -376,6 +376,62 @@ class GoogleConverseTest extends TestCase
         $this->assertSame('gemini-3.1-flash-lite', $response->getModel());
     }
 
+    public function testThoughtSignatureSurvivesTheToolUseRoundTrip(): void
+    {
+        $gemini = new RecordingGoogle();
+        $gemini->cannedResponse = [
+            'candidates' => [[
+                'content' => ['parts' => [
+                    [
+                        'functionCall' => ['name' => 'matomo_site_list', 'args' => ['idSite' => 1]],
+                        'thoughtSignature' => 'sig-abc123',
+                    ],
+                ]],
+                'finishReason' => 'STOP',
+            ]],
+        ];
+
+        $first = $gemini->converse($this->simpleRequest(), self::CONFIGURATION);
+        $toolUse = $first->getContent()[0];
+
+        $this->assertSame('sig-abc123', $toolUse['thoughtSignature']);
+
+        // Replay must put the signature back as a sibling of functionCall.
+        $followUp = new AIConversationRequest(
+            [['role' => 'assistant', 'content' => $first->getContent()]],
+            'AskMatomo'
+        );
+        $gemini->converse($followUp, self::CONFIGURATION);
+
+        $sentPart = $gemini->sentPayload['contents'][0]['parts'][0];
+        $this->assertSame('sig-abc123', $sentPart['thoughtSignature']);
+        $this->assertSame('matomo_site_list', $sentPart['functionCall']['name']);
+    }
+
+    public function testToolUseWithoutThoughtSignatureOmitsItOnBothSides(): void
+    {
+        $gemini = new RecordingGoogle();
+        $gemini->cannedResponse = [
+            'candidates' => [[
+                'content' => ['parts' => [
+                    ['functionCall' => ['name' => 'matomo_site_list', 'args' => ['idSite' => 1]]],
+                ]],
+                'finishReason' => 'STOP',
+            ]],
+        ];
+
+        $first = $gemini->converse($this->simpleRequest(), self::CONFIGURATION);
+        $this->assertArrayNotHasKey('thoughtSignature', $first->getContent()[0]);
+
+        $followUp = new AIConversationRequest(
+            [['role' => 'assistant', 'content' => $first->getContent()]],
+            'AskMatomo'
+        );
+        $gemini->converse($followUp, self::CONFIGURATION);
+
+        $this->assertArrayNotHasKey('thoughtSignature', $gemini->sentPayload['contents'][0]['parts'][0]);
+    }
+
     public function testSynthesizedIdResolvesBackToFunctionNameOnFollowUpTurn(): void
     {
         $gemini = new RecordingGoogle();


### PR DESCRIPTION
### Description

Gemini 3 models attach a thoughtSignature to each functionCall part and require it to be echoed back when the conversation history is replayed on the next request.

The existing Google provider dropped the field in both conversion directions, so every tool-using conversation failed with HTTP 400: `Function call is missing a thought_signature in functionCall parts.`

The Google provider now keeps the `thoughtSignature` on the canonical `tool_use` block and echoes it back on the rebuilt `functionCall` part on replay.

`CanonicalMessage` contract updated.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
