### PR TITLE
Link Others rows to deployment-neutral row limits FAQ

### DIFF
--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -1828,7 +1828,7 @@ $.extend(DataTable.prototype, UIControl.prototype, {
 
     handleSummaryRow: function (domElem) {
         var details = _pk_translate('General_LearnMore', [' (<a href="'
-        + _pk_externalRawLink('https://matomo.org/faq/how-to/faq_54/') + '" rel="noreferrer noopener" target="_blank">', '</a>)']);
+        + _pk_externalRawLink('https://matomo.org/faq/reports/understanding-row-limits-and-others-rows/') + '" rel="noreferrer noopener" target="_blank">', '</a>)']);
 
         domElem.find('tr.summaryRow').each(function () {
             var labelSpan = $(this).find('.label .value').filter(function(index, elem){

--- a/plugins/CoreHome/tests/UI/DataTable_spec.js
+++ b/plugins/CoreHome/tests/UI/DataTable_spec.js
@@ -135,6 +135,42 @@ describe('DataTable', function () {
     }));
   }
 
+  it('should link summary rows to the row limits documentation', async function () {
+    await loadWidget();
+    await page.waitForFunction((widgetSel) => {
+      const reportElement = document.querySelector(`${widgetSel} [data-report]`);
+      return reportElement && window.$(reportElement).data('uiControlObject');
+    }, {}, widgetSelector);
+
+    const helpLink = await page.evaluate((widgetSel) => {
+      const reportElement = document.querySelector(`${widgetSel} [data-report]`);
+      const tableBody = reportElement.querySelector('table.dataTable tbody');
+      const summaryRow = document.createElement('tr');
+      summaryRow.className = 'summaryRow';
+      summaryRow.innerHTML = '<td class="label"><span class="value">Others</span></td>';
+      tableBody.appendChild(summaryRow);
+
+      const $reportElement = window.$(reportElement);
+      $reportElement.data('uiControlObject').handleSummaryRow($reportElement);
+      window.$(summaryRow).trigger('mouseenter');
+
+      const link = summaryRow.querySelector(
+        'a[rel~="noreferrer"][rel~="noopener"][target="_blank"]',
+      );
+      return {
+        pathname: new URL(link.href).pathname,
+        rel: link.rel,
+        target: link.target,
+      };
+    }, widgetSelector);
+
+    expect(helpLink).to.deep.equal({
+      pathname: '/faq/reports/understanding-row-limits-and-others-rows/',
+      rel: 'noreferrer noopener',
+      target: '_blank',
+    });
+  });
+
   it('should total every row of the report when no table search is active', async function () {
     await loadWidget();
     await toggleTotalsRow();


### PR DESCRIPTION
## Description
- link the Learn More action on Others rows to the deployment-neutral row limits FAQ
- cover the generated URL and external-link attributes with a DataTable UI regression test

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules


Backport of #25163.
