### PR TITLE
Remove unneeded sprintf when rendering transitions error messages

### DIFF
--- a/plugins/Transitions/javascripts/transitions.js
+++ b/plugins/Transitions/javascripts/transitions.js
@@ -1623,7 +1623,7 @@ Piwik_Transitions_Ajax.prototype.callApi = function (method, params, callback) {
                     var errorTitle, errorMessage, errorBack;
                     if (typeof Piwik_Transitions_Translations[errorName] == 'undefined') {
                         errorTitle = 'Exception';
-                        errorMessage = errorName;
+                        errorMessage = piwikHelper.htmlEntities(piwikHelper.htmlDecode(errorName));
                         errorBack = '<<<';
                     } else {
                         errorTitle = Piwik_Transitions_Translations[errorName];
@@ -1637,7 +1637,6 @@ Piwik_Transitions_Ajax.prototype.callApi = function (method, params, callback) {
                         errorTitle = sprintf(errorTitle, '<span>' + url + '</span>');
                     }
 
-                    errorMessage = sprintf(errorMessage, '<br />');
                     var inlineErrorNode = $('#Transitions_Error_Container');
                     if (inlineErrorNode.length) {
                         // viewing it as report, not popover


### PR DESCRIPTION
### Description:

While looking at the error handling in the transitions overlay I noticed the `sprintf` used on the error message can never substitute anything:

* The only detail translations that can end up there are `Transitions_NoDataForActionDetails` and `Transitions_PeriodNotAllowedDetails` (see `Transitions\Controller::$jsTranslations`), and neither contains a placeholder — in any of the shipped locales.
* The placeholder only exists in the error *titles* (`Transitions_NoDataForAction` = `No data for %s`), which are already handled by the separate `sprintf` a few lines above.

So the `<br />` was never inserted anywhere and the call is dropped.

Messages that have no translation are taken verbatim from the API response, so they are now decoded and entity encoded the same way other API values are before being rendered, instead of being handed to `.html()` as-is.


### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
