### PR TITLE
Use effective host for trusted host validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 ## Matomo 6.0.0
 
 ### Breaking Changes
+* When `[General] proxy_host_headers` is configured, the effective hostname from those headers is now validated against `trusted_hosts`. Proxied installations should list their public hostname or hostnames in `trusted_hosts`; new installations do this automatically.
 * The deprecated method `Piwik\Archive::getBlob()` has been removed. Use one of the `Piwik\Archive::getDataTable*()` methods instead.
 * The deprecated method `Piwik\Archive::clearStaticCache()` has been removed. It was a no-op kept only for backwards compatibility.
 * The deprecated method `Piwik\ArchiveProcessor\Parameters::setIsPartialArchive()` has been removed. Use `Piwik\ArchiveProcessor\Parameters::setArchiveOnlyReport()` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 ## Matomo 6.0.0
 
 ### Breaking Changes
-* When `[General] proxy_host_headers` is configured, the effective hostname from those headers is now validated against `trusted_hosts`. Proxied installations should list their public hostname or hostnames in `trusted_hosts`; new installations do this automatically.
+* When `[General] proxy_host_headers` is configured, the hostname from those headers is now validated against `trusted_hosts`: `Piwik\Url::isValidHost()` checks it instead of the `Host` header, and `Piwik\Url::getCurrentHost()` — with the `Piwik\Url::getCurrentUrl*()` family built on it — returns the `Host` header's value when it is untrusted. A proxied installation must list its public hostname in `trusted_hosts` alongside the hostname the proxy reaches Matomo by; new installations record both.
 * The deprecated method `Piwik\Archive::getBlob()` has been removed. Use one of the `Piwik\Archive::getDataTable*()` methods instead.
 * The deprecated method `Piwik\Archive::clearStaticCache()` has been removed. It was a no-op kept only for backwards compatibility.
 * The deprecated method `Piwik\ArchiveProcessor\Parameters::setIsPartialArchive()` has been removed. Use `Piwik\ArchiveProcessor\Parameters::setArchiveOnlyReport()` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 ## Matomo 6.0.0
 
 ### Breaking Changes
-* Before upgrading a proxied installation that configures `[General] proxy_host_headers`, add both the public hostname and the hostname used to reach Matomo to `trusted_hosts`. Matomo 6 validates the hostname from configured proxy host headers against `trusted_hosts`; new installations record both hostnames automatically.
+* Before upgrading a proxied installation that configures `[General] proxy_host_headers`, add both the public hostname and the hostname used to reach Matomo to `trusted_hosts`; otherwise the invalid-host warning replaces the login form. With trusted-host checking enabled, `Piwik\Url::isValidHost()` without an explicit hostname now validates the proxy-derived hostname, and `Piwik\Url::getCurrentHost()` returns that hostname only when it is accepted, falling back to the request/configuration-derived hostname otherwise. New installations record both hostnames automatically.
 * The deprecated method `Piwik\Archive::getBlob()` has been removed. Use one of the `Piwik\Archive::getDataTable*()` methods instead.
 * The deprecated method `Piwik\Archive::clearStaticCache()` has been removed. It was a no-op kept only for backwards compatibility.
 * The deprecated method `Piwik\ArchiveProcessor\Parameters::setIsPartialArchive()` has been removed. Use `Piwik\ArchiveProcessor\Parameters::setArchiveOnlyReport()` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 ## Matomo 6.0.0
 
 ### Breaking Changes
