### PR TITLE
Prevent endless dispatch loop when rendering the no access login page

### DIFF
--- a/plugins/Login/Login.php
+++ b/plugins/Login/Login.php
@@ -43,6 +43,11 @@ class Login extends \Piwik\Plugin
     private $hasPerformedBruteForceCheckForUserPwdLogin = false;
 
     /**
+     * @var bool
+     */
+    private $isHandlingNoAccess = false;
+
+    /**
      * @see \Piwik\Plugin::registerEvents
      */
     public function registerEvents()
@@ -312,16 +317,27 @@ class Login extends \Piwik\Plugin
      */
     public function noAccess(Exception $exception)
     {
-        $frontController = FrontController::getInstance();
-
-        if (Common::isXmlHttpRequest()) {
-            $response = $frontController->dispatch(Piwik::getLoginPluginName(), 'ajaxNoAccess', [$exception->getMessage()]);
-            echo is_string($response) ? $response : '';
-            return;
+        if ($this->isHandlingNoAccess) {
+            // dispatching the login page raised another no access exception, which would trigger this handler
+            // again and again. Rethrow instead, so the regular error page is shown.
+            throw $exception;
         }
 
-        $response = $frontController->dispatch(Piwik::getLoginPluginName(), 'login', [$exception->getMessage()]);
-        echo is_string($response) ? $response : '';
+        $frontController = FrontController::getInstance();
+        $this->isHandlingNoAccess = true;
+
+        try {
+            if (Common::isXmlHttpRequest()) {
+                $response = $frontController->dispatch(Piwik::getLoginPluginName(), 'ajaxNoAccess', [$exception->getMessage()]);
+                echo is_string($response) ? $response : '';
+                return;
+            }
+
+            $response = $frontController->dispatch(Piwik::getLoginPluginName(), 'login', [$exception->getMessage()]);
+            echo is_string($response) ? $response : '';
+        } finally {
+            $this->isHandlingNoAccess = false;
+        }
     }
 
     /**

--- a/plugins/Login/tests/Integration/NoAccessTest.php
+++ b/plugins/Login/tests/Integration/NoAccessTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Login\tests\Integration;
+
+use Piwik\Container\StaticContainer;
+use Piwik\FrontController;
+use Piwik\NoAccessException;
+use Piwik\Piwik;
+use Piwik\Plugin\Manager;
+use Piwik\Plugins\Login\Login;
+use Piwik\Plugins\Login\Security\BruteForceDetection;
+use Piwik\Plugins\Login\SystemSettings;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group Login
+ * @group NoAccessTest
+ * @group Plugins
+ */
+class NoAccessTest extends IntegrationTestCase
+{
+    private const MAX_ALLOWED_DISPATCHES = 3;
+
+    /**
+     * @var int
+     */
+    private $dispatchCount = 0;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->dispatchCount = 0;
+
+        // makes sure a broken guard fails the test instead of recursing until the memory limit is reached
+        Piwik::addAction('Request.dispatch', function () {
+            $this->dispatchCount++;
+
+            if ($this->dispatchCount > self::MAX_ALLOWED_DISPATCHES) {
+                throw new \RuntimeException('endless dispatch recursion detected');
+            }
+        });
+    }
+
+    public function tearDown(): void
+    {
+        unset($_POST['form_login']);
+
+        parent::tearDown();
+    }
+
+    public function testNoAccessDoesNotRecurseWhenLoginPageRaisesAnotherNoAccessException()
+    {
+        Piwik::addAction('Controller.Login.login', function () {
+            throw new NoAccessException('login page not allowed');
+        });
+
+        try {
+            $this->getLoginPlugin()->noAccess(new NoAccessException('initial no access'));
+            $this->fail('expected a NoAccessException to be thrown');
+        } catch (NoAccessException $e) {
+            $this->assertSame('login page not allowed', $e->getMessage());
+        }
+
+        $this->assertSame(1, $this->dispatchCount);
+    }
+
+    public function testNoAccessStillHandlesFurtherExceptionsAfterRethrowingOne()
+    {
+        Piwik::addAction('Controller.Login.login', function () {
+            throw new NoAccessException('login page not allowed');
+        });
+
+        $plugin = $this->getLoginPlugin();
+
+        for ($i = 0; $i < 2; $i++) {
+            try {
+                $plugin->noAccess(new NoAccessException('initial no access'));
+                $this->fail('expected a NoAccessException to be thrown');
+            } catch (NoAccessException $e) {
+                $this->assertSame('login page not allowed', $e->getMessage());
+            }
+        }
+
+        $this->assertSame(2, $this->dispatchCount);
+    }
+
+    public function testDispatchDoesNotRecurseWhenTheUsedLoginIsBlocked()
+    {
+        $login = 'bruteforced';
+        // needs to be the instance used while dispatching, as the test config resets the recorded attempts
+        // when it is created
+        $bruteForce = StaticContainer::get(BruteForceDetection::class);
+
+        $settings = StaticContainer::get(SystemSettings::class);
+        $attempts = max(
+            BruteForceDetection::OVERALL_LOGIN_LOCKOUT_THRESHOLD_MIN,
+            $settings->maxFailedLoginsPerMinutes->getValue() * 3
+        ) + 1;
+
+        // enough failed attempts from other IPs to block the login, but not the IP the request is made from
+        for ($i = 1; $i <= $attempts; $i++) {
+            $bruteForce->addFailedAttempt('203.0.113.' . $i, $login);
+        }
+
+        $_POST['form_login'] = $login;
+
+        try {
+            FrontController::getInstance()->dispatch('Login', 'login');
+            $this->fail('expected a NoAccessException to be thrown');
+        } catch (NoAccessException $e) {
+            $this->assertStringContainsString('LoginNotAllowedBecauseUserLoginBlocked', $e->getMessage());
+        }
+
+        $this->assertSame(2, $this->dispatchCount);
+    }
+
+    private function getLoginPlugin(): Login
+    {
+        /** @var Login $plugin */
+        $plugin = Manager::getInstance()->getLoadedPlugin('Login');
+
+        return $plugin;
+    }
+}


