### PR TITLE
Keep regex metacharacters intact when excluding URL parameters

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -1039,7 +1039,10 @@ default_time_one_page_visit = 0
 ; and advertising/attribution tracking parameters)
 ; An entry can either be a parameter name (eg. gclid) or a regular expression including its delimiters, as used below.
 ; As this list is split on commas, a regular expression must not contain a
-; comma. Matching is case insensitive, so entries should always be written in lower case.
+; comma. Parameter names are matched case-insensitively, so literal entries should be
+; written in lower case. Regular expressions are not lowercased: keep uppercase
+; metacharacters (\D, \S, \W, \P, \Q...\E) as written, and write any literal text
+; in the pattern in lower case.
 url_query_parameter_to_exclude_from_url = "gclid,fbclid,msclkid,twclid,wbraid,gbraid,yclid,fb_xd_fragment,fb_comment_id,phpsessid,jsessionid,sessionid,aspsessionid,doing_wp_cron,sid,pk_vid,li_fat_id,token_auth,token,gad_source,gad_campaignid,/^hsa_(acc|ad|cam|grp|kw|la|mt|net|ol|src|tgt|ver)$/"
 
 ; If set to 1, Matomo will use the default provider if no other provider is configured.

--- a/core/Tracker/PageUrl.php
+++ b/core/Tracker/PageUrl.php
@@ -105,8 +105,22 @@ class PageUrl
             Common::printDebug('Excluding parameters "' . implode(',', $parametersToExclude) . '" from URL');
         }
 
-        $parametersToExclude = array_map('strtolower', $parametersToExclude);
+        $parametersToExclude = array_map([self::class, 'lowercaseLiteralExcludedParameter'], $parametersToExclude);
         return $parametersToExclude;
+    }
+
+    /**
+     * Parameter names are matched case-insensitively, so literals are lowercased.
+     * Regex patterns are left unchanged: lowercasing would rewrite metacharacters
+     * such as \D, \S, \W, \P and \Q...\E.
+     */
+    private static function lowercaseLiteralExcludedParameter($parameter)
+    {
+        if (is_string($parameter) && @preg_match($parameter, '') !== false) {
+            return $parameter;
+        }
+
+        return is_string($parameter) ? strtolower($parameter) : $parameter;
     }
 
     /**

--- a/tests/PHPUnit/Unit/Tracker/PageUrlTest.php
+++ b/tests/PHPUnit/Unit/Tracker/PageUrlTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Unit\Tracker;
+
+use Piwik\Config;
+use Piwik\Tests\Framework\TestCase\UnitTestCase;
+use Piwik\Tracker\PageUrl;
+
+/**
+ * @group Core
+ * @group PageUrlTest
+ */
+class PageUrlTest extends UnitTestCase
+{
+    public function testGetQueryParametersToExcludeDoesNotLowercaseRegexMetacharacters()
+    {
+        $this->setExcludedQueryParameters('/^ad_\D+$/,/^ad_\Q.x\E$/,SessionID');
+
+        $excluded = PageUrl::getQueryParametersToExclude(0);
+
+        $this->assertContains('/^ad_\D+$/', $excluded);
+        $this->assertNotContains('/^ad_\d+$/', $excluded);
+        $this->assertContains('/^ad_\Q.x\E$/', $excluded);
+        $this->assertContains('sessionid', $excluded);
+        $this->assertNotContains('SessionID', $excluded);
+    }
+
+    /**
+     * @dataProvider getUppercaseRegexMetacharacterUrls
+     */
+    public function testExcludeQueryParametersFromUrlPreservesUppercaseRegexMetacharacters($excludedQueryParameters, $url, $expectedUrl)
+    {
+        $this->setExcludedQueryParameters($excludedQueryParameters);
+
+        $this->assertSame($expectedUrl, PageUrl::excludeQueryParametersFromUrl($url, 0));
+    }
+
+    public function getUppercaseRegexMetacharacterUrls()
+    {
+        return [
+            'non-digit pattern excludes letters' => [
+                '/^ad_\D+$/',
+                'http://example.com/index?ad_abc=1&keep=1',
+                'http://example.com/index?keep=1',
+            ],
+            'non-digit pattern keeps digits' => [
+                '/^ad_\D+$/',
+                'http://example.com/index?ad_123=1&keep=1',
+                'http://example.com/index?ad_123=1&keep=1',
+            ],
+            'quoted metacharacters stay quoted' => [
+                '/^ad_\Q.x\E$/',
+                'http://example.com/index?ad_.x=1&keep=1',
+                'http://example.com/index?keep=1',
+            ],
+            'shipped UI example still matches session params' => [
+                '/^sess.*|.*[dD]ate$/',
+                'http://example.com/index?sessionid=abc&keep=1',
+                'http://example.com/index?keep=1',
+            ],
+            'shipped UI example still matches Date after name is lowercased' => [
+                '/^sess.*|.*[dD]ate$/',
+                'http://example.com/index?Date=2026-01-01&keep=1',
+                'http://example.com/index?keep=1',
+            ],
+            'literal names remain case-insensitive' => [
+                'SessionID',
+                'http://example.com/index?sessionid=abc&keep=1',
+                'http://example.com/index?keep=1',
+            ],
+        ];
+    }
+
+    private function setExcludedQueryParameters($parameters)
+    {
+        $section = Config::getInstance()->Tracker;
+        $section['url_query_parameter_to_exclude_from_url'] = $parameters;
+        Config::getInstance()->Tracker = $section;
+    }
+}

