### PR TITLE
Read the artifacts server password from STDIN when syncing test files

### DIFF
--- a/.ddev/README.md
+++ b/.ddev/README.md
@@ -113,7 +113,7 @@ ddev matomo:artifacts:sync-system-tests 12345 -e
 
 The first argument is the build number, and both commands accept `-r` to sync a plugin repository, eg `-r innocraft/plugin-FormAnalytics`.
 
-Syncing from `matomo-org/matomo` needs no setup, because those artifacts are public. Artifacts of premium plugins are protected, so the commands look up credentials when you point them at a premium plugin repository. The credentials come from git, so they are stored wherever your credential helper keeps them and never appear in a file in the repository, in the process list or in your shell history — the password is handed to the console over STDIN.
+Syncing from `matomo-org/matomo` needs no setup, because core's own artifacts are public. Every other repository is protected, plugin repositories under `matomo-org` included, so the commands look up credentials whenever you point them somewhere else with `-r`. The credentials come from git, so they are stored wherever your credential helper keeps them and never appear in a file in the repository, in the process list or in your shell history — the password is handed to the console over STDIN.
 
 Store them once per machine:
 

--- a/.ddev/README.md
+++ b/.ddev/README.md
@@ -102,6 +102,41 @@ When a plugin declares `require.php` in `plugin.json`, the mount command compare
 
 For more information about Matomo development, check out the official [Matomo Developer Documentation](https://developer.matomo.org/).
 
+## Syncing test files from CI
+
+When a build produces different UI screenshots or system test files than your checkout expects, you can copy the files CI generated back into your working copy:
+
+```
+ddev matomo:artifacts:sync-screenshots 12345 'Marketplace_.*'
+ddev matomo:artifacts:sync-system-tests 12345 -e
+```
+
+The first argument is the build number, and both commands accept `-r` to sync a plugin repository, eg `-r innocraft/plugin-FormAnalytics`.
+
+Syncing from `matomo-org/matomo` needs no setup, because those artifacts are public. Artifacts of premium plugins are protected, so the commands look up credentials when you point them at a premium plugin repository. The credentials come from git, so they are stored wherever your credential helper keeps them and never appear in a file in the repository, in the process list or in your shell history — the password is handed to the console over STDIN.
+
+Store them once per machine:
+
+```
+ddev matomo:artifacts:login
+```
+
+Which credential helper git uses is your own configuration, exactly as it is for `git push`. Pick one that keeps the password in your operating system's credential store rather than in a file:
+
+```
+git config --global credential.helper osxkeychain   # macOS
+git config --global credential.helper manager       # Windows
+git config --global credential.helper libsecret     # Linux
+```
+
+Git ships the helpers for macOS and Windows, so nothing needs installing there. On Debian and Ubuntu the libsecret helper ships as source in `/usr/share/doc/git/contrib/credential/libsecret` and has to be built once. Inside WSL2, point git at the Windows credential manager instead. Note that `git config --global credential.helper store` writes `~/.git-credentials` in plain text, so it is a poor choice for this.
+
+Without a helper configured, git accepts the credentials and silently stores nothing, so `ddev matomo:artifacts:login` reads them back afterwards and tells you if that happened rather than reporting a success you did not get.
+
+These host commands are covered by `tests/shell/ddev-artifacts-commands.sh`, which needs neither DDEV nor credentials to run and is run by CI on Linux, macOS and Windows.
+
+The console commands behind these wrappers, `tests:sync-ui-screenshots` and `development:sync-system-test-processed`, can also be run through `ddev matomo:console` directly. They take the password as `--http-password`, or read it from STDIN with `--http-password-stdin`.
+
 ## Update PHP or MySQL version
 
 You can create `.ddev/config.local.yaml` to adjust the environment configuration. This file will be automatically ignored by git.

--- a/.ddev/commands/host/.matomo_artifacts_lib.sh
+++ b/.ddev/commands/host/.matomo_artifacts_lib.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+MATOMO_ARTIFACTS_HOST="builds-artifacts.matomo.org"
+
+matomo_artifacts::require_git() {
+  if ! command -v git >/dev/null 2>&1; then
+    echo "git is required to read the artifacts server credentials from your credential store." >&2
+    return 1
+  fi
+}
+
+# The credential is whatever git resolves for the artifacts server, through whichever helper the
+# developer has configured. Which helper that is stays their business, exactly as it is for git
+# itself; what this library guarantees is that it never writes the password anywhere, and hands it
+# to the console over STDIN rather than on a command line.
+matomo_artifacts::fill_credential() {
+  local credential=""
+
+  # GIT_TERMINAL_PROMPT=0 so a missing credential fails cleanly instead of waiting on a terminal
+  if ! credential="$(printf 'protocol=https\nhost=%s\n\n' "${MATOMO_ARTIFACTS_HOST}" \
+    | GIT_TERMINAL_PROMPT=0 git credential fill 2>/dev/null)"; then
+    return 1
+  fi
+
+  printf '%s\n' "${credential}"
+}
+
+matomo_artifacts::credential_field() {
+  local credential="${1}"
+  local field="${2}"
+
+  printf '%s\n' "${credential}" | sed -n "s/^${field}=//p"
+}
+
+matomo_artifacts::explain_credential_helpers() {
+  cat >&2 <<MESSAGE
+git has no credential helper configured, so there is nowhere to keep the password. Configure one
+that keeps it in your operating system's credential store, rather than in a file:
+
+  macOS    git config --global credential.helper osxkeychain
+  Windows  git config --global credential.helper manager
+  Linux    git config --global credential.helper libsecret
+
+Git ships the helpers for macOS and Windows, so nothing needs installing there. On Debian and
+Ubuntu the libsecret helper ships as source in /usr/share/doc/git/contrib/credential/libsecret
+and has to be built once. Inside WSL2, point git at the Windows credential manager instead.
+MESSAGE
+}
+
+matomo_artifacts::repository_from_args() {
+  local repository=""
+  local expect_value=0
+  local argument=""
+  local cluster=""
+  local character=""
+  local rest=""
+  local index=0
+
+  for argument in "$@"; do
+    if [[ "${expect_value}" -eq 1 ]]; then
+      repository="${argument}"
+      expect_value=0
+      continue
+    fi
+
+    if [[ "${argument}" == '--' ]]; then
+      break
+    fi
+
+    case "${argument}" in
+      --repository=*)
+        repository="${argument#--repository=}"
+        ;;
+      --repository)
+        expect_value=1
+        ;;
+      --*)
+        ;;
+      -?*)
+        cluster="${argument#-}"
+        index=0
+
+        while [[ "${index}" -lt "${#cluster}" ]]; do
+          character="${cluster:index:1}"
+          rest="${cluster:index+1}"
+
+          case "${character}" in
+            r)
+              if [[ -n "${rest}" ]]; then repository="${rest}"; else expect_value=1; fi
+              break
+              ;;
+            p)
+              # -p takes a value too, so it swallows the rest of the token
+              break
+              ;;
+            *)
+              index=$((index + 1))
+              ;;
+          esac
+        done
+        ;;
+    esac
+  done
+
+  printf '%s\n' "${repository}"
+}
+
+matomo_artifacts::sync() {
+  local console_command="${1}"
+  shift
+
+  local repository=""
+  local credential=""
+  local username=""
+  local password=""
+  local argument=""
+
+  matomo_artifacts::require_git || return 1
+
+  repository="$(matomo_artifacts::repository_from_args "$@")"
+
+  # only premium plugins keep their artifacts behind HTTP auth, the matomo-org ones are public
+  if [[ -z "${repository}" || "${repository}" == matomo-org/* ]]; then
+    ddev matomo:console "${console_command}" "$@"
+    return
+  fi
+
+  credential="$(matomo_artifacts::fill_credential)" || true
+  username="$(matomo_artifacts::credential_field "${credential}" username)"
+  password="$(matomo_artifacts::credential_field "${credential}" password)"
+
+  if [[ -z "${username}" || -z "${password}" ]]; then
+    echo "No credentials are stored for ${MATOMO_ARTIFACTS_HOST}. Run: ddev matomo:artifacts:login" >&2
+    return 1
+  fi
+
+  # the credentials go before any "--", or Symfony would read them as positional arguments
+  local -a before=()
+  local -a after=()
+  local terminator=0
+
+  for argument in "$@"; do
+    if [[ "${terminator}" -eq 0 && "${argument}" == '--' ]]; then
+      terminator=1
+      continue
+    fi
+
+    if [[ "${terminator}" -eq 1 ]]; then
+      after+=("${argument}")
+    else
+      before+=("${argument}")
+    fi
+  done
+
+  if [[ "${terminator}" -eq 1 ]]; then
+    printf '%s' "${password}" | ddev matomo:console "${console_command}" \
+      ${before[@]+"${before[@]}"} --http-user="${username}" --http-password-stdin \
+      -- ${after[@]+"${after[@]}"}
+    return
+  fi
+
+  printf '%s' "${password}" | ddev matomo:console "${console_command}" \
+    ${before[@]+"${before[@]}"} --http-user="${username}" --http-password-stdin
+}

--- a/.ddev/commands/host/.matomo_artifacts_lib.sh
+++ b/.ddev/commands/host/.matomo_artifacts_lib.sh
@@ -34,10 +34,55 @@ matomo_artifacts::credential_field() {
   printf '%s\n' "${credential}" | sed -n "s/^${field}=//p"
 }
 
+# every helper that could answer for this host: the general ones and any configured for this host
+# alone. --get-urlmatch would collapse them to a single value, which names the wrong helper when
+# more than one is configured. git config exits non-zero when nothing matches, which under `set -e`
+# would abort the caller mid-assignment and swallow the explanation entirely.
+matomo_artifacts::configured_helpers() {
+  {
+    git config --get-all credential.helper 2>/dev/null || true
+    git config --get-all "credential.https://${MATOMO_ARTIFACTS_HOST}.helper" 2>/dev/null || true
+  } | sed '/^[[:space:]]*$/d'
+}
+
 matomo_artifacts::explain_credential_helpers() {
-  cat >&2 <<MESSAGE
+  local helpers
+  helpers="$(matomo_artifacts::configured_helpers)"
+
+  # saying "no helper configured" when one is configured sends the reader after the wrong
+  # problem, so report which one answered and that it kept nothing
+  if [[ -n "${helpers}" ]]; then
+    {
+      echo "git has a credential helper configured, so the password was handed to one and not"
+      echo "given back. git does not report which one answered; these could have:"
+      echo
+      printf '  %s\n' "${helpers}"
+      cat <<'MESSAGE'
+
+That is a helper's own problem rather than missing configuration, so check each can reach your
+credential store. On Linux, git-credential-libsecret silently switches to a file backend and
+stops returning passwords whenever SNAP is set, as it is in terminals started by a snap-packaged
+editor.
+
+Either fix the helper, or configure one that keeps the password in your operating system's
+credential store rather than in a file:
+MESSAGE
+      matomo_artifacts::credential_helper_options
+    } >&2
+    return
+  fi
+
+  {
+    cat <<'MESSAGE'
 git has no credential helper configured, so there is nowhere to keep the password. Configure one
 that keeps it in your operating system's credential store, rather than in a file:
+MESSAGE
+    matomo_artifacts::credential_helper_options
+  } >&2
+}
+
+matomo_artifacts::credential_helper_options() {
+  cat <<MESSAGE
 
   macOS    git config --global credential.helper osxkeychain
   Windows  git config --global credential.helper manager

--- a/.ddev/commands/host/.matomo_artifacts_lib.sh
+++ b/.ddev/commands/host/.matomo_artifacts_lib.sh
@@ -119,8 +119,9 @@ matomo_artifacts::sync() {
 
   repository="$(matomo_artifacts::repository_from_args "$@")"
 
-  # only premium plugins keep their artifacts behind HTTP auth, the matomo-org ones are public
-  if [[ -z "${repository}" || "${repository}" == matomo-org/* ]]; then
+  # only core's own artifacts are public: matomo-org plugin repositories sit behind the same HTTP
+  # auth as the premium ones
+  if [[ -z "${repository}" || "${repository}" == 'matomo-org/matomo' ]]; then
     ddev matomo:console "${console_command}" "$@"
     return
   fi

--- a/.ddev/commands/host/.matomo_artifacts_lib.sh
+++ b/.ddev/commands/host/.matomo_artifacts_lib.sh
@@ -117,8 +117,6 @@ matomo_artifacts::sync() {
   local password=""
   local argument=""
 
-  matomo_artifacts::require_git || return 1
-
   repository="$(matomo_artifacts::repository_from_args "$@")"
 
   # only premium plugins keep their artifacts behind HTTP auth, the matomo-org ones are public
@@ -126,6 +124,9 @@ matomo_artifacts::sync() {
     ddev matomo:console "${console_command}" "$@"
     return
   fi
+
+  # only the credential lookup needs git, so it is not required for a public sync
+  matomo_artifacts::require_git || return 1
 
   credential="$(matomo_artifacts::fill_credential)" || true
   username="$(matomo_artifacts::credential_field "${credential}" username)"

--- a/.ddev/commands/host/matomo_artifacts_login
+++ b/.ddev/commands/host/matomo_artifacts_login
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+## Description: Store the artifacts server credentials with your git credential helper
+## Usage: matomo:artifacts:login
+## Example: ddev matomo:artifacts:login
+## OSTypes: darwin,linux,wsl2,windows
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${script_dir}/.matomo_artifacts_lib.sh"
+
+matomo_artifacts::require_git || exit 1
+
+read -r -p "Username for https://${MATOMO_ARTIFACTS_HOST}: " username
+read -r -s -p "Password: " password
+echo
+
+if [[ -z "${username}" || -z "${password}" ]]; then
+  echo "Both a username and a password are required." >&2
+  exit 1
+fi
+
+printf 'protocol=https\nhost=%s\nusername=%s\npassword=%s\n\n' \
+  "${MATOMO_ARTIFACTS_HOST}" "${username}" "${password}" | git credential approve
+
+# git stores nothing at all when no helper is configured, and says so silently, so the only honest
+# check is to read the credential back and see that it is the one that was just entered
+stored="$(matomo_artifacts::fill_credential || true)"
+
+if [[ "$(matomo_artifacts::credential_field "${stored}" username)" != "${username}" \
+  || "$(matomo_artifacts::credential_field "${stored}" password)" != "${password}" ]]; then
+  echo "The credentials were not stored: git does not return them for ${MATOMO_ARTIFACTS_HOST}." >&2
+  echo "Either no credential helper stored them, or another one answers for this host first." >&2
+  matomo_artifacts::explain_credential_helpers
+  exit 1
+fi
+
+echo "Stored the credentials for ${MATOMO_ARTIFACTS_HOST} with your git credential helper."
+echo "To remove them again: printf 'protocol=https\\nhost=${MATOMO_ARTIFACTS_HOST}\\n\\n' | git credential reject"

--- a/.ddev/commands/host/matomo_artifacts_sync-screenshots
+++ b/.ddev/commands/host/matomo_artifacts_sync-screenshots
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+## Description: Sync expected UI test screenshots from the artifacts server
+## Usage: matomo:artifacts:sync-screenshots <buildnumber> [<screenshotsRegex>] [-r <repository>]
+## Example: ddev matomo:artifacts:sync-screenshots 12345 'Marketplace_.*'
+## OSTypes: darwin,linux,wsl2,windows
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${script_dir}/.matomo_artifacts_lib.sh"
+
+matomo_artifacts::sync tests:sync-ui-screenshots "$@"

--- a/.ddev/commands/host/matomo_artifacts_sync-system-tests
+++ b/.ddev/commands/host/matomo_artifacts_sync-system-tests
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+## Description: Sync processed system test files from the artifacts server
+## Usage: matomo:artifacts:sync-system-tests <buildnumber> [-e] [-r <repository>] [-p <plugin>]
+## Example: ddev matomo:artifacts:sync-system-tests 12345 -e -r innocraft/plugin-FormAnalytics
+## OSTypes: darwin,linux,wsl2,windows
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${script_dir}/.matomo_artifacts_lib.sh"
+
+matomo_artifacts::sync development:sync-system-test-processed "$@"

--- a/.github/workflows/shell-tests.yml
+++ b/.github/workflows/shell-tests.yml
@@ -1,0 +1,38 @@
+name: Shell tests
+
+on:
+  pull_request:
+    paths:
+      - '.ddev/**'
+      - 'tests/shell/**'
+      - '.github/workflows/shell-tests.yml'
+
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  issues: none
+  packages: none
+  pull-requests: read
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+jobs:
+  ddev-commands:
+    name: DDEV host commands (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # the host commands run on every platform DDEV supports, Windows through Git Bash
+        os: [ubuntu-24.04, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          lfs: false
+          persist-credentials: false
+      - name: Test the DDEV host commands
+        shell: bash
+        run: ./tests/shell/ddev-artifacts-commands.sh

--- a/core/Plugin/ArtifactsHttpAuthTrait.php
+++ b/core/Plugin/ArtifactsHttpAuthTrait.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugin;
+
+/**
+ * Shared HTTP auth options for the console commands that download build artifacts.
+ *
+ * Artifacts of premium plugins are protected, so those commands need credentials for the artifacts
+ * server. Reading the password from STDIN keeps it out of the process list and the shell history,
+ * which lets it be resolved from an OS credential store at the time the command runs.
+ *
+ * Can only be used in a {@see ConsoleCommand}.
+ *
+ * @internal
+ */
+trait ArtifactsHttpAuthTrait
+{
+    protected function addArtifactsHttpAuthOptions(): void
+    {
+        $this->addOptionalValueOption('http-user', '', 'the HTTP AUTH username (for premium plugins where artifacts are protected)');
+        $this->addOptionalValueOption('http-password', '', 'the HTTP AUTH password (for premium plugins where artifacts are protected)');
+        $this->addNoValueOption('http-password-stdin', '', 'read the HTTP AUTH password from STDIN instead of passing it as an option value');
+    }
+
+    protected function getArtifactsHttpPassword(): ?string
+    {
+        $input    = $this->getInput();
+        $password = $input->getOption('http-password');
+
+        if (!$input->getOption('http-password-stdin')) {
+            return $password;
+        }
+
+        // a password of "0" is falsy, but it was still passed
+        if (null !== $password && '' !== $password) {
+            throw new \InvalidArgumentException('Pass either --http-password or --http-password-stdin, not both.');
+        }
+
+        return self::readPasswordFromStream(STDIN);
+    }
+
+    /**
+     * @param resource $stream
+     */
+    protected static function readPasswordFromStream($stream): string
+    {
+        // reading from a terminal would block until something is typed, which looks like a hang
+        if (stream_isatty($stream)) {
+            throw new \InvalidArgumentException(
+                '--http-password-stdin expects the password to be piped in, eg `printf \'%s\' "$password" | ./console ...`.'
+            );
+        }
+
+        $password = rtrim((string) fgets($stream), "\r\n");
+
+        if ('' === $password) {
+            throw new \InvalidArgumentException('--http-password-stdin was given, but no password was read from STDIN.');
+        }
+
+        return $password;
+    }
+}

--- a/plugins/CoreConsole/Commands/DevelopmentSyncProcessedSystemTests.php
+++ b/plugins/CoreConsole/Commands/DevelopmentSyncProcessedSystemTests.php
@@ -15,10 +15,13 @@ use Matomo\Decompress\Tar;
 use Piwik\Development;
 use Piwik\Filesystem;
 use Piwik\Http;
+use Piwik\Plugin\ArtifactsHttpAuthTrait;
 use Piwik\Plugin\ConsoleCommand;
 
 class DevelopmentSyncProcessedSystemTests extends ConsoleCommand
 {
+    use ArtifactsHttpAuthTrait;
+
     public function isEnabled()
     {
         return Development::isEnabled();
@@ -31,8 +34,7 @@ class DevelopmentSyncProcessedSystemTests extends ConsoleCommand
         $this->addRequiredArgument('buildnumber', 'Travis build number you want to sync, eg "14820".');
         $this->addNoValueOption('expected', 'e', 'If given file will be copied in expected directories instead of processed');
         $this->addOptionalValueOption('repository', 'r', 'Repository name you want to sync screenshots for.', 'matomo-org/matomo');
-        $this->addOptionalValueOption('http-user', '', 'the HTTP AUTH username (for premium plugins where artifacts are protected)');
-        $this->addOptionalValueOption('http-password', '', 'the HTTP AUTH password (for premium plugins where artifacts are protected)');
+        $this->addArtifactsHttpAuthOptions();
         $this->addOptionalValueOption('plugin', 'p', 'Name of the plugin the files shall be synced to');
     }
 
@@ -72,7 +74,7 @@ class DevelopmentSyncProcessedSystemTests extends ConsoleCommand
         }
 
         $httpUser = $input->getOption('http-user');
-        $httpPassword = $input->getOption('http-password');
+        $httpPassword = $this->getArtifactsHttpPassword();
 
         $filename = sprintf('system.%s.tar.bz2', $buildNumber);
         $urlBase  = sprintf('https://builds-artifacts.matomo.org/%s/%s', $repository, $filename);

--- a/plugins/TestRunner/Commands/SyncScreenshots.php
+++ b/plugins/TestRunner/Commands/SyncScreenshots.php
@@ -129,7 +129,18 @@ class SyncScreenshots extends ConsoleCommand
         );
         $httpStatus = $response['status'];
         if ($httpStatus == '200') {
-            return json_decode($response['data'], true);
+            $screenshots = json_decode($response['data'], true);
+
+            // the artifacts server answers a request without credentials with its login page and a 200,
+            // so an unusable response here means the artifacts are protected rather than missing
+            if (!is_array($screenshots)) {
+                throw new \Exception(
+                    "Failed reading the screenshot list from $url - if this repository's artifacts are "
+                    . 'protected, pass --http-user together with --http-password or --http-password-stdin.'
+                );
+            }
+
+            return $screenshots;
         }
         if ($httpStatus == '401') {
             throw new \Exception('HTTP 401 - Auth username and password are invalid');

--- a/plugins/TestRunner/Commands/SyncScreenshots.php
+++ b/plugins/TestRunner/Commands/SyncScreenshots.php
@@ -13,6 +13,7 @@ use Piwik\Container\StaticContainer;
 use Piwik\Development;
 use Piwik\Filesystem;
 use Piwik\Http;
+use Piwik\Plugin\ArtifactsHttpAuthTrait;
 use Piwik\Plugin\ConsoleCommand;
 use Piwik\Log\LoggerInterface;
 
@@ -23,6 +24,8 @@ use Piwik\Log\LoggerInterface;
  */
 class SyncScreenshots extends ConsoleCommand
 {
+    use ArtifactsHttpAuthTrait;
+
     /**
      * @var LoggerInterface
      */
@@ -65,16 +68,7 @@ class SyncScreenshots extends ConsoleCommand
             'Repository name you want to sync screenshots for.',
             'matomo-org/matomo'
         );
-        $this->addOptionalValueOption(
-            'http-user',
-            '',
-            'the HTTP AUTH username (for premium plugins where artifacts are protected)'
-        );
-        $this->addOptionalValueOption(
-            'http-password',
-            '',
-            'the HTTP AUTH password (for premium plugins where artifacts are protected)'
-        );
+        $this->addArtifactsHttpAuthOptions();
     }
 
     protected function doExecute(): int
@@ -85,7 +79,7 @@ class SyncScreenshots extends ConsoleCommand
         $screenshotsRegex = $input->getArgument('screenshotsRegex');
         $repository       = $input->getOption('repository');
         $httpUser         = $input->getOption('http-user');
-        $httpPassword     = $input->getOption('http-password');
+        $httpPassword     = $this->getArtifactsHttpPassword();
 
         $screenshots = $this->getScreenshotList($repository, $buildNumber, $httpUser, $httpPassword);
 

--- a/tests/PHPUnit/Unit/Plugin/ArtifactsHttpAuthTraitTest.php
+++ b/tests/PHPUnit/Unit/Plugin/ArtifactsHttpAuthTraitTest.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Core\Plugin;
+
+use PHPUnit\Framework\TestCase;
+use Piwik\Plugin\ArtifactsHttpAuthTrait;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+
+/**
+ * @group Core
+ */
+class ArtifactsHttpAuthTraitTest extends TestCase
+{
+    public function testPasswordOptionIsUsedWhenStdinIsNotRequested()
+    {
+        $command = $this->makeCommand(['--http-password' => 'from-option']);
+
+        $this->assertSame('from-option', $command->resolvePassword());
+    }
+
+    public function testNoPasswordIsResolvedWhenNoOptionIsGiven()
+    {
+        $command = $this->makeCommand([]);
+
+        $this->assertNull($command->resolvePassword());
+    }
+
+    /**
+     * @dataProvider getConflictingPasswords
+     */
+    public function testPasswordOptionAndStdinCannotBeCombined(string $password)
+    {
+        $command = $this->makeCommand(['--http-password' => $password, '--http-password-stdin' => true]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Pass either --http-password or --http-password-stdin, not both.');
+
+        $command->resolvePassword();
+    }
+
+    public function getConflictingPasswords(): array
+    {
+        return [
+            'a password'        => ['from-option'],
+            'a falsy password'  => ['0'],
+        ];
+    }
+
+    /**
+     * @dataProvider getPipedPasswords
+     */
+    public function testPasswordIsReadFromTheStream(string $piped, string $expected)
+    {
+        $command = $this->makeCommand([]);
+
+        $this->assertSame($expected, $command::readStream($this->makeStream($piped)));
+    }
+
+    public function getPipedPasswords(): array
+    {
+        return [
+            'password only'          => ['s3cret', 's3cret'],
+            'trailing newline'       => ["s3cret\n", 's3cret'],
+            'trailing CRLF'          => ["s3cret\r\n", 's3cret'],
+            'spaces are kept'        => ["a b c\n", 'a b c'],
+            'only the first line'    => ["first\nsecond\n", 'first'],
+        ];
+    }
+
+    /**
+     * @dataProvider getEmptyStreams
+     */
+    public function testEmptyStreamIsRejected(string $piped)
+    {
+        $command = $this->makeCommand([]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('no password was read from STDIN');
+
+        $command::readStream($this->makeStream($piped));
+    }
+
+    public function getEmptyStreams(): array
+    {
+        return [
+            'nothing piped' => [''],
+            'blank line'    => ["\n"],
+        ];
+    }
+
+    /**
+     * @param resource $stream
+     */
+    private function makeStream(string $contents)
+    {
+        $stream = fopen('php://memory', 'r+');
+        fwrite($stream, $contents);
+        rewind($stream);
+
+        return $stream;
+    }
+
+    private function makeCommand(array $parameters)
+    {
+        $definition = new InputDefinition([
+            new InputOption('http-password', '', InputOption::VALUE_OPTIONAL),
+            new InputOption('http-password-stdin', '', InputOption::VALUE_NONE),
+        ]);
+
+        return new class (new ArrayInput($parameters, $definition)) {
+            use ArtifactsHttpAuthTrait;
+
+            private $input;
+
+            public function __construct(InputInterface $input)
+            {
+                $this->input = $input;
+            }
+
+            public function getInput(): InputInterface
+            {
+                return $this->input;
+            }
+
+            public function resolvePassword(): ?string
+            {
+                return $this->getArtifactsHttpPassword();
+            }
+
+            /**
+             * @param resource $stream
+             */
+            public static function readStream($stream): string
+            {
+                return self::readPasswordFromStream($stream);
+            }
+        };
+    }
+}

--- a/tests/PHPUnit/Unit/Plugin/ArtifactsHttpAuthTraitTest.php
+++ b/tests/PHPUnit/Unit/Plugin/ArtifactsHttpAuthTraitTest.php
@@ -11,6 +11,7 @@ namespace Piwik\Tests\Core\Plugin;
 
 use PHPUnit\Framework\TestCase;
 use Piwik\Plugin\ArtifactsHttpAuthTrait;
+use Piwik\Plugin\ConsoleCommand;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
@@ -99,7 +100,7 @@ class ArtifactsHttpAuthTraitTest extends TestCase
     }
 
     /**
-     * @param resource $stream
+     * @return resource
      */
     private function makeStream(string $contents)
     {
@@ -117,19 +118,23 @@ class ArtifactsHttpAuthTraitTest extends TestCase
             new InputOption('http-password-stdin', '', InputOption::VALUE_NONE),
         ]);
 
-        return new class (new ArrayInput($parameters, $definition)) {
+        // the trait belongs to a ConsoleCommand, so the fixture has to be one for its option
+        // definitions to resolve
+        return new class (new ArrayInput($parameters, $definition)) extends ConsoleCommand {
             use ArtifactsHttpAuthTrait;
 
-            private $input;
+            private $testInput;
 
             public function __construct(InputInterface $input)
             {
-                $this->input = $input;
+                parent::__construct('test:artifacts-http-auth');
+
+                $this->testInput = $input;
             }
 
-            public function getInput(): InputInterface
+            protected function getInput(): InputInterface
             {
-                return $this->input;
+                return $this->testInput;
             }
 
             public function resolvePassword(): ?string

--- a/tests/shell/ddev-artifacts-commands.sh
+++ b/tests/shell/ddev-artifacts-commands.sh
@@ -134,7 +134,22 @@ test_public_repository_needs_no_credentials() {
   assert_not_contains "${DDEV_ARGS}" '--http-user' 'a public sync sends no credentials'
 
   run_sync no-helper 12345 -r matomo-org/matomo
-  assert_equals 0 "${SYNC_STATUS}" 'an explicit matomo-org repository needs no credentials'
+  assert_equals 0 "${SYNC_STATUS}" 'core artifacts need no credentials'
+}
+
+test_matomo_org_plugins_are_protected_too() {
+  # only core's own artifacts are public; matomo-org plugin repositories need the same credentials
+  seed_credential
+
+  run_sync with-credential 12345 -r matomo-org/plugin-Slack
+
+  assert_contains "${DDEV_ARGS}" '--http-user=ci-user' 'a matomo-org plugin sync authenticates'
+  assert_contains "${DDEV_ARGS}" '--http-password-stdin' 'a matomo-org plugin sync reads the password from STDIN'
+
+  run_sync no-helper 12345 -r matomo-org/plugin-Slack
+
+  assert_equals 1 "${SYNC_STATUS}" 'a matomo-org plugin sync stops without a credential'
+  assert_equals '' "${DDEV_ARGS}" 'a matomo-org plugin sync without a credential never runs ddev'
 }
 
 test_public_repository_does_not_need_git() {
@@ -269,6 +284,7 @@ setup
 
 test_public_repository_needs_no_credentials
 test_public_repository_does_not_need_git
+test_matomo_org_plugins_are_protected_too
 test_premium_repository_sends_the_credentials
 test_premium_repository_stops_without_a_credential
 test_every_repository_option_spelling_is_recognised

--- a/tests/shell/ddev-artifacts-commands.sh
+++ b/tests/shell/ddev-artifacts-commands.sh
@@ -137,6 +137,34 @@ test_public_repository_needs_no_credentials() {
   assert_equals 0 "${SYNC_STATUS}" 'an explicit matomo-org repository needs no credentials'
 }
 
+test_public_repository_does_not_need_git() {
+  # nothing on the public path talks to git, so a machine without it can still sync core artifacts
+  local without_git="${TEST_DIR}/bin-without-git"
+  local binary=''
+
+  mkdir -p "${without_git}"
+  ln -sf "${TEST_DIR}/bin/ddev" "${without_git}/ddev"
+
+  for binary in cat sed bash env; do
+    ln -sf "$(command -v "${binary}")" "${without_git}/${binary}"
+  done
+
+  rm -f "${TEST_DIR}/args"
+
+  local status=0
+  (
+    export GIT_CONFIG_GLOBAL="${TEST_DIR}/no-helper"
+    export PATH="${without_git}"
+    source "${LIBRARY}"
+    matomo_artifacts::sync tests:sync-ui-screenshots 12345 2>&1 </dev/null
+  ) >/dev/null
+  status=$?
+
+  assert_equals 0 "${status}" 'a public sync works with no git on PATH'
+  assert_contains "$(cat "${TEST_DIR}/args" 2>/dev/null)" 'tests:sync-ui-screenshots' \
+    'the console still runs without git'
+}
+
 test_premium_repository_sends_the_credentials() {
   seed_credential
 
@@ -242,6 +270,7 @@ test_login_reports_credentials_that_came_back_different() {
 setup
 
 test_public_repository_needs_no_credentials
+test_public_repository_does_not_need_git
 test_premium_repository_sends_the_credentials
 test_premium_repository_stops_without_a_credential
 test_every_repository_option_spelling_is_recognised

--- a/tests/shell/ddev-artifacts-commands.sh
+++ b/tests/shell/ddev-artifacts-commands.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+
+# Tests for the DDEV host commands that sync build artifacts, in .ddev/commands/host.
+#
+# Neither DDEV, a credential helper nor network access is needed: ddev is stubbed on PATH and git is
+# pointed at a fake credential helper through an isolated configuration, so the developer's own git
+# configuration and credential store stay untouched.
+
+set -uo pipefail
+
+REPOSITORY_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LIBRARY="${REPOSITORY_ROOT}/.ddev/commands/host/.matomo_artifacts_lib.sh"
+LOGIN_COMMAND="${REPOSITORY_ROOT}/.ddev/commands/host/matomo_artifacts_login"
+
+# BSD mktemp, as shipped on macOS, needs a template
+TEST_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t matomo-artifacts)"
+FAILURES=0
+ASSERTIONS=0
+
+trap 'rm -rf "${TEST_DIR}"' EXIT
+
+setup() {
+  mkdir -p "${TEST_DIR}/bin"
+
+  cat > "${TEST_DIR}/bin/ddev" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "${DDEV_STUB_DIR}/args"
+cat > "${DDEV_STUB_DIR}/stdin"
+STUB
+
+  # git looks a helper up as git-credential-<name> on PATH, so the fake is a real one. It keeps what
+  # it is given in a file, so a test can tell whether "git credential approve" actually stored
+  # anything; FAKE_IGNORE_STORE makes it behave like a helper that quietly stores nothing.
+  cat > "${TEST_DIR}/bin/git-credential-fake" <<'HELPER'
+#!/usr/bin/env bash
+case "${1}" in
+  get)
+    [[ -f "${FAKE_CREDENTIAL_STORE}" ]] && cat "${FAKE_CREDENTIAL_STORE}"
+    ;;
+  store)
+    [[ -n "${FAKE_IGNORE_STORE:-}" ]] && exit 0
+    grep -E '^(username|password)=' > "${FAKE_CREDENTIAL_STORE}"
+    ;;
+  erase)
+    rm -f "${FAKE_CREDENTIAL_STORE}"
+    ;;
+esac
+exit 0
+HELPER
+
+  chmod +x "${TEST_DIR}/bin/ddev" "${TEST_DIR}/bin/git-credential-fake"
+
+  export PATH="${TEST_DIR}/bin:${PATH}"
+  export DDEV_STUB_DIR="${TEST_DIR}"
+  export GIT_CONFIG_SYSTEM=/dev/null
+  export GIT_CONFIG_NOSYSTEM=1
+  # without these git would read the configuration of whatever repository the suite runs in
+  export GIT_CONFIG_GLOBAL="${TEST_DIR}/no-helper"
+  export GIT_DIR="${TEST_DIR}/isolated.git"
+
+  export FAKE_CREDENTIAL_STORE="${TEST_DIR}/credential-store"
+
+  : > "${TEST_DIR}/no-helper"
+  printf '[credential]\n\thelper = fake\n' > "${TEST_DIR}/with-credential"
+
+  seed_credential
+}
+
+seed_credential() {
+  printf 'username=ci-user\npassword=p@ss word\n' > "${FAKE_CREDENTIAL_STORE}"
+}
+
+run_login() {
+  LOGIN_OUTPUT="$(
+    export GIT_CONFIG_GLOBAL="${TEST_DIR}/${1}"
+    "${LOGIN_COMMAND}" <<<"${2}
+${3}" 2>&1
+  )"
+  LOGIN_STATUS=$?
+}
+
+fail() {
+  FAILURES=$((FAILURES + 1))
+  printf 'not ok - %s\n' "${1}"
+  printf '  expected: %s\n  actual:   %s\n' "${2}" "${3}"
+}
+
+pass() {
+  printf 'ok - %s\n' "${1}"
+}
+
+assert_equals() {
+  ASSERTIONS=$((ASSERTIONS + 1))
+  if [[ "${1}" == "${2}" ]]; then pass "${3}"; else fail "${3}" "${1}" "${2}"; fi
+}
+
+assert_contains() {
+  ASSERTIONS=$((ASSERTIONS + 1))
+  if [[ "${1}" == *"${2}"* ]]; then pass "${3}"; else fail "${3}" "containing '${2}'" "${1}"; fi
+}
+
+assert_not_contains() {
+  ASSERTIONS=$((ASSERTIONS + 1))
+  if [[ "${1}" != *"${2}"* ]]; then pass "${3}"; else fail "${3}" "not containing '${2}'" "${1}"; fi
+}
+
+# Runs matomo_artifacts::sync with the given git configuration, and records what reached the ddev
+# stub. Sets SYNC_STATUS, SYNC_OUTPUT, DDEV_ARGS and DDEV_STDIN.
+run_sync() {
+  local configuration="${1}"
+  shift
+
+  rm -f "${TEST_DIR}/args" "${TEST_DIR}/stdin"
+
+  # both redirections belong inside the substitution: a redirection on an assignment-only
+  # command resets $? to 0, and stderr is where the commands report why they stopped
+  SYNC_OUTPUT="$(
+    export GIT_CONFIG_GLOBAL="${TEST_DIR}/${configuration}"
+    source "${LIBRARY}"
+    matomo_artifacts::sync tests:sync-ui-screenshots "$@" 2>&1 </dev/null
+  )"
+  SYNC_STATUS=$?
+
+  DDEV_ARGS="$(cat "${TEST_DIR}/args" 2>/dev/null || true)"
+  DDEV_STDIN="$(cat "${TEST_DIR}/stdin" 2>/dev/null || true)"
+}
+
+test_public_repository_needs_no_credentials() {
+  run_sync no-helper 12345 'Marketplace_.*'
+
+  assert_equals 0 "${SYNC_STATUS}" 'a public sync works without any credential'
+  assert_equals 'matomo:console tests:sync-ui-screenshots 12345 Marketplace_.*' "${DDEV_ARGS}" \
+    'a public sync forwards the arguments unchanged'
+  assert_not_contains "${DDEV_ARGS}" '--http-user' 'a public sync sends no credentials'
+
+  run_sync no-helper 12345 -r matomo-org/matomo
+  assert_equals 0 "${SYNC_STATUS}" 'an explicit matomo-org repository needs no credentials'
+}
+
+test_premium_repository_sends_the_credentials() {
+  seed_credential
+
+  run_sync with-credential 12345 -r innocraft/plugin-FormAnalytics
+
+  assert_equals 0 "${SYNC_STATUS}" 'a premium sync succeeds when a credential is stored'
+  assert_contains "${DDEV_ARGS}" '--http-user=ci-user' 'the stored username is passed'
+  assert_contains "${DDEV_ARGS}" '--http-password-stdin' 'the console is asked to read STDIN'
+  assert_equals 'p@ss word' "${DDEV_STDIN}" 'the password reaches the console over STDIN intact'
+  assert_not_contains "${DDEV_ARGS}" 'p@ss word' 'the password never appears in the arguments'
+}
+
+test_premium_repository_stops_without_a_credential() {
+  run_sync no-helper 12345 -r innocraft/plugin-FormAnalytics
+
+  assert_equals 1 "${SYNC_STATUS}" 'a premium sync fails when nothing is stored'
+  assert_equals '' "${DDEV_ARGS}" 'a premium sync without a credential never runs ddev'
+  assert_contains "${SYNC_OUTPUT}" 'matomo:artifacts:login' 'the failure points at the login command'
+}
+
+test_every_repository_option_spelling_is_recognised() {
+  local spelling=''
+
+  seed_credential
+
+  for spelling in '-r innocraft/plugin-Funnels' '-rinnocraft/plugin-Funnels' \
+    '--repository innocraft/plugin-Funnels' '--repository=innocraft/plugin-Funnels' \
+    '-er innocraft/plugin-Funnels' '-erinnocraft/plugin-Funnels'; do
+    # shellcheck disable=SC2086
+    run_sync with-credential 12345 ${spelling}
+
+    assert_contains "${DDEV_ARGS}" '--http-password-stdin' "'${spelling}' is treated as a premium repository"
+  done
+
+  # -p takes a value, so its value must not be mistaken for a repository even when it contains an "r"
+  for spelling in '-p FormAnalytics' '-pFormAnalytics' '-e'; do
+    # shellcheck disable=SC2086
+    run_sync no-helper 12345 ${spelling}
+
+    assert_equals 0 "${SYNC_STATUS}" "'${spelling}' alone stays a public sync"
+  done
+}
+
+test_option_parsing_stops_at_the_terminator() {
+  run_sync no-helper 12345 -- -r innocraft/plugin-FormAnalytics
+
+  assert_equals 0 "${SYNC_STATUS}" 'an option after -- is not read as a repository'
+  assert_not_contains "${DDEV_ARGS}" '--http-user' 'nothing is appended after the terminator'
+}
+
+test_credentials_are_inserted_before_the_terminator() {
+  seed_credential
+
+  run_sync with-credential 12345 -r innocraft/plugin-FormAnalytics -- --passed-through
+
+  assert_contains "${DDEV_ARGS}" '--http-password-stdin -- --passed-through' \
+    'the credentials are placed before -- so Symfony still reads them as options'
+  assert_equals 'p@ss word' "${DDEV_STDIN}" 'the password is still piped when -- is used'
+}
+
+test_login_stores_the_credentials() {
+  rm -f "${FAKE_CREDENTIAL_STORE}"
+
+  run_login with-credential 'ci-user' 'p@ss word'
+
+  assert_equals 0 "${LOGIN_STATUS}" 'login succeeds when the helper stores the password'
+  assert_contains "${LOGIN_OUTPUT}" 'Stored the credentials' 'login confirms what it did'
+  assert_contains "$(cat "${FAKE_CREDENTIAL_STORE}" 2>/dev/null)" 'password=p@ss word' \
+    'the password reached the credential helper'
+  assert_contains "$(cat "${FAKE_CREDENTIAL_STORE}" 2>/dev/null)" 'username=ci-user' \
+    'the username reached the credential helper'
+  assert_not_contains "${LOGIN_OUTPUT}" 'p@ss word' 'login never echoes the password'
+}
+
+test_login_reports_when_nothing_was_stored() {
+  # git accepts "credential approve" without a helper and stores nothing, silently
+  run_login no-helper 'ci-user' 'p@ss word'
+
+  assert_equals 1 "${LOGIN_STATUS}" 'login fails when nothing was actually stored'
+  assert_contains "${LOGIN_OUTPUT}" 'not stored' 'login says the credentials were not stored'
+  assert_contains "${LOGIN_OUTPUT}" 'credential.helper' 'login explains how to configure a helper'
+  assert_not_contains "${LOGIN_OUTPUT}" 'p@ss word' 'login never echoes the password'
+}
+
+test_login_reports_a_helper_that_silently_ignores_the_store() {
+  rm -f "${FAKE_CREDENTIAL_STORE}"
+
+  FAKE_IGNORE_STORE=1 run_login with-credential 'ci-user' 'p@ss word'
+
+  assert_equals 1 "${LOGIN_STATUS}" 'login fails when the helper accepts but stores nothing'
+}
+
+test_login_reports_credentials_that_came_back_different() {
+  # another helper answering first would return someone else's credentials for this host
+  seed_credential
+
+  FAKE_IGNORE_STORE=1 run_login with-credential 'other-user' 'other-password'
+
+  assert_equals 1 "${LOGIN_STATUS}" 'login fails when git returns different credentials'
+  assert_contains "${LOGIN_OUTPUT}" 'does not return them' 'login explains what it read back'
+}
+
+setup
+
+test_public_repository_needs_no_credentials
+test_premium_repository_sends_the_credentials
+test_premium_repository_stops_without_a_credential
+test_every_repository_option_spelling_is_recognised
+test_option_parsing_stops_at_the_terminator
+test_credentials_are_inserted_before_the_terminator
+test_login_stores_the_credentials
+test_login_reports_when_nothing_was_stored
+test_login_reports_a_helper_that_silently_ignores_the_store
+test_login_reports_credentials_that_came_back_different
+
+printf '\n%s assertions, %s failures\n' "${ASSERTIONS}" "${FAILURES}"
+
+[[ "${FAILURES}" -eq 0 ]]

--- a/tests/shell/ddev-artifacts-commands.sh
+++ b/tests/shell/ddev-artifacts-commands.sh
@@ -62,6 +62,8 @@ HELPER
 
   : > "${TEST_DIR}/no-helper"
   printf '[credential]\n\thelper = fake\n' > "${TEST_DIR}/with-credential"
+  # git consults every configured helper in order, so the diagnostic must not name just one
+  printf '[credential]\n\thelper = first\n\thelper = fake\n' > "${TEST_DIR}/two-helpers"
 
   seed_credential
 }
@@ -268,6 +270,20 @@ test_login_reports_a_helper_that_silently_ignores_the_store() {
   FAKE_IGNORE_STORE=1 run_login with-credential 'ci-user' 'p@ss word'
 
   assert_equals 1 "${LOGIN_STATUS}" 'login fails when the helper accepts but stores nothing'
+  assert_contains "${LOGIN_OUTPUT}" 'fake' 'login names the configured helper'
+  assert_not_contains "${LOGIN_OUTPUT}" 'no credential helper configured' \
+    'login does not blame missing configuration when a helper is configured'
+  assert_not_contains "${LOGIN_OUTPUT}" 'p@ss word' 'login never echoes the password'
+}
+
+test_login_lists_every_helper_that_could_have_answered() {
+  rm -f "${FAKE_CREDENTIAL_STORE}"
+
+  FAKE_IGNORE_STORE=1 run_login two-helpers 'ci-user' 'p@ss word'
+
+  assert_equals 1 "${LOGIN_STATUS}" 'login fails when no helper returns the password'
+  assert_contains "${LOGIN_OUTPUT}" 'first' 'the first configured helper is listed'
+  assert_contains "${LOGIN_OUTPUT}" 'fake' 'the second configured helper is listed'
 }
 
 test_login_reports_credentials_that_came_back_different() {
@@ -293,6 +309,7 @@ test_credentials_are_inserted_before_the_terminator
 test_login_stores_the_credentials
 test_login_reports_when_nothing_was_stored
 test_login_reports_a_helper_that_silently_ignores_the_store
+test_login_lists_every_helper_that_could_have_answered
 test_login_reports_credentials_that_came_back_different
 
 printf '\n%s assertions, %s failures\n' "${ASSERTIONS}" "${FAILURES}"

--- a/tests/shell/ddev-artifacts-commands.sh
+++ b/tests/shell/ddev-artifacts-commands.sh
@@ -138,31 +138,29 @@ test_public_repository_needs_no_credentials() {
 }
 
 test_public_repository_does_not_need_git() {
-  # nothing on the public path talks to git, so a machine without it can still sync core artifacts
-  local without_git="${TEST_DIR}/bin-without-git"
-  local binary=''
-
-  mkdir -p "${without_git}"
-  ln -sf "${TEST_DIR}/bin/ddev" "${without_git}/ddev"
-
-  for binary in cat sed bash env; do
-    ln -sf "$(command -v "${binary}")" "${without_git}/${binary}"
-  done
+  # nothing on the public path talks to git, so a machine without it can still sync core artifacts.
+  # The check is that require_git is never consulted: overriding it to fail would stop the sync if it
+  # were. PATH cannot be stripped instead, because Git Bash needs its own directory on it.
+  local status=0
 
   rm -f "${TEST_DIR}/args"
 
-  local status=0
   (
     export GIT_CONFIG_GLOBAL="${TEST_DIR}/no-helper"
-    export PATH="${without_git}"
     source "${LIBRARY}"
-    matomo_artifacts::sync tests:sync-ui-screenshots 12345 2>&1 </dev/null
-  ) >/dev/null
+
+    matomo_artifacts::require_git() {
+      echo 'require_git was called on the public path' >&2
+      return 1
+    }
+
+    matomo_artifacts::sync tests:sync-ui-screenshots 12345 </dev/null
+  ) >/dev/null 2>&1
   status=$?
 
-  assert_equals 0 "${status}" 'a public sync works with no git on PATH'
+  assert_equals 0 "${status}" 'a public sync does not depend on git being installed'
   assert_contains "$(cat "${TEST_DIR}/args" 2>/dev/null)" 'tests:sync-ui-screenshots' \
-    'the console still runs without git'
+    'the console still runs when git is unavailable'
 }
 
 test_premium_repository_sends_the_credentials() {


### PR DESCRIPTION
### Description

Syncing expected UI screenshots or system test files from a premium plugin's CI build needed the artifacts server password on the command line, where it ends up in the process list and in shell history. Both sync commands now accept `--http-password-stdin` and read the password from standard input instead.

Three DDEV host commands build on that, so the password does not have to be handled by hand at all. `ddev matomo:artifacts:login` stores it once, and `ddev matomo:artifacts:sync-screenshots` and `ddev matomo:artifacts:sync-system-tests` fetch it when a sync actually needs it. Syncing from `matomo-org/matomo` is unaffected and needs no credentials at all, because those artifacts are public.

The credentials come from git, so which credential helper holds the password is your own configuration, exactly as it is for `git push`; the `.ddev` README recommends a keychain-backed helper for each operating system. Because git silently stores nothing when no helper is configured, the login command reads the credential back afterwards and tells you if that happened, rather than reporting a success you did not get.

The existing `--http-user` and `--http-password` options are unchanged, so CI and any existing scripts keep working.

The host commands are covered by `tests/shell/ddev-artifacts-commands.sh`, which needs neither DDEV nor credentials and runs on Linux, macOS and Windows, and the new console option by a unit test.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
