### PR TITLE
Base the token-only two-factor authentication exemption on the token that granted access

### DIFF
--- a/plugins/TwoFactorAuth/TwoFactorAuth.php
+++ b/plugins/TwoFactorAuth/TwoFactorAuth.php
@@ -303,9 +303,18 @@ class TwoFactorAuth extends \Piwik\Plugin
         }
 
         $auth = StaticContainer::get('Piwik\Auth');
-        if (!$auth->getLogin() && method_exists($auth, 'getTokenAuth') && $auth->getTokenAuth()) {
+        if (
+            !$auth->getLogin()
+            && method_exists($auth, 'getTokenAuth')
+            && $auth->getTokenAuth()
+            && $auth->getTokenAuth() === Access::getInstance()->getTokenAuth()
+        ) {
             // when authenticated by token only, we do not require 2fa
             // needed eg for rendering exported widgets authenticated by token
+            //
+            // the token must also be the one the current access was granted with. a session
+            // authenticating the request keeps its own token, so a token that does not match it did
+            // not authenticate anything and must not exempt the request from 2fa
             return false;
         }
 

--- a/plugins/TwoFactorAuth/tests/Integration/TwoFactorAuthTest.php
+++ b/plugins/TwoFactorAuth/tests/Integration/TwoFactorAuthTest.php
@@ -17,6 +17,7 @@ use Piwik\Nonce;
 use Piwik\Session\SessionFingerprint;
 use Piwik\Session\SessionNamespace;
 use Piwik\Container\StaticContainer;
+use Piwik\Plugins\Login\Auth as LoginAuth;
 use Piwik\Plugins\Login\Security\BruteForceDetection;
 use Piwik\Plugins\TwoFactorAuth\Dao\RecoveryCodeDao;
 use Piwik\Plugins\TwoFactorAuth\Dao\TwoFaSecretRandomGenerator;
@@ -28,6 +29,7 @@ use Piwik\Plugins\TwoFactorAuth\Validator;
 use Piwik\Plugins\UsersManager\API;
 use Piwik\Plugins\UsersManager\Model;
 use Piwik\Plugins\UsersManager\UserUpdater;
+use Piwik\Request\AuthenticationToken;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
 /**
@@ -96,7 +98,14 @@ class TwoFactorAuthTest extends IntegrationTestCase
     public function tearDown(): void
     {
         $this->bruteForceDetection->deleteAll();
-        unset($_GET['authCode'], $_GET['authCodeNonce'], $_GET['module'], $_GET['action']);
+        unset(
+            $_GET['authCode'],
+            $_GET['authCodeNonce'],
+            $_GET['module'],
+            $_GET['action'],
+            $_GET['token_auth'],
+            $_GET['force_api_session']
+        );
         // the session is not reset between tests, so leftover fingerprints or setup secrets would leak
         $_SESSION = [];
     }
@@ -271,6 +280,69 @@ class TwoFactorAuthTest extends IntegrationTestCase
         $this->assertSame('login', $action);
         $this->assertNull($sessionFingerprint->getUser());
         $this->assertTrue(Access::getInstance()->wasSessionExpired());
+    }
+
+    public function testOnRequestDispatchRequiresTwoFactorAuthWhenTokenDidNotAuthenticateTheRequest()
+    {
+        // the session authenticated the request and kept its own token, so the supplied token is not
+        // the one the current access was granted with
+        $this->setCurrentUser($this->otherUserWith2Fa, 'pending-session-token');
+        $sessionFingerprint = new SessionFingerprint();
+        $sessionFingerprint->initialize($this->userWith2Fa, 'pending-session-token');
+
+        $this->setTokenAuthRequest('a-different-token', true);
+
+        $module = 'Widgetize';
+        $action = 'iframe';
+        $parameters = [];
+
+        $plugin = new TwoFactorAuth();
+        $plugin->onRequestDispatch($module, $action, $parameters);
+
+        $this->assertSame(\Piwik\Piwik::getLoginPluginName(), $module);
+        $this->assertSame('login', $action);
+    }
+
+    public function testOnRequestDispatchSkipsTwoFactorAuthWhenAuthenticatedByTokenOnly()
+    {
+        // the supplied token is the one the current access was granted with, which is needed eg for
+        // rendering exported widgets authenticated by token
+        $this->setCurrentUser($this->otherUserWith2Fa, 'a-token-that-authenticated');
+        $sessionFingerprint = new SessionFingerprint();
+        $sessionFingerprint->initialize($this->userWith2Fa, 'pending-session-token');
+
+        $this->setTokenAuthRequest('a-token-that-authenticated', false);
+
+        $module = 'Widgetize';
+        $action = 'iframe';
+        $parameters = [];
+
+        $plugin = new TwoFactorAuth();
+        $plugin->onRequestDispatch($module, $action, $parameters);
+
+        $this->assertSame('Widgetize', $module);
+        $this->assertSame('iframe', $action);
+    }
+
+    public function testOnRequestDispatchSkipsTwoFactorAuthWhenTokenAuthenticatedRequestDespiteForcedSessionAuth()
+    {
+        // `force_api_session=1` only asks for session authentication - when that does not happen the
+        // token still authenticates the request, and such a request stays exempt from 2fa
+        $this->setCurrentUser($this->otherUserWith2Fa, 'a-token-that-authenticated');
+        $sessionFingerprint = new SessionFingerprint();
+        $sessionFingerprint->initialize($this->userWith2Fa, 'pending-session-token');
+
+        $this->setTokenAuthRequest('a-token-that-authenticated', true);
+
+        $module = 'Widgetize';
+        $action = 'iframe';
+        $parameters = [];
+
+        $plugin = new TwoFactorAuth();
+        $plugin->onRequestDispatch($module, $action, $parameters);
+
+        $this->assertSame('Widgetize', $module);
+        $this->assertSame('iframe', $action);
     }
 
     public function testValidatorDetectsPendingSessionUserMismatch()
@@ -507,13 +579,33 @@ class TwoFactorAuthTest extends IntegrationTestCase
         return $code->getCode($secret);
     }
 
-    private function setCurrentUser(string $login): void
+    /**
+     * Puts the request and the auth object into the state they have after a token was supplied and
+     * `Piwik\Plugins\Login\Login::apiRequestAuthenticate()` reloaded the auth for it.
+     */
+    private function setTokenAuthRequest(string $tokenAuth, bool $forceApiSession): void
+    {
+        $_GET['token_auth'] = $tokenAuth;
+
+        if ($forceApiSession) {
+            $_GET['force_api_session'] = '1';
+        }
+
+        StaticContainer::getContainer()->set(AuthenticationToken::class, new AuthenticationToken());
+
+        $auth = new LoginAuth();
+        $auth->setLogin(null);
+        $auth->setTokenAuth($tokenAuth);
+        StaticContainer::getContainer()->set('Piwik\Auth', $auth);
+    }
+
+    private function setCurrentUser(string $login, ?string $tokenAuth = null): void
     {
         $auth = $this->getMockBuilder(Auth::class)
                     ->onlyMethods(['getName', 'setTokenAuth', 'getTokenAuthSecret', 'getLogin', 'setLogin', 'setPassword', 'setPasswordHash', 'authenticate'])
                     ->getMock();
         $auth->method('authenticate')
-            ->willReturn(new AuthResult(AuthResult::SUCCESS, $login, $login . '-token'));
+            ->willReturn(new AuthResult(AuthResult::SUCCESS, $login, $tokenAuth ?? $login . '-token'));
 
         Access::getInstance()->setSuperUserAccess(false);
         Access::getInstance()->reloadAccess($auth);


### PR DESCRIPTION
### Description

`TwoFactorAuth::requiresAuth()` exempts a request from two-factor authentication when it was authenticated by an auth token rather than by a session. That exemption is needed for exported and embedded widgets, which authenticate with a token and have no second factor to present.

The exemption was inferred indirectly, from the state of the auth object — an empty login together with a non-empty token — rather than from the token that actually granted the request its access. Those two are not equivalent, so the check did not always reflect what had authenticated the request.

**The change**

The exemption now additionally requires the supplied token to be the one the current access was granted with:

```php
&& $auth->getTokenAuth() === Access::getInstance()->getTokenAuth()
```

`Login\Auth::authenticate()` puts the supplied token into its `AuthResult` and `Access::reloadAccess()` stores exactly that, so a request that really was authenticated by its token still matches and stays exempt — which is what exported and embedded widgets rely on. Where the access was granted by something else, the tokens differ and the exemption no longer applies.

The comparison is placed last in the condition, so it is only evaluated when the login is already empty and a token is already present, and it fails closed: a custom auth implementation whose result carries a different token means two-factor authentication is required rather than skipped.

**Alternative considered**

An earlier iteration derived this from the request parameters instead. Comparing the tokens expresses the intended rule directly and keeps behaviour unchanged for requests that legitimately authenticate with a token.

**Tests**

Three integration tests in `plugins/TwoFactorAuth/tests/Integration/TwoFactorAuthTest.php` pin the exemption from both sides: it must not apply when the supplied token is not the one that granted the current access, and it must still apply when it is. Each was verified by mutation — every test fails under a different wrong form of the condition, and all three pass only with the implemented comparison.

Also run: the full `TwoFactorAuth` suite, `Login`, `Widgetize` controller tests, `API`, `SessionAuth` and `AuthenticationToken` tests, plus the `TwoFactorAuth` UI spec covering widget rendering by token. PHPCS and PHPStan are clean on both files.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
