### PR TITLE
Make DataTable Pattern filter Unicode case-insensitive

### DIFF
--- a/core/DataTable/Filter/Pattern.php
+++ b/core/DataTable/Filter/Pattern.php
@@ -61,7 +61,10 @@ class Pattern extends BaseFilter
     }
 
     /**
-     * Performs case insensitive match
+     * Performs a Unicode case-insensitive match.
+     *
+     * ASCII-only `/i` does not fold letters such as å/ä/ö, so a search for
+     * "öppettider" would miss the label "Öppettider".
      *
      * @param string $patternQuoted
      * @param string $string
@@ -71,7 +74,7 @@ class Pattern extends BaseFilter
      */
     public static function match($patternQuoted, $string, $invertedMatch = false)
     {
-        return preg_match($patternQuoted . "i", $string) == 1 ^ $invertedMatch;
+        return preg_match($patternQuoted . 'iu', $string) == 1 ^ $invertedMatch;
     }
 
     /**

--- a/tests/PHPUnit/Unit/DataTable/Filter/PatternTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/PatternTest.php
@@ -123,4 +123,39 @@ class PatternTest extends \PHPUnit\Framework\TestCase
             array('org', array(2, 5)),
         );
     }
+
+    /**
+     * @dataProvider getUnicodeCaseInsensitiveData
+     */
+    public function testMatchIsUnicodeCaseInsensitive($pattern, $string, $shouldMatch)
+    {
+        $quoted = DataTable\Filter\Pattern::getPatternQuoted($pattern);
+        $this->assertSame($shouldMatch, (bool) DataTable\Filter\Pattern::match($quoted, $string));
+    }
+
+    public function getUnicodeCaseInsensitiveData()
+    {
+        return [
+            'lowercase search finds title case' => ['öppettider', 'Öppettider', true],
+            'same casing still matches' => ['Öppettider', 'Öppettider', true],
+            'uppercase search finds title case' => ['ÖPPETTIDER', 'Öppettider', true],
+            'mixed casing search finds title case' => ['ÖpPeTtIdEr', 'Öppettider', true],
+            'unrelated word does not match' => ['öppettider', 'stängt', false],
+            'lowercase ä finds Ä' => ['äpple', 'Äpple', true],
+            'lowercase å finds Å' => ['ångest', 'Ångest', true],
+            'uppercase Ä finds ä' => ['ÄPPLE', 'äpple', true],
+        ];
+    }
+
+    public function testFilterPatternMatchesLowercaseUnicodeSearchAgainstTitleCaseLabel()
+    {
+        $table = new DataTable();
+        $table->addRowFromArray([Row::COLUMNS => ['label' => 'Öppettider']]);
+
+        $filteredTable = clone $table;
+        $filteredTable->filter('Pattern', ['label', 'öppettider']);
+
+        $this->assertCount(1, $filteredTable->getRows());
+        $this->assertSame('Öppettider', $filteredTable->getFirstRow()->getColumn('label'));
+    }
 }


### PR DESCRIPTION
### Description

The Page Titles search (and every other `DataTable` `Pattern` / `filter_pattern` match) used ASCII-only `/i`. That folds A–Z, but not letters such as å/ä/ö.

Searching for `Öppettider`, `ÖPPETTIDER` or `ÖpPeTtIdEr` found the title `Öppettider`, because the uppercase `Ö` in the query is the same code point as in the label. Searching for `öppettider` did not: `ö` and `Ö` are different code points, and `/i` does not fold them.

`Pattern::match()` now uses `/iu`. `PatternRecursive` already goes through that helper, so both filters pick this up. ASCII patterns are unchanged.

Fixes #25147

### Tests

`PatternTest` covers lowercase/uppercase/mixed `ö`, plus `ä`/`å` in both directions, and a full table filter for `öppettider` → `Öppettider`. Existing ASCII cases still pass (29 tests).

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