-* When `[General] proxy_host_headers` is configured, the hostname from those headers is now validated against `trusted_hosts`: `Piwik\Url::isValidHost()` checks it instead of the `Host` header, and `Piwik\Url::getCurrentHost()` — with the `Piwik\Url::getCurrentUrl*()` family built on it — returns the `Host` header's value when it is untrusted. A proxied installation must list its public hostname in `trusted_hosts` alongside the hostname the proxy reaches Matomo by; new installations record both.
+* Before upgrading a proxied installation that configures `[General] proxy_host_headers`, add both the public hostname and the hostname used to reach Matomo to `trusted_hosts`. Matomo 6 validates the hostname from configured proxy host headers against `trusted_hosts`; new installations record both hostnames automatically.
 * The deprecated method `Piwik\Archive::getBlob()` has been removed. Use one of the `Piwik\Archive::getDataTable*()` methods instead.
 * The deprecated method `Piwik\Archive::clearStaticCache()` has been removed. It was a no-op kept only for backwards compatibility.
 * The deprecated method `Piwik\ArchiveProcessor\Parameters::setIsPartialArchive()` has been removed. Use `Piwik\ArchiveProcessor\Parameters::setArchiveOnlyReport()` instead.

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -728,7 +728,8 @@ multi_server_environment = 0
 ;proxy_client_headers[] = HTTP_X_FORWARDED_FOR
 
 ; List of proxy headers for the public hostname. When configured, the hostname from these headers takes precedence over
-; the Host header and is validated against trusted_hosts.
+; the Host header and is validated against trusted_hosts. List both names in trusted_hosts: the tracker config cache is
+; keyed on the Host header and is only written for a host listed there.
 ;
 ; de facto standard (X-Forwarded-Host)
 ;proxy_host_headers[] = HTTP_X_FORWARDED_HOST

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -727,7 +727,8 @@ multi_server_environment = 0
 ; de facto standard (X-Forwarded-For)
 ;proxy_client_headers[] = HTTP_X_FORWARDED_FOR
 
-; List of proxy headers for host IP addresses
+; List of proxy headers for the public hostname. When configured, the hostname from these headers takes precedence over
+; the Host header and is validated against trusted_hosts.
 ;
 ; de facto standard (X-Forwarded-Host)
 ;proxy_host_headers[] = HTTP_X_FORWARDED_HOST

--- a/core/Plugin/Controller.php
+++ b/core/Plugin/Controller.php
@@ -878,7 +878,7 @@ abstract class Controller
             // invalid host, so display warning to user
             $validHosts = Url::getTrustedHostsFromConfig();
             $validHost = $validHosts[0];
-            $invalidHost = Common::sanitizeInputValue(Url::getHost(false));
+            $invalidHost = Common::sanitizeInputValue(Url::getCurrentHost('unknown', false));
 
             $emailSubject = rawurlencode(Piwik::translate('CoreHome_InjectedHostEmailSubject', $invalidHost));
             $emailBody = rawurlencode(Piwik::translate('CoreHome_InjectedHostEmailBody'));

--- a/core/SettingsPiwik.php
+++ b/core/SettingsPiwik.php
@@ -202,15 +202,21 @@ class SettingsPiwik
             || $currentUrl !== $url
         ) {
             $host = Url::getHostFromUrl($currentUrl);
+            // an untrusted forwarded host falls back to the proxy-facing name, not the public one
+            $hasTrustedProxyHost = Url::hasTrustedProxyHost();
 
             if (
                 strlen($currentUrl) >= strlen('http://a/')
                 && Url::isValidHost($host)
                 && !Url::isLocalHost($host)
+                && $hasTrustedProxyHost
             ) {
                 self::overwritePiwikUrl($currentUrl);
             }
-            $url = $currentUrl;
+
+            if ($hasTrustedProxyHost || empty($url)) {
+                $url = $currentUrl;
+            }
         }
 
         if (ProxyHttp::isHttps()) {

--- a/core/SettingsPiwik.php
+++ b/core/SettingsPiwik.php
@@ -202,19 +202,18 @@ class SettingsPiwik
             || $currentUrl !== $url
         ) {
             $host = Url::getHostFromUrl($currentUrl);
-            // an untrusted forwarded host falls back to the proxy-facing name, not the public one
-            $hasTrustedProxyHost = Url::hasTrustedProxyHost();
+            $isProxyHostValid = Url::isProxyHostValid();
 
             if (
                 strlen($currentUrl) >= strlen('http://a/')
                 && Url::isValidHost($host)
                 && !Url::isLocalHost($host)
-                && $hasTrustedProxyHost
+                && $isProxyHostValid
             ) {
                 self::overwritePiwikUrl($currentUrl);
             }
 
-            if ($hasTrustedProxyHost || empty($url)) {
+            if ($isProxyHostValid || empty($url)) {
                 $url = $currentUrl;
             }
         }

--- a/core/Url.php
+++ b/core/Url.php
@@ -408,9 +408,10 @@ class Url
     }
 
     /**
-     * Returns the current host.
+     * Returns the current host, preferring the hostname from proxy_host_headers when configured.
      *
-     * @param string $default Default value to return if host unknown
+     * @param string $default Default value to return if the host is unknown. Also returned in place
+     *                        of a proxy-supplied hostname that is not trusted.
      * @param bool $checkTrustedHost Whether to do trusted host check. Should ALWAYS be true,
      *                               except in Controller.
      * @return string eg, `"example.org"` if the current URL is
@@ -428,13 +429,40 @@ class Url
 
         $host = self::getHost($checkTrustedHost);
         $default = Common::sanitizeInputValue($host ? $host : $default);
-        $host = IP::getNonProxyIpFromHeader($default, $hostHeaders);
+        $hostFromProxyHeader = IP::getNonProxyIpFromHeader($default, $hostHeaders);
 
-        if ($checkTrustedHost && !self::isValidHost($host)) {
+        // no proxy header supplied a host, so getHost() already checked it
+        if ($hostFromProxyHeader === $default) {
             return $default;
         }
 
-        return $host;
+        if ($checkTrustedHost && !self::isValidHost($hostFromProxyHeader)) {
+            return $default;
+        }
+
+        return $hostFromProxyHeader;
+    }
+
+    /**
+     * Whether the host the proxy headers report is trusted. True when no proxy header supplied one.
+     *
+     * @internal
+     */
+    public static function hasTrustedProxyHost(): bool
+    {
+        $hostHeaders = GeneralConfig::getConfigValue('proxy_host_headers');
+
+        if (!is_array($hostHeaders)) {
+            return true;
+        }
+
+        foreach ($hostHeaders as $hostHeader) {
+            if (!empty($_SERVER[$hostHeader])) {
+                return self::isValidHost(self::getCurrentHost('', false));
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/core/Url.php
+++ b/core/Url.php
@@ -230,11 +230,10 @@ class Url
     }
 
     /**
-     * Validates the **Host** HTTP header (untrusted user input). Used to prevent Host header
-     * attacks.
+     * Checks whether the effective host for the current request is allowed. If proxy host headers are configured,
+     * they take precedence over the Host header.
      *
-     * @param string|null|false $host Contents of Host: header from the HTTP request. If `false`, gets the
-     *                          value from the request.
+     * @param string|null|false $host Hostname to check. If `false`, gets the effective host from the request.
      * @return bool `true` if valid; `false` otherwise.
      */
     public static function isValidHost($host = false): bool
@@ -248,7 +247,7 @@ class Url
         }
 
         if (false === $host || null === $host) {
-            $host = self::getHostFromServerVariable();
+            $host = self::getCurrentHost('', false);
             if (empty($host)) {
                 // if no current host, assume valid
                 return true;
@@ -429,8 +428,13 @@ class Url
 
         $host = self::getHost($checkTrustedHost);
         $default = Common::sanitizeInputValue($host ? $host : $default);
+        $host = IP::getNonProxyIpFromHeader($default, $hostHeaders);
 
-        return IP::getNonProxyIpFromHeader($default, $hostHeaders);
+        if ($checkTrustedHost && !self::isValidHost($host)) {
+            return $default;
+        }
+
+        return $host;
     }
 
     /**

--- a/core/Url.php
+++ b/core/Url.php
@@ -410,8 +410,7 @@ class Url
     /**
      * Returns the current host, preferring the hostname from proxy_host_headers when configured.
      *
-     * @param string $default Default value to return if the host is unknown. Also returned in place
-     *                        of a proxy-supplied hostname that is not trusted.
+     * @param string $default Default value to return if no host can be resolved from the request or configuration.
      * @param bool $checkTrustedHost Whether to do trusted host check. Should ALWAYS be true,
      *                               except in Controller.
      * @return string eg, `"example.org"` if the current URL is
@@ -444,9 +443,10 @@ class Url
     }
 
     /**
-     * Whether the host the proxy headers report is trusted. True when no proxy header supplied one.
+     * Checks the host from the first configured proxy host header that is present.
      *
      * @internal
+     * @return bool True if no configured proxy host header is present or its host is trusted.
      */
     public static function hasTrustedProxyHost(): bool
     {

--- a/core/Url.php
+++ b/core/Url.php
@@ -419,18 +419,10 @@ class Url
      */
     public static function getCurrentHost($default = 'unknown', $checkTrustedHost = true)
     {
-        $hostHeaders = [];
-
-        $hostHeadersInConfig = GeneralConfig::getConfigValue('proxy_host_headers');
-        if (is_array($hostHeadersInConfig)) {
-            $hostHeaders = $hostHeadersInConfig;
-        }
-
         $host = self::getHost($checkTrustedHost);
         $default = Common::sanitizeInputValue($host ? $host : $default);
-        $hostFromProxyHeader = IP::getNonProxyIpFromHeader($default, $hostHeaders);
+        $hostFromProxyHeader = self::getHostFromProxyHeaders($default);
 
-        // no proxy header supplied a host, so getHost() already checked it
         if ($hostFromProxyHeader === $default) {
             return $default;
         }
@@ -443,26 +435,25 @@ class Url
     }
 
     /**
-     * Checks the host from the first configured proxy host header that is present.
-     *
      * @internal
-     * @return bool True if no configured proxy host header is present or its host is trusted.
      */
-    public static function hasTrustedProxyHost(): bool
+    public static function isProxyHostValid(): bool
+    {
+        $host = self::getHost();
+        $default = Common::sanitizeInputValue($host ?: '');
+        $hostFromProxyHeader = self::getHostFromProxyHeaders($default);
+
+        return $hostFromProxyHeader === $default || self::isValidHost($hostFromProxyHeader);
+    }
+
+    private static function getHostFromProxyHeaders(string $default): string
     {
         $hostHeaders = GeneralConfig::getConfigValue('proxy_host_headers');
-
         if (!is_array($hostHeaders)) {
-            return true;
+            $hostHeaders = [];
         }
 
-        foreach ($hostHeaders as $hostHeader) {
-            if (!empty($_SERVER[$hostHeader])) {
-                return self::isValidHost(self::getCurrentHost('', false));
-            }
-        }
-
-        return true;
+        return IP::getNonProxyIpFromHeader($default, $hostHeaders);
     }
 
     /**

--- a/plugins/Installation/Controller.php
+++ b/plugins/Installation/Controller.php
@@ -704,11 +704,19 @@ class Controller extends ControllerAdmin
      */
     private function setTrustedHost(Config $config): void
     {
-        $host = Url::getCurrentHost('', false);
+        $hosts = [];
 
-        // check hostname in server variables is correctly parsable
-        if ($host === $this->extractHostAndPort('http://' . $host)) {
-            $config->General['trusted_hosts'] = [$host];
+        // the Host header is trusted alongside the public hostname because the tracker config cache
+        // is keyed on it
+        foreach ([Url::getCurrentHost('', false), Url::getHost(false)] as $host) {
+            // check hostname in server variables is correctly parsable
+            if (!empty($host) && $host === $this->extractHostAndPort('http://' . $host)) {
+                $hosts[] = $host;
+            }
+        }
+
+        if (!empty($hosts)) {
+            $config->General['trusted_hosts'] = array_values(array_unique($hosts));
         }
     }
 

--- a/plugins/Installation/Controller.php
+++ b/plugins/Installation/Controller.php
@@ -704,7 +704,7 @@ class Controller extends ControllerAdmin
      */
     private function setTrustedHost(Config $config): void
     {
-        $host = Url::getHost(false);
+        $host = Url::getCurrentHost('', false);
 
         // check hostname in server variables is correctly parsable
         if ($host === $this->extractHostAndPort('http://' . $host)) {

--- a/tests/PHPUnit/Unit/UrlTest.php
+++ b/tests/PHPUnit/Unit/UrlTest.php
@@ -98,6 +98,50 @@ class UrlTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('example.org', Url::getCurrentHost());
     }
 
+    public function testUntrustedConfiguredProxyHostIsNotUsedForThePiwikUrl()
+    {
+        Url::setHost('matomo-app');
+        $_SERVER['HTTP_X_FORWARDED_HOST'] = 'untrusted.example.net';
+        Config::getInstance()->General['proxy_host_headers'] = ['HTTP_X_FORWARDED_HOST'];
+        Config::getInstance()->General['enable_trusted_host_check'] = 1;
+        Config::getInstance()->General['trusted_hosts'] = ['example.org'];
+
+        $this->assertFalse(Url::hasTrustedProxyHost());
+    }
+
+    public function testHostHeaderAloneCountsAsATrustedProxyHost()
+    {
+        Url::setHost('example.org');
+        unset($_SERVER['HTTP_X_FORWARDED_HOST']);
+        Config::getInstance()->General['proxy_host_headers'] = ['HTTP_X_FORWARDED_HOST'];
+        Config::getInstance()->General['enable_trusted_host_check'] = 1;
+        Config::getInstance()->General['trusted_hosts'] = ['example.org'];
+
+        $this->assertTrue(Url::hasTrustedProxyHost());
+    }
+
+    public function testAnEchoedUntrustedHostIsNotATrustedProxyHost()
+    {
+        Url::setHost('untrusted.example.net');
+        $_SERVER['HTTP_X_FORWARDED_HOST'] = 'untrusted.example.net';
+        Config::getInstance()->General['proxy_host_headers'] = ['HTTP_X_FORWARDED_HOST'];
+        Config::getInstance()->General['enable_trusted_host_check'] = 1;
+        Config::getInstance()->General['trusted_hosts'] = ['example.org'];
+
+        $this->assertFalse(Url::hasTrustedProxyHost());
+    }
+
+    public function testDefaultHostIsNotSeededIntoTrustedHostsWithoutARequestHost()
+    {
+        unset($_SERVER['HTTP_HOST'], $_SERVER['SERVER_NAME'], $_SERVER['SERVER_PORT']);
+        Config::getInstance()->General['proxy_host_headers'] = [];
+        Config::getInstance()->General['enable_trusted_host_check'] = 1;
+        Config::getInstance()->General['trusted_hosts'] = [];
+
+        $this->assertSame('unknown', Url::getCurrentHost());
+        $this->assertSame([], Config::getInstance()->General['trusted_hosts']);
+    }
+
     public function testGetHostWithTrustedHosts()
     {
         Config::getInstance()->General['enable_trusted_host_check'] = 1;

--- a/tests/PHPUnit/Unit/UrlTest.php
+++ b/tests/PHPUnit/Unit/UrlTest.php
@@ -74,6 +74,30 @@ class UrlTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($test[4], Url::getCurrentHost(), $description);
     }
 
+    public function testConfiguredProxyHostIsUsedForTrustedHostCheck()
+    {
+        Url::setHost('matomo-app');
+        $_SERVER['HTTP_X_FORWARDED_HOST'] = 'example.org';
+        Config::getInstance()->General['proxy_host_headers'] = ['HTTP_X_FORWARDED_HOST'];
+        Config::getInstance()->General['enable_trusted_host_check'] = 1;
+        Config::getInstance()->General['trusted_hosts'] = ['example.org'];
+
+        $this->assertTrue(Url::isValidHost());
+        $this->assertSame('example.org', Url::getCurrentHost());
+    }
+
+    public function testUntrustedConfiguredProxyHostIsRejected()
+    {
+        Url::setHost('matomo-app');
+        $_SERVER['HTTP_X_FORWARDED_HOST'] = 'untrusted.example.net';
+        Config::getInstance()->General['proxy_host_headers'] = ['HTTP_X_FORWARDED_HOST'];
+        Config::getInstance()->General['enable_trusted_host_check'] = 1;
+        Config::getInstance()->General['trusted_hosts'] = ['example.org'];
+
+        $this->assertFalse(Url::isValidHost());
+        $this->assertSame('example.org', Url::getCurrentHost());
+    }
+
     public function testGetHostWithTrustedHosts()
     {
         Config::getInstance()->General['enable_trusted_host_check'] = 1;

--- a/tests/PHPUnit/Unit/UrlTest.php
+++ b/tests/PHPUnit/Unit/UrlTest.php
@@ -98,7 +98,7 @@ class UrlTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('example.org', Url::getCurrentHost());
     }
 
-    public function testUntrustedConfiguredProxyHostIsNotUsedForThePiwikUrl()
+    public function testConfiguredProxyHostMustPassHostValidation()
     {
         Url::setHost('matomo-app');
         $_SERVER['HTTP_X_FORWARDED_HOST'] = 'untrusted.example.net';
@@ -106,10 +106,10 @@ class UrlTest extends \PHPUnit\Framework\TestCase
         Config::getInstance()->General['enable_trusted_host_check'] = 1;
         Config::getInstance()->General['trusted_hosts'] = ['example.org'];
 
-        $this->assertFalse(Url::hasTrustedProxyHost());
+        $this->assertFalse(Url::isProxyHostValid());
     }
 
-    public function testHostHeaderAloneCountsAsATrustedProxyHost()
+    public function testRequestWithoutProxyHostPassesProxyHostValidation()
     {
         Url::setHost('example.org');
         unset($_SERVER['HTTP_X_FORWARDED_HOST']);
@@ -117,18 +117,72 @@ class UrlTest extends \PHPUnit\Framework\TestCase
         Config::getInstance()->General['enable_trusted_host_check'] = 1;
         Config::getInstance()->General['trusted_hosts'] = ['example.org'];
 
-        $this->assertTrue(Url::hasTrustedProxyHost());
+        $this->assertTrue(Url::isProxyHostValid());
     }
 
-    public function testAnEchoedUntrustedHostIsNotATrustedProxyHost()
+    public function testProxyHostValidationUsesTheFirstUsableConfiguredHeader()
     {
         Url::setHost('untrusted.example.net');
-        $_SERVER['HTTP_X_FORWARDED_HOST'] = 'untrusted.example.net';
+        $_SERVER['HTTP_X_FORWARDED_HOST'] = 'unknown';
+        $_SERVER['HTTP_X_ALTERNATE_FORWARDED_HOST'] = 'proxy.example.org';
+        Config::getInstance()->General['proxy_host_headers'] = [
+            'HTTP_X_FORWARDED_HOST',
+            'HTTP_X_ALTERNATE_FORWARDED_HOST',
+        ];
+        Config::getInstance()->General['enable_trusted_host_check'] = 1;
+        Config::getInstance()->General['trusted_hosts'] = ['example.org'];
+
+        $this->assertTrue(Url::isProxyHostValid());
+    }
+
+    public function testProxyHostValidationStopsAtTheFirstUsableConfiguredHeader()
+    {
+        Url::setHost('example.org');
+        $_SERVER['HTTP_X_FORWARDED_HOST'] = 'unknown';
+        $_SERVER['HTTP_X_ALTERNATE_FORWARDED_HOST'] = 'untrusted.example.net';
+        $_SERVER['HTTP_X_LAST_FORWARDED_HOST'] = 'example.org';
+        Config::getInstance()->General['proxy_host_headers'] = [
+            'HTTP_X_FORWARDED_HOST',
+            'HTTP_X_ALTERNATE_FORWARDED_HOST',
+            'HTTP_X_LAST_FORWARDED_HOST',
+        ];
+        Config::getInstance()->General['enable_trusted_host_check'] = 1;
+        Config::getInstance()->General['trusted_hosts'] = ['example.org'];
+
+        $this->assertFalse(Url::isProxyHostValid());
+    }
+
+    public function testDiscardedProxyHostPassesProxyHostValidation()
+    {
+        Url::setHost('untrusted.example.net');
+        $_SERVER['HTTP_X_FORWARDED_HOST'] = 'unknown';
         Config::getInstance()->General['proxy_host_headers'] = ['HTTP_X_FORWARDED_HOST'];
         Config::getInstance()->General['enable_trusted_host_check'] = 1;
         Config::getInstance()->General['trusted_hosts'] = ['example.org'];
 
-        $this->assertFalse(Url::hasTrustedProxyHost());
+        $this->assertTrue(Url::isProxyHostValid());
+    }
+
+    public function testProxyHostPassesValidationWhenTrustedHostCheckIsDisabled()
+    {
+        Url::setHost('example.org');
+        $_SERVER['HTTP_X_FORWARDED_HOST'] = 'other.example.net';
+        Config::getInstance()->General['proxy_host_headers'] = ['HTTP_X_FORWARDED_HOST'];
+        Config::getInstance()->General['enable_trusted_host_check'] = 0;
+        Config::getInstance()->General['trusted_hosts'] = ['example.org'];
+
+        $this->assertTrue(Url::isProxyHostValid());
+    }
+
+    public function testProxyHostPassesValidationWithoutConfiguredTrustedHosts()
+    {
+        Url::setHost('matomo-app');
+        $_SERVER['HTTP_X_FORWARDED_HOST'] = 'example.org';
+        Config::getInstance()->General['proxy_host_headers'] = ['HTTP_X_FORWARDED_HOST'];
+        Config::getInstance()->General['enable_trusted_host_check'] = 1;
+        Config::getInstance()->General['trusted_hosts'] = [];
+
+        $this->assertTrue(Url::isProxyHostValid());
     }
 
     public function testDefaultHostIsNotSeededIntoTrustedHostsWithoutARequestHost()


### PR DESCRIPTION
## Description

When `[General] proxy_host_headers` is configured, this aligns current-host selection and validation with the effective proxy hostname.

- use one selection path for `getCurrentHost()` and the Matomo URL persistence gate
- evaluate the first usable configured proxy-host value
- preserve the request/configuration-derived fallback when no usable proxy-host value is available
- record both the public and backend hostnames during installation

## Upgrade note

Before upgrading a proxied installation that configures `[General] proxy_host_headers`, add both the public hostname and the hostname used to reach Matomo to `trusted_hosts`. Otherwise the invalid-host warning replaces the login form. New installations record both hostnames automatically.

With trusted-host checking enabled, `Piwik\Url::isValidHost()` without an explicit hostname now validates the proxy-derived hostname. `Piwik\Url::getCurrentHost()` returns that hostname when accepted and otherwise returns the request/configuration-derived hostname.

fixes #18675

## Validation

- `ddev matomo:console tests:run --file=tests/PHPUnit/Unit/UrlTest.php` — 159 tests passed with 209 assertions
- PHPCS — clean
- PHPStan on the changed PHP files — clean

### Review

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules