### PR TITLE
Run the preview release build ahead of the Cloud staging release windows

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -33,7 +33,8 @@ on:
         description: 'Release password'
         required: true
   schedule:
-    - cron: '0 1 * * *' # 1am daily
+    # Scheduled in the evening (UTC) so a preview build is ready earlier in the day.
+    - cron: '0 18 * * *' # 6pm UTC daily
 env:
   RELEASE_PASSWORD: ${{ secrets.RELEASE_PASSWORD }}
 jobs:


### PR DESCRIPTION
### Description

Keeps `release-preview.yml` on 5.x-dev in sync with the same change on 6.x-dev (#25214), which moves the scheduled run of the `Build preview release` workflow from 1am UTC to 6pm UTC.

Scheduled workflows only run from the repository's default branch, which is now 6.x-dev, so the cron in this copy is dormant and this change has no effect on its own. It is worth making anyway: the workflow builds 5.x-dev previews by default, and letting the two copies drift on the one value that decides when a preview gets built is how the next person reads the wrong schedule.

**Tests**

Nothing to add — the change is limited to the `schedule` trigger, and the `workflow_dispatch` path is untouched. The YAML was validated locally.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