--- a/tests/PHPUnit/Unit/UrlHelperTest.php
+++ b/tests/PHPUnit/Unit/UrlHelperTest.php
@@ -357,6 +357,22 @@ class UrlHelperTest extends \PHPUnit\Framework\TestCase
                 array('p1' => 'v1', 'p2' => 'v2', 'p3' => 'v3', 'p4' => 'v4', 'utm_source' => 'gekko', 'utm_medium' => 'email', 'utm_campaign' => 'daily'),
                 array('/p[1|3]/', '/utm_/'),
             ),
+            // uppercase regex metacharacters must keep their meaning (#25105)
+            array(
+                'keep=1',
+                array('ad_abc' => '1', 'keep' => '1'),
+                array('/^ad_\D+$/'),
+            ),
+            array(
+                'ad_123=1&keep=1',
+                array('ad_123' => '1', 'keep' => '1'),
+                array('/^ad_\D+$/'),
+            ),
+            array(
+                'keep=1',
+                array('ad_.x' => '1', 'keep' => '1'),
+                array('/^ad_\Q.x\E$/'),
+            ),
         );
     }
 


### PR DESCRIPTION
### Description

`PageUrl::getQueryParametersToExclude()` lowercased every excluded-parameter entry, regexes included. `UrlHelper::inArrayMatchesRegex()` then ran that lowercased string as the pattern.

Uppercase metacharacters change meaning rather than case, so this was silent and wrong:

- `/^ad_\D+$/` became `/^ad_\d+$/` and inverted the match
- `/^ad_\Q.x\E$/` became `/^ad_\q.x\e$/` and stopped being a valid regex, so the exclusion never fired

Literal parameter names are still lowercased, so matching stays case-insensitive. Valid regex patterns are left as written. The example shipped in the UI, `/^sess.*|.*[dD]ate$/`, still matches because the parameter name is lowercased before comparison.

Fixes #25105

### Tests

- `PageUrlTest` covers `\D` inversion, `\Q...\E` quoting, the shipped session/date example, and literal case-insensitivity through `excludeQueryParametersFromUrl()`.
- `UrlHelperTest` adds matching cases for `\D` and `\Q...\E`.

Locally: `PageUrlTest` (7) and the `UrlHelperTest` exclusion cases (11) pass. PHPCS and PHPStan are clean on the touched files.

### Review

- [x] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [x] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about)
- [x] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done)
- [x] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [x] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [x] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [x] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [x] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [x] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [x] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
