### PR TITLE
Resync the UsersManager superuser access expected screenshot

### DIFF
--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_superuser_tab_activityLog.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_superuser_tab_activityLog.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9aab25a9dcbe49eac78ce9c1a5bbb2e7ff38b6fc2151e6c3e1b8032265bf5056
-size 107723
+oid sha256:8a7f4530f1b9e430ee77d1e556dc0e8d6dbb396b65504288b9e000640f0e4005
+size 107729


### PR DESCRIPTION
### Description

`UsersManager_superuser_tab_activityLog.png` no longer matches what the superuser access tab renders on `6.x-dev`, so `UI-plugins (UsersManager)` fails on the branch itself and on anything branched from it.

The difference is confined to the "Potential risks are:" list: seven of its fifteen text lines sit exactly one pixel lower than the stored baseline. Wording, wrapping, colours, glyph rendering and the block's overall bounds are unchanged, and every other part of the page is pixel-identical. The comparison reports the same 22897 pixels every time, and three separate CI runs produced a byte-identical image, so the new rendering is deterministic rather than a flake.

This replaces the expectation with the image CI generates.

### Review

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
