### PR TITLE
Fix scheduled report period in HTML exports

### DIFF
--- a/core/ReportRenderer/Html.php
+++ b/core/ReportRenderer/Html.php
@@ -92,7 +92,7 @@ class Html extends ReportRenderer
             $reportMetadata,
             $segment,
             $this->idSite,
-            $this->report['period']
+            $this->report['period_param'] ?? $this->report['period']
         );
         $this->rendering .= $frontPageView->render();
     }

--- a/plugins/CoreHome/templates/ReportRenderer/_htmlReportHeader.twig
+++ b/plugins/CoreHome/templates/ReportRenderer/_htmlReportHeader.twig
@@ -8,7 +8,7 @@
         {% if isAttachedFile is defined and isAttachedFile %}
         {{ 'ScheduledReports_PleaseFindAttachedFile'|translate(frequency, reportTitle|escape|preventLinking)|raw }}
         {% else %}
-        {{ 'ScheduledReports_PleaseFindBelow'|translate(('Intl_Period' ~ period|capitalize)|translate, reportTitle|escape|preventLinking)|raw }}
+        {{ 'ScheduledReports_PleaseFindBelow'|translate((period == 'range' ? 'General_DateRangeInPeriodList' : 'Intl_Period' ~ period|capitalize)|translate, reportTitle|escape|preventLinking)|raw }}
         {% endif %}
         <br />{{ description|escape|preventLinking }}
         <br />{{ 'General_DateRange'|translate }} {{ prettyDate }}

--- a/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_schedrep_html_tables_only__ScheduledReports.generateReport_week.original.html
+++ b/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_schedrep_html_tables_only__ScheduledReports.generateReport_week.original.html
@@ -18,7 +18,7 @@
                             </a>
         </td>
         <td align="right">
-                        <a style="color:#212121;font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, 'Helvetica Neue', sans-serif;; font-size:16px; padding:0 15px; color: &#x23;646464" title="View Web Analytics reports for A very long name for a very tiny test site, that also reaches the 90 character limit fully." target="_blank" href="http://example.com/piwik/tests/PHPUnit/proxy/index.php?module=CoreHome&action=redirectToCoreHomeIndex&idSite=1&period=day&date=today-date-removed-in-tests">
+                        <a style="color:#212121;font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, 'Helvetica Neue', sans-serif;; font-size:16px; padding:0 15px; color: &#x23;646464" title="View Web Analytics reports for A very long name for a very tiny test site, that also reaches the 90 character limit fully." target="_blank" href="http://example.com/piwik/tests/PHPUnit/proxy/index.php?module=CoreHome&action=redirectToCoreHomeIndex&idSite=1&period=week&date=today-date-removed-in-tests">
                 Dashboard
             </a>
                     </td>
@@ -32,7 +32,7 @@
     </h2>
 
     <p style='font-size:15px;line-height:24px;margin:0 0 16px;color:#212121;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;'>
-                Please find below your day report for A very long name for a very tiny test site, that also reaches the 90 character limit fully.
+                Please find below your week report for A very long name for a very tiny test site, that also reaches the 90 character limit fully.
                 <br />Mail Test report with &lt;long&gt; déscription and some 🚀 $peciäl characters $%&amp;-~°^&#039;&quot;@#*ß§²³
         <br />Date range: week April 4 – 10, 2011
         <br />Sent from http://example.com/piwik/tests/PHPUnit/proxy/.

--- a/plugins/ScheduledReports/API.php
+++ b/plugins/ScheduledReports/API.php
@@ -796,7 +796,10 @@ class API extends \Piwik\Plugin\API
         // init report renderer
         $reportRenderer->setIdSite((int)$idSite);
         $reportRenderer->setLocale($language);
-        $reportRenderer->setReport($report);
+        // Render the effective period requested without changing the stored report passed to events.
+        $rendererReport = $report;
+        $rendererReport['period_param'] = $period;
+        $reportRenderer->setReport($rendererReport);
 
         // render report
         $reportName = str_replace(["\r", "\n"], ' ', Common::unsanitizeInputValue((string) $report['description']));

--- a/plugins/ScheduledReports/tests/Integration/ApiTest.php
+++ b/plugins/ScheduledReports/tests/Integration/ApiTest.php
@@ -949,6 +949,17 @@ class ApiTest extends IntegrationTestCase
         );
 
         self::assertStringContainsString('id="VisitsSummary_get"', $result);
