### PR TITLE
Ecommerce and Goals: docblocks still describe the pre-batch VisitorDetails queries

### DIFF
--- a/plugins/Ecommerce/VisitorDetails.php
+++ b/plugins/Ecommerce/VisitorDetails.php
@@ -195,8 +195,7 @@ class VisitorDetails extends VisitorDetailsAbstract
     }
 
     /**
-     * @param $idVisit
-     * @param $limit
+     * @param $idVisits
      * @return array
      * @throws \Exception
      */
@@ -243,7 +242,6 @@ class VisitorDetails extends VisitorDetailsAbstract
     /**
      * @param $idVisit
      * @param $idOrder
-     * @param $actionsLimit
      * @return array
      * @throws \Exception
      */

--- a/plugins/Goals/VisitorDetails.php
+++ b/plugins/Goals/VisitorDetails.php
@@ -55,7 +55,7 @@ class VisitorDetails extends VisitorDetailsAbstract
     }
 
     /**
-     * @param $idVisit
+     * @param $idVisits
      * @return array
      * @throws \Exception
      */


### PR DESCRIPTION
The same batch conversion went through three VisitorDetails classes, and the one in Actions got its docblock updated at the time while these two seem to have been missed, along with two params that no longer exist. The docblock chunk PRs from July covered core, so this looks like leftovers rather than something already queued.

### Checklist
[✔] I have understood, reviewed, and tested all AI outputs before use
[✔] All AI instructions respect security, IP, and privacy rules