### PR DESCRIPTION
### Description

Some Matomo installs die with `Allowed memory size of N bytes exhausted`, reported from whatever line happened to allocate last — in the case that led to this PR, the `throw` in `SuspiciousLoginAttemptsInLastHourEmail::setUpEmail()`. That line is not the cause; the request had already run out of memory in an endless dispatch loop.

`Login::noAccess()` handles `User.isNotAuthorized` by dispatching the login page. Dispatching the login page posts `Controller.Login.login`, which runs the brute force check again for the same login. If that check is what raised the no access exception in the first place — the login is currently blocked, so `NoAccessException` is thrown before the controller action runs — `FrontController::dispatch()` catches it, posts `User.isNotAuthorized` again, and the handler dispatches the login page once more. Nothing in that cycle changes state (the "already checked" flag is only set when the check passes), so it repeats until the memory limit is reached. Every iteration deepens the stack by five frames and every exception created along the way captures a backtrace of that stack, so memory grows quadratically and a large limit is used up quickly.

Where the fatal error is reported depends on which allocation is last. When the blocked login does not exist as a user — the common case, since failed attempts are recorded for any submitted login name — each iteration also runs into `SuspiciousLoginAttemptsInLastHourEmail`, which throws because there is no user to send the mail to (that exception is expected and swallowed by `BruteForceDetection`). That is why the reported location often points at the mail class.

`Login::noAccess()` now refuses to handle a second exception while it is still handling one and rethrows instead, so the regular error page with the same message is shown and the request ends. The guard sits in the handler rather than in the brute force check on purpose: setting the "already checked" flag before the check would let the nested dispatch of the login page process a submitted login form for a login that is currently blocked.

Visible change: a login that is blocked by the brute force detection now ends on the standard error page carrying the "Logging in has been turned off ..." message instead of the login form carrying it.

### Tests

`plugins/Login/tests/Integration/NoAccessTest.php` covers the handler being re-entered, that it keeps working for later exceptions, and dispatching the login page for a blocked login. Each test aborts after a few dispatches, so a regression fails the test instead of running into the memory limit. All three fail without the fix.

To be backported to 5.x-dev.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)



Backport of #25212. The only difference to the 6.x change is that the new property and the test property use `@var` docblocks instead of native property types, since 5.x still supports PHP 7.2.
