### PR TITLE
Announce the granular compliance settings in What's New

### DIFF
--- a/plugins/PrivacyManager/PrivacyManager.php
+++ b/plugins/PrivacyManager/PrivacyManager.php
@@ -23,8 +23,10 @@ use Piwik\Period;
 use Piwik\Period\Range;
 use Piwik\Piwik;
 use Piwik\Plugin;
+use Piwik\Plugins\FeatureFlags\FeatureFlagManager;
 use Piwik\Plugins\Goals\Archiver;
 use Piwik\Plugins\Installation\FormDefaultSettings;
+use Piwik\Plugins\PrivacyManager\FeatureFlags\GranularPrivacyCompliance;
 use Piwik\Plugins\PrivacyManager\Model\LogDataAnonymizations;
 use Piwik\Plugins\PrivacyManager\Settings\IPAnonymisation;
 use Piwik\Request;
@@ -49,6 +51,13 @@ class PrivacyManager extends Plugin
     public const OPTION_LAST_DELETE_PIWIK_LOGS_INITIAL = "lastDelete_piwik_logs_initial";
     public const OPTION_USERID_SALT = 'useridsalt';
 
+    /**
+     * Title of the What's New entry in `changes.json` announcing the granular compliance settings.
+     * The entry is only shown while the feature it announces is available.
+     *
+     * @internal
+     */
+    public const CHANGE_TITLE_GRANULAR_COMPLIANCE = 'More control over CNIL compliance settings';
 
     // options for data purging feature array[configName => configSection]
     public static $purgeDataOptions = [
@@ -191,7 +200,30 @@ class PrivacyManager extends Plugin
             'CustomJsTracker.shouldAddTrackerFile'    => 'shouldAddTrackerFile',
             'Request.shouldDisablePostProcessing'     => 'shouldDisablePostProcessing',
             'SitesManager.deleteSite.end'             => 'deleteSiteSpecificAnonymisationSettings',
+            'Changes.filterChanges'                   => 'filterChanges',
         ];
+    }
+
+    /**
+     * Hides the What's New entry announcing the granular compliance settings while that feature is
+     * not available.
+     *
+     * The entry is recorded when the plugin is updated, but the feature flag can be switched on or
+     * off at any time afterwards, so the entry is filtered when it is displayed rather than when it
+     * is recorded.
+     *
+     * @param array<int|string, array<string, mixed>> $changes
+     */
+    public function filterChanges(array &$changes): void
+    {
+        if (StaticContainer::get(FeatureFlagManager::class)->isFeatureActive(GranularPrivacyCompliance::class)) {
+            return;
+        }
+
+        $changes = array_values(array_filter($changes, static function ($change) {
+            return ($change['plugin_name'] ?? '') !== 'PrivacyManager'
+                || ($change['title'] ?? '') !== self::CHANGE_TITLE_GRANULAR_COMPLIANCE;
+        }));
     }
 
     public function shouldDisablePostProcessing(&$shouldDisable, $request)