+
+        $effectivePeriod = $period ?: Schedule::PERIOD_DAY;
+        $periodTranslationKey = $effectivePeriod === Schedule::PERIOD_RANGE
+            ? 'General_DateRangeInPeriodList'
+            : 'Intl_Period' . ucfirst($effectivePeriod);
+        $expectedHeader = Piwik::translate('ScheduledReports_PleaseFindBelow', [
+            Piwik::translate($periodTranslationKey),
+            Site::getNameFor(1),
+        ]);
+
+        self::assertStringContainsString($expectedHeader, $result);
     }
 
     /**
@@ -990,6 +1001,39 @@ class ApiTest extends IntegrationTestCase
             'last7',
             'range',
         ];
+    }
+
+    public function testGenerateReportUsesDefaultDataPeriodForNeverScheduledReport(): void
+    {
+        $idReport = APIScheduledReports::getInstance()->addReport(
+            1,
+            '',
+            Schedule::PERIOD_NEVER,
+            0,
+            ScheduledReports::EMAIL_TYPE,
+            ReportRenderer::HTML_FORMAT,
+            [
+                'VisitsSummary_get',
+            ],
+            [
+                ScheduledReports::DISPLAY_FORMAT_PARAMETER => ScheduledReports::DISPLAY_FORMAT_TABLES_ONLY,
+            ]
+        );
+
+        $result = APIScheduledReports::getInstance()->generateReport(
+            $idReport,
+            '2024-01-01',
+            false,
+            APIScheduledReports::OUTPUT_RETURN
+        );
+
+        $expectedHeader = Piwik::translate('ScheduledReports_PleaseFindBelow', [
+            Piwik::translate('Intl_PeriodDay'),
+            Site::getNameFor(1),
+        ]);
+
+        self::assertStringContainsString($expectedHeader, $result);
+        self::assertStringNotContainsString('Intl_PeriodNever', $result);
     }
 
     public function testGenerateReportThrowsIfMultiplePeriodsRequested()

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_schedrep_html_row_evolution_graph__ScheduledReports.generateReport_month.original.html
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_schedrep_html_row_evolution_graph__ScheduledReports.generateReport_month.original.html
@@ -18,7 +18,7 @@
                             </a>
         </td>
         <td align="right">
-                        <a style="color:#212121;font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, 'Helvetica Neue', sans-serif;; font-size:16px; padding:0 15px; color: &#x23;646464" title="View Web Analytics reports for Site 1." target="_blank" href="http://example.com/piwik/tests/PHPUnit/proxy/index.php?module=CoreHome&action=redirectToCoreHomeIndex&idSite=1&period=day&date=today-date-removed-in-tests">
+                        <a style="color:#212121;font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, 'Helvetica Neue', sans-serif;; font-size:16px; padding:0 15px; color: &#x23;646464" title="View Web Analytics reports for Site 1." target="_blank" href="http://example.com/piwik/tests/PHPUnit/proxy/index.php?module=CoreHome&action=redirectToCoreHomeIndex&idSite=1&period=month&date=today-date-removed-in-tests">
                 Dashboard
             </a>
                     </td>
@@ -32,7 +32,7 @@
     </h2>
 
     <p style='font-size:15px;line-height:24px;margin:0 0 16px;color:#212121;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;'>
-                Please find below your day report for Site 1.
+                Please find below your month report for Site 1.
                 <br />Mail Test report (previous default)
         <br />Date range: January 2010
         <br />Sent from http://example.com/piwik/tests/PHPUnit/proxy/.

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_schedrep_html_row_evolution_overEach__ScheduledReports.generateReport_month.original.html
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_schedrep_html_row_evolution_overEach__ScheduledReports.generateReport_month.original.html
@@ -18,7 +18,7 @@
                             </a>
         </td>
         <td align="right">
-                        <a style="color:#212121;font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, 'Helvetica Neue', sans-serif;; font-size:16px; padding:0 15px; color: &#x23;646464" title="View Web Analytics reports for Site 1." target="_blank" href="http://example.com/piwik/tests/PHPUnit/proxy/index.php?module=CoreHome&action=redirectToCoreHomeIndex&idSite=1&period=week&date=today-date-removed-in-tests">
+                        <a style="color:#212121;font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, 'Helvetica Neue', sans-serif;; font-size:16px; padding:0 15px; color: &#x23;646464" title="View Web Analytics reports for Site 1." target="_blank" href="http://example.com/piwik/tests/PHPUnit/proxy/index.php?module=CoreHome&action=redirectToCoreHomeIndex&idSite=1&period=month&date=today-date-removed-in-tests">
                 Dashboard
             </a>
                     </td>
@@ -32,7 +32,7 @@
     </h2>
 
     <p style='font-size:15px;line-height:24px;margin:0 0 16px;color:#212121;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;'>
-                Please find below your week report for Site 1.
+                Please find below your month report for Site 1.
                 <br />Mail Test report (each in period)
         <br />Date range: January 2010
         <br />Sent from http://example.com/piwik/tests/PHPUnit/proxy/.

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_schedrep_html_row_evolution_prevCustomN__ScheduledReports.generateReport_month.original.html
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_schedrep_html_row_evolution_prevCustomN__ScheduledReports.generateReport_month.original.html
@@ -18,7 +18,7 @@
                             </a>
         </td>
         <td align="right">
-                        <a style="color:#212121;font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, 'Helvetica Neue', sans-serif;; font-size:16px; padding:0 15px; color: &#x23;646464" title="View Web Analytics reports for Site 1." target="_blank" href="http://example.com/piwik/tests/PHPUnit/proxy/index.php?module=CoreHome&action=redirectToCoreHomeIndex&idSite=1&period=day&date=today-date-removed-in-tests">
+                        <a style="color:#212121;font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, 'Helvetica Neue', sans-serif;; font-size:16px; padding:0 15px; color: &#x23;646464" title="View Web Analytics reports for Site 1." target="_blank" href="http://example.com/piwik/tests/PHPUnit/proxy/index.php?module=CoreHome&action=redirectToCoreHomeIndex&idSite=1&period=month&date=today-date-removed-in-tests">
                 Dashboard
             </a>
                     </td>
@@ -32,7 +32,7 @@
     </h2>
 
     <p style='font-size:15px;line-height:24px;margin:0 0 16px;color:#212121;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;'>
-                Please find below your day report for Site 1.
+                Please find below your month report for Site 1.
                 <br />Mail Test report (previous10)
         <br />Date range: January 2010
         <br />Sent from http://example.com/piwik/tests/PHPUnit/proxy/.

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_schedrep_html_tables_and_graph__ScheduledReports.generateReport_month.original.html
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_schedrep_html_tables_and_graph__ScheduledReports.generateReport_month.original.html
@@ -18,7 +18,7 @@
                             </a>
         </td>
         <td align="right">
-                        <a style="color:#212121;font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, 'Helvetica Neue', sans-serif;; font-size:16px; padding:0 15px; color: &#x23;646464" title="View Web Analytics reports for Site 1." target="_blank" href="http://example.com/piwik/tests/PHPUnit/proxy/index.php?module=CoreHome&action=redirectToCoreHomeIndex&idSite=1&period=day&date=today-date-removed-in-tests">
+                        <a style="color:#212121;font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, 'Helvetica Neue', sans-serif;; font-size:16px; padding:0 15px; color: &#x23;646464" title="View Web Analytics reports for Site 1." target="_blank" href="http://example.com/piwik/tests/PHPUnit/proxy/index.php?module=CoreHome&action=redirectToCoreHomeIndex&idSite=1&period=month&date=today-date-removed-in-tests">
                 Dashboard
             </a>
                     </td>
@@ -32,7 +32,7 @@
     </h2>
 
     <p style='font-size:15px;line-height:24px;margin:0 0 16px;color:#212121;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;'>
-                Please find below your day report for Site 1.
+                Please find below your month report for Site 1.
                 <br />Mail Test report
         <br />Date range: January 2010
         <br />Sent from http://example.com/piwik/tests/PHPUnit/proxy/.

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_schedrep_html_tables_only__ScheduledReports.generateReport_month.original.html
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_schedrep_html_tables_only__ScheduledReports.generateReport_month.original.html
@@ -18,7 +18,7 @@
                             </a>
         </td>
         <td align="right">
-                        <a style="color:#212121;font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, 'Helvetica Neue', sans-serif;; font-size:16px; padding:0 15px; color: &#x23;646464" title="View Web Analytics reports for Site 1." target="_blank" href="http://example.com/piwik/tests/PHPUnit/proxy/index.php?module=CoreHome&action=redirectToCoreHomeIndex&idSite=1&period=day&date=today-date-removed-in-tests">
+                        <a style="color:#212121;font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, 'Helvetica Neue', sans-serif;; font-size:16px; padding:0 15px; color: &#x23;646464" title="View Web Analytics reports for Site 1." target="_blank" href="http://example.com/piwik/tests/PHPUnit/proxy/index.php?module=CoreHome&action=redirectToCoreHomeIndex&idSite=1&period=month&date=today-date-removed-in-tests">
                 Dashboard
             </a>
                     </td>
@@ -32,7 +32,7 @@
     </h2>
 
     <p style='font-size:15px;line-height:24px;margin:0 0 16px;color:#212121;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;'>
-                Please find below your day report for Site 1.
+                Please find below your month report for Site 1.
                 <br />Mail Test report with &lt;long&gt; déscription and some 🚀 $peciäl characters $%&amp;-~°^&#039;&quot;@#*ß§²³
         <br />Date range: January 2010
         <br />Sent from http://example.com/piwik/tests/PHPUnit/proxy/.

--- a/tests/UI/expected-screenshots/UIIntegrationTest_email_reports_download.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_email_reports_download.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e728c37dee8f7e27f738f3549e67a3478da453171d96e56259256722caea292d
-size 83934
+oid sha256:62cc2cf187746fd87fa676705a4cdab3b95edaa70a70b9e0a8e03c7bd956303c
+size 83776


### PR DESCRIPTION
Problem: HTML scheduled report downloads used the stored delivery schedule instead of the currently selected data period. For reports scheduled as Never, this could expose the literal `Intl_PeriodNever`; other overrides could be mislabeled too.

Impact: Downloaded HTML reports could show an internal translation key, the wrong period label, and a dashboard link with the wrong period.

Fix: Pass the effective requested period to the HTML renderer, reuse the existing date-range translation, and add regression and system coverage.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules