### PR TITLE
Run the preview release build ahead of the Cloud staging release windows

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -45,7 +45,8 @@ on:
           - '5.x-dev'
           - '6.x-dev'
   schedule:
-    - cron: '0 1 * * *' # 1am daily
+    # Scheduled in the evening (UTC) so a preview build is ready earlier in the day.
+    - cron: '0 18 * * *' # 6pm UTC daily
 
 # Two builds for the same target would force-push the same preview branch and
 # race for the same version number, so they are queued instead of cancelled.


### PR DESCRIPTION
### Description

Moves the scheduled run of the `Build preview release` workflow from 1am UTC to 6pm UTC, so a preview build is ready earlier in the day and merged changes become available sooner.

**Changes**

- Change the `schedule` cron from `'0 1 * * *'` to `'0 18 * * *'`.

`preview-retry-handler.yml` needs no change: it is triggered by `workflow_run` and inherits the new timing.

The same change for 5.x-dev, which keeps the two copies of this workflow in sync, is in #25215.

**Tests**

Nothing to add — the change is limited to the `schedule` trigger, and the `workflow_dispatch` path is untouched. The YAML was validated locally. Scheduled workflows only run from the repository's default branch, so the new time takes effect once this is merged.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
