### PR TITLE
Let the visits log skip its GROUP BY, behind a config setting

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -1391,6 +1391,15 @@ time_dom_completion_cap_duration_ms = 0
 ; Cap for On load time: avg/high 10ms (recommended value: 1000)
 time_on_load_cap_duration_ms = 0
 
+[Live]
+; When enabled, the visits log asks the joined log tables for a match with a subquery instead of
+; grouping away the rows they duplicate. Grouping by log_visit.idvisit while ordering by
+; log_visit.visit_last_action_time makes MySQL sort every matching visit before it can apply the
+; LIMIT, so the query costs as much as the whole date range even when a single page of visits is
+; requested. Both forms return the same visits in the same order, a visit matching several actions
+; still counting once, see https://github.com/matomo-org/matomo/issues/13861
+use_semi_join_query = 0
+
 [APISettings]
 ; Any key/value pair can be added in this section, they will be available via the REST call
 ; index.php?module=API&method=API.getSettings

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -1398,6 +1398,9 @@ time_on_load_cap_duration_ms = 0
 ; LIMIT, so the query costs as much as the whole date range even when a single page of visits is
 ; requested. Both forms return the same visits in the same order, a visit matching several actions
 ; still counting once, see https://github.com/matomo-org/matomo/issues/13861
+; The subquery form only stops early when an index serves the order by, which is the case when the
+; visits log is asked for a single site. Asking for several sites at once sorts the matching visits
+; either way.
 use_semi_join_query = 0
 
 [APISettings]

--- a/core/DataAccess/LogQueryBuilder.php
+++ b/core/DataAccess/LogQueryBuilder.php
@@ -10,6 +10,8 @@
 namespace Piwik\DataAccess;
 
 use Exception;
+use Piwik\Common;
+use Piwik\Config;
 use Piwik\DataAccess\LogQueryBuilder\JoinGenerator;
 use Piwik\DataAccess\LogQueryBuilder\JoinTables;
 use Piwik\Plugin\LogTablesProvider;
@@ -18,6 +20,19 @@ use Piwik\Segment\SegmentExpression;
 class LogQueryBuilder
 {
     public const FORCE_INNER_GROUP_BY_NO_SUBSELECT = '__##nosubquery##__';
+
+    /**
+     * Column the visits log groups by to return one row per visit.
+     */
+    private const LOG_VISIT_ID_COLUMN = 'log_visit.idvisit';
+
+    /**
+     * Alias the outer log_visit gets when the joined tables move into a subquery. It is the outer
+     * table that is renamed and not the one in the subquery, because the segment conditions can
+     * contain subqueries of their own that select from log_visit again, eg. `actionUrl!@x`. Leaving
+     * the generated join and the segment conditions untouched keeps those working.
+     */
+    private const LOG_VISIT_OUTER_ALIAS = 'log_visit_outer';
 
     /**
      * @var LogTablesProvider
@@ -66,11 +81,14 @@ class LogQueryBuilder
         }
 
         $fromInitially = $from;
+        $whereWithoutSegment = $where;
+        $segmentWhere = null;
 
         if (!$segmentExpression->isEmpty()) {
             $segmentExpression->parseSubExpressionsIntoSqlExpressions($from);
             $segmentSql = $segmentExpression->getSql();
-            $where = $this->getWhereMatchBoth($where, $segmentSql['where']);
+            $segmentWhere = $segmentSql['where'];
+            $where = $this->getWhereMatchBoth($where, $segmentWhere);
             $bind = array_merge($bind, $segmentSql['bind']);
         }
 
@@ -94,7 +112,15 @@ class LogQueryBuilder
 
         if (!empty($this->forcedInnerGroupBy)) {
             if ($this->forcedInnerGroupBy === self::FORCE_INNER_GROUP_BY_NO_SUBSELECT) {
-                $sql = $this->buildSelectQuery($select, $from, $where, $groupBy, $orderBy, $limitAndOffset);
+                $sql = null;
+
+                if ($this->isVisitSemiJoinEnabled()) {
+                    $sql = $this->buildVisitQueryWithoutGroupBy($select, $from, $whereWithoutSegment, $segmentWhere, $groupBy, $orderBy, $limitAndOffset, $tables);
+                }
+
+                if ($sql === null) {
+                    $sql = $this->buildSelectQuery($select, $from, $where, $groupBy, $orderBy, $limitAndOffset);
+                }
             } else {
                 $sql = $this->buildWrappedSelectQuery($select, $from, $where, $groupBy, $orderBy, $limitAndOffset, $tables, $this->forcedInnerGroupBy);
             }
@@ -119,6 +145,133 @@ class LogQueryBuilder
             $names[] = $logTable->getName();
         }
         return $names;
+    }
+
+    /**
+     * Build a query that returns one row per visit by construction, so that `GROUP BY
+     * log_visit.idvisit` is not needed to remove the duplicate visits the joined log tables create.
+     *
+     * Grouping by `log_visit.idvisit` while ordering by another log_visit column makes MySQL buffer
+     * and sort every matching visit before it can apply the LIMIT, so the query costs as much as the
+     * whole date range even though only one page of visits is returned.
+     *
+     * Two shapes are built:
+     *
+     * - when log_visit is the only table of the query, the GROUP BY is dropped. log_visit.idvisit is
+     *   the primary key of that table, so grouping by it cannot merge any rows.
+     * - when other log tables are joined, they move into a correlated EXISTS subquery. The subquery
+     *   matches a visit exactly when at least one of its joined rows matches the segment, which is
+     *   the set of visits the GROUP BY produced, so a visit matching several actions still counts
+     *   once against the LIMIT (see https://github.com/matomo-org/matomo/issues/13861). MySQL can
+     *   then stop reading log_visit as soon as it has enough visits.
+     *
+     * @param string          $select         Select clause, has to select from log_visit only.
+     * @param string          $from           Generated join string.
+     * @param string|false    $where          Where clause of the caller, without the segment conditions.
+     * @param string|null     $segmentWhere   Where clause generated for the segment.
+     * @param string|false    $groupBy
+     * @param string|false    $orderBy
+     * @param string|int|null $limitAndOffset
+     * @param JoinTables      $tables         Tables of the generated join, in the order they are joined.
+     * @return string|null The query, or null when it does not have the shape this rewrite is
+     *                     equivalent for and the caller has to build the grouped query instead.
+     */
+    private function buildVisitQueryWithoutGroupBy($select, $from, $where, $segmentWhere, $groupBy, $orderBy, $limitAndOffset, JoinTables $tables)
+    {
+        if (trim((string) $groupBy) !== self::LOG_VISIT_ID_COLUMN) {
+            return null;
+        }
+
+        // the rewrite reasons about visits, so the query may only select and sort log_visit rows
+        if (trim((string) $select) !== 'log_visit.*') {
+            return null;
+        }
+
+        if (!$this->referencesLogVisitOnly($where) || !$this->referencesLogVisitOnly($orderBy)) {
+            return null;
+        }
+
+        // the caller's conditions are rewritten to the alias, which would rewrite the inside of a
+        // subquery that selects from log_visit as well. Those references belong to the log_visit of
+        // that subquery, so the query has to stay grouped instead.
+        if (preg_match('/\bSELECT\b/i', (string) $where)) {
+            return null;
+        }
+
+        // log_visit has to be the table the other ones are joined on, so that every row of the join
+        // belongs to exactly one visit
+        if (!isset($tables[0]) || $tables[0] !== 'log_visit') {
+            return null;
+        }
+
+        if (count($tables) === 1) {
+            $where = empty($segmentWhere) ? $where : $this->getWhereMatchBoth($where, $segmentWhere);
+
+            return $this->buildSelectQuery($select, $from, $where, false, $orderBy, $limitAndOffset);
+        }
+
+        if (empty($segmentWhere)) {
+            return null;
+        }
+
+        $alias = self::LOG_VISIT_OUTER_ALIAS;
+
+        $visitMatchesSegment = $this->buildSelectQuery(
+            '1',
+            $from,
+            self::LOG_VISIT_ID_COLUMN . " = $alias.idvisit
+				AND ($segmentWhere)",
+            false,
+            false,
+            null
+        );
+
+        return $this->buildSelectQuery(
+            $this->aliasLogVisitTable($select, $alias),
+            Common::prefixTable('log_visit') . " AS $alias",
+            $this->getWhereMatchBoth($this->aliasLogVisitTable($where, $alias), "EXISTS ($visitMatchesSegment)"),
+            false,
+            $this->aliasLogVisitTable($orderBy, $alias),
+            $limitAndOffset
+        );
+    }
+
+    /**
+     * Whether the visits log may drop its group by. Off by default while the query change is
+     * validated, see the [Live] section of global.ini.php.
+     *
+     * @return bool
+     */
+    private function isVisitSemiJoinEnabled()
+    {
+        $live = Config::getInstance()->Live;
+
+        return !empty($live['use_semi_join_query']);
+    }
+
+    /**
+     * @param string|false $sqlExpression
+     * @return bool
+     */
+    private function referencesLogVisitOnly($sqlExpression)
+    {
+        foreach (SegmentExpression::parseColumnsFromSqlExpr((string) $sqlExpression) as $column) {
+            if (strpos($column, 'log_visit.') !== 0) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param string|false $sqlExpression
+     * @param string $alias
+     * @return string
+     */
+    private function aliasLogVisitTable($sqlExpression, $alias)
+    {
+        return preg_replace('/(?<![a-zA-Z0-9_])log_visit\./', $alias . '.', (string) $sqlExpression);
     }
 
     /**
@@ -240,10 +393,10 @@ class LogQueryBuilder
      *
      * @param string $select fieldlist to be selected
      * @param string $from tablelist to select from
-     * @param string $where where clause
-     * @param string $groupBy group by clause
-     * @param string $orderBy order by clause
-     * @param string|int $limitAndOffset limit by clause eg '5' for Limit 5 Offset 0 or '10, 5' for Limit 5 Offset 10
+     * @param string|false $where where clause
+     * @param string|false $groupBy group by clause
+     * @param string|false $orderBy order by clause
+     * @param string|int|null $limitAndOffset limit by clause eg '5' for Limit 5 Offset 0 or '10, 5' for Limit 5 Offset 10
      * @return string
      */
     private function buildSelectQuery($select, $from, $where, $groupBy, $orderBy, $limitAndOffset, bool $withRollup = false)

--- a/core/DataAccess/LogQueryBuilder.php
+++ b/core/DataAccess/LogQueryBuilder.php
@@ -35,6 +35,12 @@ class LogQueryBuilder
     private const LOG_VISIT_OUTER_ALIAS = 'log_visit_outer';
 
     /**
+     * A reference to the log_visit table of the query. This matches more forms than the rewrite to
+     * the alias replaces on purpose, so that a reference the rewrite left behind can be detected.
+     */
+    private const LOG_VISIT_REFERENCE_REGEX = '/(?<![a-zA-Z0-9_])`?log_visit`?\s*\./i';
+
+    /**
      * @var LogTablesProvider
      */
     private $logTableProvider;
@@ -163,7 +169,10 @@ class LogQueryBuilder
      *   matches a visit exactly when at least one of its joined rows matches the segment, which is
      *   the set of visits the GROUP BY produced, so a visit matching several actions still counts
      *   once against the LIMIT (see https://github.com/matomo-org/matomo/issues/13861). MySQL can
-     *   then stop reading log_visit as soon as it has enough visits.
+     *   then stop reading log_visit as soon as it has enough visits, as long as an index serves the
+     *   order by. The visits log sorts by log_visit.idsite first when a single site is requested,
+     *   which the idsite indexes of log_visit serve. Sorting several sites at once has no index to
+     *   use, so the outer query still sorts every visit the query matched before the LIMIT applies.
      *
      * @param string          $select         Select clause, has to select from log_visit only.
      * @param string          $from           Generated join string.
@@ -187,14 +196,7 @@ class LogQueryBuilder
             return null;
         }
 
-        if (!$this->referencesLogVisitOnly($where) || !$this->referencesLogVisitOnly($orderBy)) {
-            return null;
-        }
-
-        // the caller's conditions are rewritten to the alias, which would rewrite the inside of a
-        // subquery that selects from log_visit as well. Those references belong to the log_visit of
-        // that subquery, so the query has to stay grouped instead.
-        if (preg_match('/\bSELECT\b/i', (string) $where)) {
+        if (!$this->canRewriteLogVisitReferences($where) || !$this->canRewriteLogVisitReferences($orderBy)) {
             return null;
         }
 
@@ -250,18 +252,36 @@ class LogQueryBuilder
     }
 
     /**
+     * Whether an expression of the caller can be carried over into the rewritten query. It has to
+     * reference log_visit and nothing else, and it has to reference it in the form the rewrite below
+     * understands, because the rewrite renames the outer log_visit: a reference it does not replace
+     * ends up pointing at a table the rewritten query does not have.
+     *
      * @param string|false $sqlExpression
      * @return bool
      */
-    private function referencesLogVisitOnly($sqlExpression)
+    private function canRewriteLogVisitReferences($sqlExpression)
     {
-        foreach (SegmentExpression::parseColumnsFromSqlExpr((string) $sqlExpression) as $column) {
+        $sqlExpression = (string) $sqlExpression;
+
+        foreach (SegmentExpression::parseColumnsFromSqlExpr($sqlExpression) as $column) {
             if (strpos($column, 'log_visit.') !== 0) {
                 return false;
             }
         }
 
-        return true;
+        // a subquery selects from log_visit itself, so the references inside it belong to that
+        // log_visit and must not be pointed at the renamed outer one
+        if (preg_match('/\bSELECT\b/i', $sqlExpression)) {
+            return false;
+        }
+
+        // parseColumnsFromSqlExpr() reads `log_visit`.idsite as a log_visit column while the rewrite
+        // only replaces the unquoted form, so check what the rewrite leaves behind instead of
+        // trusting the two to read the expression the same way
+        $aliased = $this->aliasLogVisitTable($sqlExpression, self::LOG_VISIT_OUTER_ALIAS);
+
+        return !preg_match(self::LOG_VISIT_REFERENCE_REGEX, $aliased);
     }
 
     /**

--- a/core/Segment.php
+++ b/core/Segment.php
@@ -607,8 +607,12 @@ class Segment
      * @param false|string $groupBy (optional) Group by clause, eg, `"t2.col2"`.
      * @param int $limit Limit number of result to $limit
      * @param int $offset Specified the offset of the first row to return
-     * @param bool $forceGroupBy Force the group by and not using a subquery. Note: This may make the query slower see https://github.com/matomo-org/matomo/issues/9200#issuecomment-183641293
-     *                           A $groupBy value needs to be set for this to work.
+     * @param bool $forceGroupBy Keep the group by in the query instead of moving it into a subquery,
+     *                           see https://github.com/matomo-org/matomo/issues/9200#issuecomment-183641293
+     *                           A $groupBy value needs to be set for this to work. A query that groups
+     *                           visits by `log_visit.idvisit` while selecting and sorting log_visit rows
+     *                           gets the group by replaced by a subquery that matches the joined tables,
+     *                           which returns the same visits without sorting the whole date range first.
      * @return array{sql: string, bind: array<scalar>} The entire select query.
      */
     public function getSelectQuery($select, $from, $where = false, $bind = array(), $orderBy = false, $groupBy = false, $limit = 0, $offset = 0, $forceGroupBy = false, bool $withRollup = false)

--- a/core/Segment.php
+++ b/core/Segment.php
@@ -609,10 +609,12 @@ class Segment
      * @param int $offset Specified the offset of the first row to return
      * @param bool $forceGroupBy Keep the group by in the query instead of moving it into a subquery,
      *                           see https://github.com/matomo-org/matomo/issues/9200#issuecomment-183641293
-     *                           A $groupBy value needs to be set for this to work. A query that groups
-     *                           visits by `log_visit.idvisit` while selecting and sorting log_visit rows
-     *                           gets the group by replaced by a subquery that matches the joined tables,
-     *                           which returns the same visits without sorting the whole date range first.
+     *                           A $groupBy value needs to be set for this to work. When the [Live]
+     *                           use_semi_join_query setting is enabled, which it is not by default, a
+     *                           query built the way the visits log builds it can get the group by
+     *                           replaced by a subquery matching the joined tables instead, which
+     *                           returns the same visits without sorting the whole date range first.
+     *                           Every other query keeps the group by.
      * @return array{sql: string, bind: array<scalar>} The entire select query.
      */
     public function getSelectQuery($select, $from, $where = false, $bind = array(), $orderBy = false, $groupBy = false, $limit = 0, $offset = 0, $forceGroupBy = false, bool $withRollup = false)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -371,16 +371,6 @@ parameters:
 			path: core/DataAccess/ArchivingDbAdapter.php
 
 		-
-			message: "#^Parameter \\#3 \\$where of method Piwik\\\\DataAccess\\\\LogQueryBuilder\\:\\:buildSelectQuery\\(\\) expects string, false given\\.$#"
-			count: 1
-			path: core/DataAccess/LogQueryBuilder.php
-
-		-
-			message: "#^Parameter \\#6 \\$limitAndOffset of method Piwik\\\\DataAccess\\\\LogQueryBuilder\\:\\:buildSelectQuery\\(\\) expects int\\|string, null given\\.$#"
-			count: 1
-			path: core/DataAccess/LogQueryBuilder.php
-
-		-
 			message: "#^Call to an undefined method Piwik\\\\Db\\|Piwik\\\\Db\\\\AdapterInterface\\|Piwik\\\\Tracker\\\\Db\\:\\:fetchCol\\(\\)\\.$#"
 			count: 2
 			path: core/DataAccess/Model.php

--- a/plugins/Live/tests/Integration/ModelTest.php
+++ b/plugins/Live/tests/Integration/ModelTest.php
@@ -351,6 +351,135 @@ class ModelTest extends IntegrationTestCase
         $this->assertEquals(SegmentTest::removeExtraWhiteSpaces($expectedBind), SegmentTest::removeExtraWhiteSpaces($bind));
     }
 
+    public function testMakeLogVisitsQueryStringWhenSegmentAndSemiJoinEnabled()
+    {
+        $this->enableSemiJoinQuery();
+
+        $model = new Model();
+        [$dateStart, $dateEnd] = $model->getStartAndEndDate($idSite = 1, 'month', '2010-01-01');
+        [$sql, $bind] = $model->makeLogVisitsQueryString(
+            $idSite = 1,
+            $dateStart,
+            $dateEnd,
+            $segment = 'siteSearchCategory==Test',
+            $offset = 10,
+            $limit = 100,
+            $visitorId = 'abc',
+            $minTimestamp = false,
+            $filterSortOrder = false
+        );
+
+        // the joined table moves into a subquery, so the group by that removed the visits it
+        // duplicated is no longer needed
+        $expectedSql = ' SELECT log_visit_outer.*
+                        FROM log_visit AS log_visit_outer
+                        WHERE (
+                            log_visit_outer.idsite in (?)
+                            AND log_visit_outer.idvisitor = ?
+                            AND log_visit_outer.visit_last_action_time >= ?
+                            AND log_visit_outer.visit_last_action_time <= ? )
+                            AND ( EXISTS (
+                                SELECT 1
+                                FROM log_visit AS log_visit
+                                LEFT JOIN log_link_visit_action AS log_link_visit_action ON log_link_visit_action.idvisit = log_visit.idvisit
+                                WHERE log_visit.idvisit = log_visit_outer.idvisit
+                                    AND ( log_link_visit_action.search_cat = ? ) ) )
+                        ORDER BY log_visit_outer.idsite DESC, log_visit_outer.visit_last_action_time DESC, log_visit_outer.idvisit DESC
+                        LIMIT 10, 100';
+        $expectedBind = array(
+            '1',
+            Common::hex2bin('abc'),
+            '2010-01-01 00:00:00',
+            '2010-02-01 00:00:00',
+            'Test',
+        );
+        $this->assertEquals(SegmentTest::removeExtraWhiteSpaces($expectedSql), SegmentTest::removeExtraWhiteSpaces($sql));
+        $this->assertEquals(SegmentTest::removeExtraWhiteSpaces($expectedBind), SegmentTest::removeExtraWhiteSpaces($bind));
+    }
+
+    public function testMakeLogVisitsQueryStringWhenSegmentOnlyUsesTheVisitTable()
+    {
+        $this->enableSemiJoinQuery();
+
+        $model = new Model();
+        [$dateStart, $dateEnd] = $model->getStartAndEndDate($idSite = 1, 'month', '2010-01-01');
+        [$sql, $bind] = $model->makeLogVisitsQueryString(
+            $idSite = 1,
+            $dateStart,
+            $dateEnd,
+            $segment = 'countryCode==fr',
+            $offset = 0,
+            $limit = 100,
+            $visitorId = false,
+            $minTimestamp = false,
+            $filterSortOrder = false
+        );
+
+        // nothing is joined that could return a visit twice, so there is nothing to group
+        $expectedSql = ' SELECT log_visit.*
+                        FROM log_visit AS log_visit
+                        WHERE (
+                            log_visit.idsite in (?)
+                            AND log_visit.visit_last_action_time >= ?
+                            AND log_visit.visit_last_action_time <= ? )
+                            AND ( log_visit.location_country = ? )
+                        ORDER BY log_visit.idsite DESC, log_visit.visit_last_action_time DESC, log_visit.idvisit DESC
+                        LIMIT 0, 100';
+        $expectedBind = array(
+            '1',
+            '2010-01-01 00:00:00',
+            '2010-02-01 00:00:00',
+            'fr',
+        );
+        $this->assertEquals(SegmentTest::removeExtraWhiteSpaces($expectedSql), SegmentTest::removeExtraWhiteSpaces($sql));
+        $this->assertEquals(SegmentTest::removeExtraWhiteSpaces($expectedBind), SegmentTest::removeExtraWhiteSpaces($bind));
+    }
+
+    public function testMakeLogVisitsQueryStringWhenSegmentCombinesTablesWithOr()
+    {
+        $this->enableSemiJoinQuery();
+
+        $model = new Model();
+        [$dateStart, $dateEnd] = $model->getStartAndEndDate($idSite = 1, 'month', '2010-01-01');
+        [$sql, $bind] = $model->makeLogVisitsQueryString(
+            $idSite = 1,
+            $dateStart,
+            $dateEnd,
+            $segment = 'siteSearchCategory==Test,countryCode==fr',
+            $offset = 0,
+            $limit = 100,
+            $visitorId = false,
+            $minTimestamp = false,
+            $filterSortOrder = false
+        );
+
+        // the condition on log_visit cannot be pulled out of the OR, so the whole segment stays
+        // inside the subquery, where log_visit is available as well
+        $expectedSql = ' SELECT log_visit_outer.*
+                        FROM log_visit AS log_visit_outer
+                        WHERE (
+                            log_visit_outer.idsite in (?)
+                            AND log_visit_outer.visit_last_action_time >= ?
+                            AND log_visit_outer.visit_last_action_time <= ? )
+                            AND ( EXISTS (
+                                SELECT 1
+                                FROM log_visit AS log_visit
+                                LEFT JOIN log_link_visit_action AS log_link_visit_action ON log_link_visit_action.idvisit = log_visit.idvisit
+                                WHERE log_visit.idvisit = log_visit_outer.idvisit
+                                    AND (( log_link_visit_action.search_cat = ? OR log_visit.location_country = ? )) ) )
+                        ORDER BY log_visit_outer.idsite DESC, log_visit_outer.visit_last_action_time DESC, log_visit_outer.idvisit DESC
+                        LIMIT 0, 100';
+        $expectedBind = array(
+            '1',
+            '2010-01-01 00:00:00',
+            '2010-02-01 00:00:00',
+            'Test',
+            'fr',
+        );
+        $this->assertEquals(SegmentTest::removeExtraWhiteSpaces($expectedSql), SegmentTest::removeExtraWhiteSpaces($sql));
+        $this->assertEquals(SegmentTest::removeExtraWhiteSpaces($expectedBind), SegmentTest::removeExtraWhiteSpaces($bind));
+    }
+
     public function testMakeLogVisitsQueryStringAddsMaxExecutionHintIfConfigured()
     {
         $this->setMaxExecutionTime(30);
@@ -771,6 +900,172 @@ class ModelTest extends IntegrationTestCase
         $general = $config->General;
         $general['live_query_max_execution_time'] = $time;
         $config->General = $general;
+    }
+
+    /**
+     * @see https://github.com/matomo-org/matomo/issues/13861
+     */
+    public function testQueryLogVisitsReturnsAVisitOnceWhenSeveralOfItsActionsMatchTheSegment()
+    {
+        $this->enableSemiJoinQuery();
+
+        $this->trackVisitWithPageUrls('2010-03-01 03:00:00', ['/needle/one', '/needle/two', '/needle/three']);
+        $this->trackVisitWithPageUrls('2010-03-01 04:00:00', ['/haystack']);
+
+        $visits = $this->queryVisitsLog('actionUrl=@needle', $offset = 0, $limit = 10);
+
+        $this->assertCount(1, $visits);
+        $this->assertEquals('2010-03-01 03:00:00', $visits[0]['visit_first_action_time']);
+    }
+
+    /**
+     * @see https://github.com/matomo-org/matomo/issues/13861
+     */
+    public function testQueryLogVisitsFillsTheLimitWithDistinctVisitsWhenSeveralActionsMatchTheSegment()
+    {
+        $this->enableSemiJoinQuery();
+
+        for ($visit = 1; $visit <= 5; $visit++) {
+            $this->trackVisitWithPageUrls('2010-03-02 0' . $visit . ':00:00', ['/needle/one', '/needle/two', '/needle/three']);
+        }
+
+        $visits = $this->queryVisitsLog('actionUrl=@needle', $offset = 0, $limit = 3, '2010-03-02');
+
+        $this->assertCount(3, $visits);
+        $this->assertCount(3, array_unique(array_column($visits, 'idvisit')));
+    }
+
+    public function testQueryLogVisitsPagesThroughDistinctVisitsWhenSeveralActionsMatchTheSegment()
+    {
+        $this->enableSemiJoinQuery();
+
+        for ($visit = 1; $visit <= 5; $visit++) {
+            $this->trackVisitWithPageUrls('2010-03-03 0' . $visit . ':00:00', ['/needle/one', '/needle/two']);
+        }
+
+        $all = array_column($this->queryVisitsLog('actionUrl=@needle', 0, 10, '2010-03-03'), 'idvisit');
+        $this->assertCount(5, $all);
+
+        $page = array_column($this->queryVisitsLog('actionUrl=@needle', 2, 2, '2010-03-03'), 'idvisit');
+
+        $this->assertEquals(array_slice($all, 2, 2), $page);
+    }
+
+    /**
+     * With the setting on, the visits log asks the joined log tables for a match instead of
+     * grouping their rows away. Both forms have to select the same visits, whichever tables the
+     * segment touches and however its conditions are combined.
+     *
+     * @dataProvider getSegmentsAcrossLogTables
+     */
+    public function testMakeLogVisitsQueryStringSelectsTheSameVisitsWithTheSettingOnAsOff($segment, $offset, $limit, $order)
+    {
+        $this->trackVisitWithPageUrls('2010-03-04 01:00:00', ['/needle/one', '/needle/two', '/needle/three'], 'someone@example.com');
+        $this->trackVisitWithPageUrls('2010-03-04 02:00:00', ['/haystack'], 'nobody@example.com');
+        $this->trackVisitWithPageUrls('2010-03-04 03:00:00', ['/needle/one'], 'nobody@example.com');
+        $this->trackVisitWithPageUrls('2010-03-04 04:00:00', ['/haystack/one', '/haystack/two'], 'someone@example.com');
+        $this->trackVisitWithPageUrls('2010-03-04 05:00:00', ['/needle/one', '/haystack/two'], 'nobody@example.com');
+
+        [$groupedSql, $groupedBind] = $this->visitsLogQuery($segment, $offset, $limit, $order, '2010-03-04');
+
+        // guard against the setting leaking in from an earlier test, which would compare the same
+        // query with itself and pass without testing anything
+        $this->assertStringContainsString('GROUP BY', $groupedSql);
+
+        $grouped = array_column(Db::fetchAll($groupedSql, $groupedBind), 'idvisit');
+
+        if (0 === $offset) {
+            // make sure the segments actually select something, so the comparison cannot pass empty
+            $this->assertNotEmpty($grouped);
+        }
+
+        $this->enableSemiJoinQuery();
+
+        [$semiJoinSql, $semiJoinBind] = $this->visitsLogQuery($segment, $offset, $limit, $order, '2010-03-04');
+        $this->assertStringNotContainsString('GROUP BY', $semiJoinSql);
+
+        $this->assertEquals($grouped, array_column(Db::fetchAll($semiJoinSql, $semiJoinBind), 'idvisit'));
+    }
+
+    public function getSegmentsAcrossLogTables()
+    {
+        $segments = [
+            'actionUrl=@needle',
+            'actionUrl=@needle;userId==someone@example.com',
+            'actionUrl=@needle,userId==someone@example.com',
+            'actionUrl=@needle;pageTitle=@Page',
+            'actionUrl=@needle,pageTitle=@haystack',
+            'actionUrl!@needle',
+            'userId==someone@example.com',
+            'entryPageUrl=@needle',
+        ];
+
+        $cases = [];
+        foreach ($segments as $segment) {
+            foreach ([['DESC', 0, 10], ['ASC', 0, 10], ['DESC', 2, 2], ['ASC', 1, 3]] as [$order, $offset, $limit]) {
+                $cases["$segment $order $offset,$limit"] = [$segment, $offset, $limit, $order];
+            }
+        }
+
+        return $cases;
+    }
+
+    private function enableSemiJoinQuery(): void
+    {
+        $config = Config::getInstance();
+        $live = $config->Live;
+        $live['use_semi_join_query'] = 1;
+        $config->Live = $live;
+    }
+
+    private function queryVisitsLog(string $segment, int $offset, int $limit, string $date = '2010-03-01'): array
+    {
+        return (new Model())->queryLogVisits(
+            1,
+            'day',
+            $date,
+            $segment,
+            $offset,
+            $limit,
+            $visitorId = false,
+            $minTimestamp = false,
+            $filterSortOrder = 'desc'
+        );
+    }
+
+    private function visitsLogQuery(string $segment, int $offset, int $limit, string $order, string $date): array
+    {
+        $model = new Model();
+        [$dateStart, $dateEnd] = $model->getStartAndEndDate(1, 'day', $date);
+
+        return $model->makeLogVisitsQueryString(
+            1,
+            $dateStart,
+            $dateEnd,
+            $segment,
+            $offset,
+            $limit,
+            $visitorId = false,
+            $minTimestamp = false,
+            $order
+        );
+    }
+
+    private function trackVisitWithPageUrls(string $dateTime, array $urls, ?string $userId = null): void
+    {
+        $t = Fixture::getTracker(1, $dateTime, $defaultInit = true);
+        $t->setTokenAuth(Fixture::getTokenAuth());
+        $t->setNewVisitorId();
+
+        if (null !== $userId) {
+            $t->setUserId($userId);
+        }
+
+        foreach (array_values($urls) as $index => $url) {
+            $t->setForceVisitDateTime(Date::factory($dateTime)->addPeriod($index, 'minute')->getDatetime());
+            $t->setUrl('http://example.org' . $url);
+            Fixture::checkResponse($t->doTrackPageView('Page ' . $url));
+        }
     }
 
     private function trackPageView(): void

--- a/tests/PHPUnit/Integration/SegmentTest.php
+++ b/tests/PHPUnit/Integration/SegmentTest.php
@@ -2420,6 +2420,83 @@ SQL;
         $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
     }
 
+    public function testGetSelectQueryWithForceGroupByKeepsTheGroupByWhenTheWhereQuotesTheVisitTable()
+    {
+        // the conditions of the caller are rewritten to an alias of log_visit, and the rewrite only
+        // replaces the unquoted form of the table name. A quoted reference would be left pointing at
+        // a table the rewritten query does not have, so those queries keep the group by.
+        $this->enableVisitsLogSemiJoinQuery();
+
+        $logVisit = Common::prefixTable('log_visit');
+        $segment = new Segment('siteSearchCategory==Test', $idSites = array());
+
+        $query = $segment->getSelectQuery(
+            'log_visit.*',
+            'log_visit',
+            '`log_visit`.idsite = ?',
+            array(1),
+            'log_visit.visit_last_action_time DESC',
+            'log_visit.idvisit',
+            $limit = 100,
+            $offset = 0,
+            $forceGroupBy = true
+        );
+
+        $this->assertQueryDoesNotFail($query);
+
+        $expected = array(
+            'sql' => 'SELECT log_visit.*
+                      FROM ' . $logVisit . ' AS log_visit
+                      LEFT JOIN ' . Common::prefixTable('log_link_visit_action') . ' AS log_link_visit_action ON log_link_visit_action.idvisit = log_visit.idvisit
+                      WHERE ( `log_visit`.idsite = ? )
+                        AND ( log_link_visit_action.search_cat = ? )
+                      GROUP BY log_visit.idvisit
+                      ORDER BY log_visit.visit_last_action_time DESC LIMIT 0, 100',
+            'bind' => array(1, 'Test'),
+        );
+
+        $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
+    }
+
+    public function testGetSelectQueryWithForceGroupByKeepsTheGroupByWhenTheOrderByContainsASubquery()
+    {
+        // the sorting of the caller is rewritten to an alias of log_visit just like its conditions
+        // are, which would rewrite the inside of a subquery selecting from log_visit too. Those
+        // queries keep the group by.
+        $this->enableVisitsLogSemiJoinQuery();
+
+        $logVisit = Common::prefixTable('log_visit');
+        $orderBy = '(log_visit.idvisit IN (SELECT log_visit.idvisit FROM ' . $logVisit . ' AS log_visit WHERE log_visit.location_country = \'fr\')) DESC, log_visit.visit_last_action_time DESC';
+        $segment = new Segment('siteSearchCategory==Test', $idSites = array());
+
+        $query = $segment->getSelectQuery(
+            'log_visit.*',
+            'log_visit',
+            'log_visit.idsite = ?',
+            array(1),
+            $orderBy,
+            'log_visit.idvisit',
+            $limit = 100,
+            $offset = 0,
+            $forceGroupBy = true
+        );
+
+        $this->assertQueryDoesNotFail($query);
+
+        $expected = array(
+            'sql' => 'SELECT log_visit.*
+                      FROM ' . $logVisit . ' AS log_visit
+                      LEFT JOIN ' . Common::prefixTable('log_link_visit_action') . ' AS log_link_visit_action ON log_link_visit_action.idvisit = log_visit.idvisit
+                      WHERE ( log_visit.idsite = ? )
+                        AND ( log_link_visit_action.search_cat = ? )
+                      GROUP BY log_visit.idvisit
+                      ORDER BY ' . $orderBy . ' LIMIT 0, 100',
+            'bind' => array(1, 'Test'),
+        );
+
+        $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
+    }
+
     private function enableVisitsLogSemiJoinQuery(): void
     {
         $config = Config::getInstance();

--- a/tests/PHPUnit/Integration/SegmentTest.php
+++ b/tests/PHPUnit/Integration/SegmentTest.php
@@ -2346,6 +2346,88 @@ SQL;
         $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
     }
 
+    public function testGetSelectQueryWithForceGroupByKeepsTheGroupByWhenTheQueryIsNotAboutVisitsOnly()
+    {
+        // the visits log lets a subquery match the joined tables instead of grouping their rows away,
+        // which only returns the same rows when the query selects and sorts log_visit rows. Every
+        // other query keeps the grouped shape.
+        $this->enableVisitsLogSemiJoinQuery();
+
+        $segment = new Segment('siteSearchCategory==Test', $idSites = array());
+
+        $query = $segment->getSelectQuery(
+            'log_visit.idvisit, log_link_visit_action.idaction_url',
+            'log_visit',
+            'log_visit.idsite = ?',
+            array(1),
+            'log_visit.visit_last_action_time DESC',
+            'log_visit.idvisit',
+            $limit = 100,
+            $offset = 0,
+            $forceGroupBy = true
+        );
+
+        $this->assertQueryDoesNotFail($query);
+
+        $expected = array(
+            'sql' => 'SELECT log_visit.idvisit, log_link_visit_action.idaction_url
+                      FROM ' . Common::prefixTable('log_visit') . ' AS log_visit
+                      LEFT JOIN ' . Common::prefixTable('log_link_visit_action') . ' AS log_link_visit_action ON log_link_visit_action.idvisit = log_visit.idvisit
+                      WHERE ( log_visit.idsite = ? )
+                        AND ( log_link_visit_action.search_cat = ? )
+                      GROUP BY log_visit.idvisit
+                      ORDER BY log_visit.visit_last_action_time DESC LIMIT 0, 100',
+            'bind' => array(1, 'Test'),
+        );
+
+        $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
+    }
+
+    public function testGetSelectQueryWithForceGroupByKeepsTheGroupByWhenTheWhereContainsASubquery()
+    {
+        // the conditions of the caller are rewritten to an alias of log_visit, which would rewrite
+        // the inside of a subquery selecting from log_visit too. Those queries keep the group by.
+        $this->enableVisitsLogSemiJoinQuery();
+
+        $logVisit = Common::prefixTable('log_visit');
+        $segment = new Segment('siteSearchCategory==Test', $idSites = array());
+
+        $query = $segment->getSelectQuery(
+            'log_visit.*',
+            'log_visit',
+            'log_visit.idsite = ? AND log_visit.idvisit IN (SELECT log_visit.idvisit FROM ' . $logVisit . ' AS log_visit WHERE log_visit.location_country = ?)',
+            array(1, 'fr'),
+            'log_visit.visit_last_action_time DESC',
+            'log_visit.idvisit',
+            $limit = 100,
+            $offset = 0,
+            $forceGroupBy = true
+        );
+
+        $this->assertQueryDoesNotFail($query);
+
+        $expected = array(
+            'sql' => 'SELECT log_visit.*
+                      FROM ' . $logVisit . ' AS log_visit
+                      LEFT JOIN ' . Common::prefixTable('log_link_visit_action') . ' AS log_link_visit_action ON log_link_visit_action.idvisit = log_visit.idvisit
+                      WHERE ( log_visit.idsite = ? AND log_visit.idvisit IN (SELECT log_visit.idvisit FROM ' . $logVisit . ' AS log_visit WHERE log_visit.location_country = ?) )
+                        AND ( log_link_visit_action.search_cat = ? )
+                      GROUP BY log_visit.idvisit
+                      ORDER BY log_visit.visit_last_action_time DESC LIMIT 0, 100',
+            'bind' => array(1, 'fr', 'Test'),
+        );
+
+        $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
+    }
+
+    private function enableVisitsLogSemiJoinQuery(): void
+    {
+        $config = Config::getInstance();
+        $live = $config->Live;
+        $live['use_semi_join_query'] = 1;
+        $config->Live = $live;
+    }
+
     public function testSegmentExpressionParseSubExpressionsIntoSqlExpressionsRecognizesAvailableTablesCorrectly()
     {
         $segment = 'pageTitle=@abc';

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:563ecfe4f792095fb68c0f0c8b8bee07625374a8eab08e49b5c63ef67b7779d6
-size 5645302
+oid sha256:3c395e93c8592ffbb65b3ee1158909b86c595f844d890c6c7f7f083baf62e0f3
+size 5658792

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6625604dcea7fe046fd70ab704f98dc60b3eaa641087c11f4ed577b081078fc9
-size 5604355
+oid sha256:563ecfe4f792095fb68c0f0c8b8bee07625374a8eab08e49b5c63ef67b7779d6
+size 5645302


### PR DESCRIPTION
Implements [DEV-20719](https://innocraft.atlassian.net/browse/DEV-20719). Targets 5.x-dev first; the 6.x-dev forward port follows once this is approved.

### What

The visits log is slow when an action level segment is applied, e.g. `actionUrl=@something`. This adds a faster query shape behind a new setting, off by default.

### Why it is slow today

`Live\Model::makeLogVisitsQueryString()` asks `Segment::getSelectQuery()` for `GROUP BY log_visit.idvisit` so that a visit matching several actions is still returned once (#13861, fixed by #14963). The group by is on idvisit but the order by is on `visit_last_action_time`, so MySQL has to buffer and sort every matching visit before it can apply the LIMIT. `Extra` on the driving table is `Using temporary; Using filesort`, the LIMIT never short circuits, and the query costs as much as the whole date range even though only 100 rows come back.

### The setting

```ini
[Live]
use_semi_join_query = 0
```

With it off, the generated SQL is byte for byte what it is today, which is what the existing SQL assertions in `ModelTest` now pin. With it on the query is built so it returns one row per visit without grouping.

When log_visit is the only table the group by is simply dropped, since `log_visit.idvisit` is the primary key of that table and grouping by it cannot merge anything. When other log tables are joined they move into a correlated `EXISTS` subquery, which is true for a visit exactly when at least one of its joined rows matches the segment. That is the same set of visits the group by produced, so the LIMIT counts distinct visits again and MySQL can stop reading log_visit once it has enough.

```sql
SELECT log_visit_outer.*
FROM log_visit AS log_visit_outer
WHERE ( log_visit_outer.idsite in (?) AND log_visit_outer.visit_last_action_time >= ? AND log_visit_outer.visit_last_action_time <= ? )
  AND EXISTS (
      SELECT 1
      FROM log_visit AS log_visit
        LEFT JOIN log_link_visit_action ON log_link_visit_action.idvisit = log_visit.idvisit
        LEFT JOIN log_action AS ... ON log_link_visit_action.idaction_url = ....idaction
      WHERE log_visit.idvisit = log_visit_outer.idvisit
        AND ( ...segment conditions... ))
ORDER BY log_visit_outer.idsite DESC, log_visit_outer.visit_last_action_time DESC, log_visit_outer.idvisit DESC
LIMIT 0, 100
```

The join tree and the segment SQL inside the subquery are exactly what is generated today, only the outer log_visit is aliased. That is deliberate: segment conditions can contain subqueries that select from log_visit again, `actionUrl!@x` produces `log_visit.idvisit NOT IN (SELECT log_visit.idvisit FROM log_visit ...)`, and renaming inside those would break them. It also means segments that mix tables with OR need no special casing, since the whole segment moves across unsplit.

The rewrite only applies when the query selects and sorts log_visit rows and joins everything else on log_visit, which is the visits log query. `LogAggregator` and the other `getSelectQuery()` callers do not match and keep the grouped query, and so does a caller whose own conditions contain a subquery selecting from log_visit. There are tests for both.

### Numbers

Measured on a test dataset of ~130M visits for one site, single run per point, warm, `actionUrl=@needle` with `filter_limit=100`. Before:

| Date range | Time |
|---|---|
| 1 day | 46s |
| 2 days | 85s |
| 4 days | 153s |
| 8 days | 350s |
| 14 days | 499s |
| 30 days | did not finish within 600s |

On a smaller local dataset (300k visits, 1.2M actions, 0.8% of visits matching) the two shapes return the same 100 idvisits in the same order for every range:

| Date range | setting off | setting on |
|---|---|---|
| 1 day | 0.84s | 0.31s |
| 4 days | 0.72s | 0.32s |
| 14 days | 4.20s | 0.20s |
| 27 days | 7.92s | 0.18s |

`EXPLAIN` goes from `Using index condition; Using temporary; Using filesort` on log_visit to a `Backward index scan` with `FirstMatch`, no temporary and no filesort.

Worth being clear about the limit of this. It does not make a leading wildcard `LIKE '%x%'` on `log_action.name` indexable, so a segment that matches nothing over a long range still has to walk the whole range and takes about as long as it does today (8.7-10.2s before vs 7.6-9.4s after on the local dataset, so no regression, but no win either). The win is for the normal case where the segment does match something and the LIMIT can be filled.

### Tests

`plugins/Live/tests/Integration/ModelTest.php`:

- the existing SQL assertions stay on the grouped shape, which is what the default produces
- new SQL assertions for the shape with the setting on, for a visit level segment, an action level segment and a segment combining tables with OR
- a regression test for #13861 with the setting on: a visit with three matching actions comes back once, and `filter_limit` returns that many distinct visits, with paging
- an equivalence test running 8 segments x 4 order/offset combinations with the setting off and then on, asserting identical idvisit lists. It also asserts the first query really does contain `GROUP BY` and the second really does not, so the comparison cannot pass by comparing a query with itself.

`tests/PHPUnit/Integration/SegmentTest.php` pins that with the setting on, a `$forceGroupBy = true` query which is not about log_visit rows, and one whose where clause contains a subquery, both keep the grouped shape.

I checked the regression tests fail if the group by is dropped without the subquery, and that the subquery test fails if the guard is removed.

### Checklist
[✔] I have understood, reviewed, and tested all AI outputs before use
[✔] All AI instructions respect security, IP, and privacy rules


[DEV-20719]: https://innocraft.atlassian.net/browse/DEV-20719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