--- a/plugins/PrivacyManager/changes.json
+++ b/plugins/PrivacyManager/changes.json
@@ -1,5 +1,10 @@
 [
   {
+    "title":       "More control over CNIL compliance settings",
+    "description": "Superusers can now manage individual CNIL requirements from the CNIL compliance page while keeping the option to enforce the full configuration in one step. Improved descriptions and impact details make each requirement easier to assess, while related Matomo settings stay aligned. The same granular controls are also available through the API.",
+    "version":     "5.14.0"
+  },
+  {
     "title":       "User Opt-Out Improvements",
     "description": "The privacy manager user opt-out has been updated to provide new code generation options that improve compatibility and allow additional customisation.",
     "version":     "4.12.0",

--- a/plugins/PrivacyManager/tests/Integration/WhatsNewChangeTest.php
+++ b/plugins/PrivacyManager/tests/Integration/WhatsNewChangeTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\PrivacyManager\tests\Integration;
+
+use Piwik\Changes\Model as ChangesModel;
+use Piwik\Config;
+use Piwik\Plugins\PrivacyManager\PrivacyManager;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * The What's New entry announcing the granular compliance settings is only shown while the feature
+ * it announces is available.
+ *
+ * @group PrivacyManager
+ * @group Plugins
+ */
+class WhatsNewChangeTest extends IntegrationTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        (new ChangesModel())->addChanges('PrivacyManager');
+    }
+
+    public function testChangesFileAnnouncesTheGranularComplianceSettingsOnce(): void
+    {
+        $titles = array_column($this->getChangesFile(), 'title');
+
+        // The filter matches the entry by title, so the two must not drift apart.
+        self::assertCount(1, array_keys($titles, PrivacyManager::CHANGE_TITLE_GRANULAR_COMPLIANCE, true));
+    }
+
+    public function testGranularComplianceChangeIsShownWhenTheFeatureIsEnabled(): void
+    {
+        $this->setGranularComplianceFeature('enabled');
+
+        self::assertContains(PrivacyManager::CHANGE_TITLE_GRANULAR_COMPLIANCE, $this->getChangeTitles());
+    }
+
+    public function testGranularComplianceChangeIsHiddenWhenTheFeatureIsDisabled(): void
+    {
+        $this->setGranularComplianceFeature('disabled');
+
+        self::assertNotContains(PrivacyManager::CHANGE_TITLE_GRANULAR_COMPLIANCE, $this->getChangeTitles());
+    }
+
+    public function testFilteringKeepsTheOtherChangesAsAList(): void
+    {
+        $this->setGranularComplianceFeature('disabled');
+
+        $changes = (new ChangesModel())->getChangeItems();
+
+        self::assertNotEmpty($changes);
+        self::assertSame(range(0, count($changes) - 1), array_keys($changes));
+        self::assertContains('User Opt-Out Improvements', array_column($changes, 'title'));
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function getChangeTitles(): array
+    {
+        // A new model per call: the change items are cached per instance.
+        return array_column((new ChangesModel())->getChangeItems(), 'title');
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function getChangesFile(): array
+    {
+        $changes = json_decode(file_get_contents(__DIR__ . '/../../changes.json'), true);
+
+        self::assertIsArray($changes);
+
+        return $changes;
+    }
+
+    private function setGranularComplianceFeature(string $state): void
+    {
+        Config::getInstance()->FeatureFlags = ['GranularPrivacyCompliance_feature' => $state];
+    }
+}


### PR DESCRIPTION
### Description

Adds a What's New entry announcing the granular compliance settings, and hides it while the `GranularPrivacyCompliance` feature flag is inactive, so the announcement and the feature it announces appear together.

**Why the entry is filtered when it is displayed**

`GranularPrivacyCompliance` is stored only in `config.ini.php`, so it can be switched on or off at any time without a plugin update. Change entries, on the other hand, are recorded once, on `Updater.componentUpdated` or `PluginManager.pluginActivated`.

Omitting the entry at *record* time — by overriding `Plugin::getChanges()` — would therefore be a one-shot decision: an instance that enables the flag after upgrading would never see the entry, and one that disables it would keep the entry forever.

Instead `PrivacyManager` subscribes to the existing `Changes.filterChanges` event, which `Piwik\Changes\Model` documents for exactly this purpose. The entry is then hidden or shown according to the current flag state, in both directions. Because `UserChanges::markChangesAsRead()` works off the same filtered list, an entry hidden while the flag was off is never marked as read, so enabling the flag later still announces it as new.

**Changes**

- `plugins/PrivacyManager/changes.json` — the new entry. No link: the compliance page is superuser-only while What's New is shown to every logged-in user, so a call to action there would not be followable by most viewers.
- `plugins/PrivacyManager/PrivacyManager.php` — registers `Changes.filterChanges` and adds the `filterChanges()` handler. The entry's title is held in a constant so the filter and the JSON file cannot drift apart.
- `plugins/PrivacyManager/tests/Integration/WhatsNewChangeTest.php` — new integration coverage.

**Validation**

- New integration tests cover the flag-enabled case, the flag-disabled case, the list shape the filter must preserve, and the title-drift guard. The disabled-case test was confirmed to fail without the event registration.
- `plugins/CoreHome/tests/Integration/ChangesTest.php`, `plugins/Login/tests/Integration/WhatsNewProviderTest.php` and `plugins/Login/tests/Integration/WhatsNewPanelRenderTest.php` all pass — these are the other consumers of the changes list.
- PHPCS and PHPStan are clean on the touched files.
- Verified end to end on a local instance in both flag states.

Note the entry's `version` is `5.14.0` rather than `6.0.0` because this is intended for backport. The `changes` table's unique key is `(plugin_name, version, title)`, so one identical version string on both branches keeps the backport byte-identical and lets `INSERT IGNORE` dedupe — otherwise anyone upgrading 5.13 → 5.14 → 6.0 would receive the same announcement twice. The version is never rendered.

### Step by step tests

1. On an upgraded instance (not a fresh install) with `GranularPrivacyCompliance` enabled in `config.ini.php`, log in as a superuser and open the What's New page.
  👁️ A card titled "More control over CNIL compliance settings" is listed, with no link, ordered among the most recent entries.
2. Set `GranularPrivacyCompliance_feature = "disabled"`, run `./console core:clear-caches`, and reload.
  👁️ That card is gone; every other entry still renders.
3. Open *Administration → Privacy → Compliance* with the flag still off.
  👁️ The legacy compliance card is shown rather than the granular dashboard — the announcement and the feature match.
4. Re-enable the flag, clear caches, and reload the What's New page.
  👁️ The card is listed again.
5. With the flag off, choose "Do not show this again" on the What's New popup, then enable the flag and reload.
  👁️ The entry still counts as unread and re-appears, because a hidden entry is never marked as read.
6. Load a few normal admin and reporting pages with the flag both on and off.
  👁️ Pages render normally — the filter runs on every admin page render.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
