### PR TITLE
Validate parameters in the Goals API

### DIFF
--- a/plugins/Goals/API.php
+++ b/plugins/Goals/API.php
@@ -29,6 +29,8 @@ use Piwik\Plugins\Goals\Reports\GetMetrics;
 use Piwik\Segment;
 use Piwik\Segment\SegmentExpression;
 use Piwik\Site;
+use Piwik\Validators\BaseValidator;
+use Piwik\Validators\CharacterLength;
 use Piwik\Tracker\Cache;
 use Piwik\Tracker\GoalManager;
 use Piwik\Plugins\VisitFrequency\API as VisitFrequencyAPI;
@@ -56,7 +58,7 @@ use Piwik\Validators\WhitelistedValue;
  * @method static \Piwik\Plugins\Goals\API getInstance()
  *
  * @phpstan-import-type GoalStoredRecord from Model
- * @phpstan-type GoalMatchAttribute 'url'|'title'|'file'|'external_website'|'manually'|'visit_duration'|'visit_total_actions'|'visit_total_pageviews'|'event_action'|'event_category'|'event_name'
+ * @phpstan-type GoalMatchAttribute 'url'|'title'|'file'|'external_website'|'manually'|'visit_duration'|'event_action'|'event_category'|'event_name'
  * @phpstan-type GoalPatternType ''|'regex'|'contains'|'exact'|'greater_than'
  * @phpstan-type GoalRecord array{
  *     idgoal: int|string,
@@ -187,11 +189,13 @@ class API extends \Piwik\Plugin\API
      *
      * @param int $idSite The numeric ID of the website to configure the goal for.
      * @param string $name Goal name.
-     * @param string $matchAttribute Attribute used to match conversions.
+     * @param string $matchAttribute Attribute used to match conversions. One of `url`, `title`, `file`,
+     *                                `external_website`, `manually`, `visit_duration`, `event_action`,
+     *                                `event_category` or `event_name`.
      * @phpstan-param GoalMatchAttribute $matchAttribute
      * @param string $pattern Match pattern. Use a URL, title, filename, external website, or event value for string
-     *                        match attributes; use a numeric threshold for visit duration, actions, or pageview
-     *                        match attributes; this value is ignored for `manually`.
+     *                        match attributes; use a numeric threshold in minutes for `visit_duration`; this value is
+     *                        ignored for `manually`.
      * @param string $patternType Matching operator. Numeric match attributes only accept `greater_than`; string match
      *                            attributes accept `exact`, `contains`, or `regex`; use an empty string for `manually`.
      * @phpstan-param GoalPatternType $patternType
@@ -223,6 +227,7 @@ class API extends \Piwik\Plugin\API
         $patternType = $this->checkPatternType($patternType, $matchAttribute);
         $pattern = $this->checkPattern($pattern, $matchAttribute);
         $this->checkPatternIsValid($patternType, $pattern, $matchAttribute);
+        $this->checkFieldLengths($name, $description, $pattern, $matchAttribute);
 
         $revenue = Common::forceDotAsSeparatorForDecimalPoint((float)$revenue);
 
@@ -238,6 +243,8 @@ class API extends \Piwik\Plugin\API
             'deleted' => 0,
             'event_value_as_revenue' => (int)$useEventValueAsRevenue,
         );
+
+        $this->checkEventValueAsRevenue($goal);
 
         $idGoal = $this->getModel()->createGoalForSite($idSite, $goal);
 
@@ -255,14 +262,18 @@ class API extends \Piwik\Plugin\API
     /**
      * Updates an existing goal without reprocessing already recorded conversions.
      *
+     * Fails if the site has no such goal.
+     *
      * @param int $idSite The numeric ID of the website the goal belongs to.
      * @param int $idGoal Goal ID to update.
      * @param string $name Goal name.
-     * @param string $matchAttribute Attribute used to match conversions.
+     * @param string $matchAttribute Attribute used to match conversions. One of `url`, `title`, `file`,
+     *                                `external_website`, `manually`, `visit_duration`, `event_action`,
+     *                                `event_category` or `event_name`.
      * @phpstan-param GoalMatchAttribute $matchAttribute
      * @param string $pattern Match pattern. Use a URL, title, filename, external website, or event value for string
-     *                        match attributes; use a numeric threshold for visit duration, actions, or pageview
-     *                        match attributes; this value is ignored for `manually`.
+     *                        match attributes; use a numeric threshold in minutes for `visit_duration`; this value is
+     *                        ignored for `manually`.
      * @param string $patternType Matching operator. Numeric match attributes only accept `greater_than`; string match
      *                            attributes accept `exact`, `contains`, or `regex`; use an empty string for `manually`.
      * @phpstan-param GoalPatternType $patternType
@@ -289,11 +300,18 @@ class API extends \Piwik\Plugin\API
     ): void {
         Piwik::checkUserHasWriteAccess($idSite);
 
+        $idGoal = (int) $idGoal;
+
+        if (!$this->getModel()->doesGoalExist($idGoal, $idSite)) {
+            throw new Exception("There is no goal with id '$idGoal' for site with id '$idSite'.");
+        }
+
         $patternType = Common::unsanitizeInputValue($patternType);
 
         $patternType = $this->checkPatternType($patternType, $matchAttribute);
         $pattern = $this->checkPattern($pattern, $matchAttribute);
         $this->checkPatternIsValid($patternType, $pattern, $matchAttribute);
+        $this->checkFieldLengths($name, $description, $pattern, $matchAttribute);
 
         $revenue = Common::forceDotAsSeparatorForDecimalPoint((float)$revenue);
 
@@ -362,6 +380,18 @@ class API extends \Piwik\Plugin\API
     }
 
     /**
+     * Ensures the given values still fit their columns, as the database would otherwise truncate them silently.
+     */
+    private function checkFieldLengths(string $name, string $description, string $pattern, string $matchAttribute): void
+    {
+        BaseValidator::check(Piwik::translate('Goals_GoalName'), Common::unsanitizeInputValue($name), [new CharacterLength(null, 50)]);
+        BaseValidator::check(Piwik::translate('General_Description'), Common::unsanitizeInputValue($description), [new CharacterLength(null, 255)]);
+        BaseValidator::check(Piwik::translate('Goals_Pattern'), Common::unsanitizeInputValue($pattern), [new CharacterLength(null, 255)]);
+        // unlike the fields above this one is no free text, so the stored value is what has to fit
+        BaseValidator::check('matchAttribute', $matchAttribute, [new CharacterLength(null, 20)]);
+    }
+
+    /**
      * @param string|null $patternType
      * @param string $matchAttribute
      * @phpstan-return GoalPatternType
@@ -410,6 +440,8 @@ class API extends \Piwik\Plugin\API
      * Soft deletes a given Goal.
      * Stats data in the archives will still be recorded, but not displayed.
      *
+     * Nothing is deleted if the site has no such goal.
+     *
      * @param int $idSite The numeric ID of the website to query.
      * @param int $idGoal The numeric ID of the goal to delete.
      *
@@ -418,6 +450,18 @@ class API extends \Piwik\Plugin\API
     public function deleteGoal(int $idSite, $idGoal)
     {
         Piwik::checkUserHasWriteAccess($idSite);
+
+        $idGoal = (int) $idGoal;
+
+        // the reserved ecommerce ids are no goals, so only ids of goals configured for the site
+        // may reach the conversion deletion below
+        if (
+            $idGoal === GoalManager::IDGOAL_ORDER
+            || $idGoal === GoalManager::IDGOAL_CART
+            || !$this->getModel()->doesGoalExist($idGoal, $idSite)
+        ) {
+            return;
+        }
 
         $this->getModel()->deleteGoal($idSite, $idGoal);
         $this->getModel()->deleteGoalConversions($idSite, $idGoal);

--- a/plugins/Goals/Commands/CalculateConversionPages.php
+++ b/plugins/Goals/Commands/CalculateConversionPages.php
@@ -261,12 +261,13 @@ class CalculateConversionPages extends ConsoleCommand
 
             $bind = [];
             if ($idGoal !== null) {
-                $where .= ' AND c.idgoal = ? ';
-                $bind[] = $idGoal;
+                $goalIds = explode(',', $idGoal);
+                $where .= ' AND c.idgoal IN (' . Common::getSqlStringFieldsArray($goalIds) . ') ';
+                $bind = array_merge($bind, $goalIds);
             }
             if ($idSite !== null) {
-                $where .= ' AND c.idsite = ? ';
-                $bind[] = $idSite;
+                $where .= ' AND c.idsite IN (' . Common::getSqlStringFieldsArray($sites) . ') ';
+                $bind = array_merge($bind, $sites);
             }
 
             if ($where !== '') {

--- a/plugins/Goals/tests/Integration/APITest.php
+++ b/plugins/Goals/tests/Integration/APITest.php
@@ -9,10 +9,14 @@
 
 namespace Piwik\Plugins\Goals\tests\Integration;
 
+use Piwik\Common;
+use Piwik\Db;
+use Piwik\Piwik;
 use Piwik\Plugins\Goals\API;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\Mock\FakeAccess;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Tracker\GoalManager;
 
 /**
  * @group Goals
@@ -36,6 +40,11 @@ class APITest extends IntegrationTestCase
      * @var int
      */
     private $idSiteTwo;
+
+    /**
+     * @var int
+     */
+    private $idVisit = 0;
 
     public function setUp(): void
     {
@@ -85,9 +94,76 @@ class APITest extends IntegrationTestCase
 
     public function testAddGoalShouldSucceedIfAllFieldsGiven()
     {
-        $idGoal = $this->api->addGoal($this->idSite, 'MyName', 'url', 'http://www.test.de', 'exact', true, 50, true, 'desc', true);
+        $idGoal = $this->api->addGoal($this->idSite, 'MyName', 'event_action', 'test', 'exact', true, 50, true, 'desc', true);
 
-        $this->assertGoal($idGoal, 'MyName', 'desc', 'url', 'http://www.test.de', 'exact', 1, 50, 1, 1);
+        $this->assertGoal($idGoal, 'MyName', 'desc', 'event_action', 'test', 'exact', 1, 50, 1, 1);
+    }
+
+    /**
+     * @dataProvider getTooLongGoalFields
+     */
+    public function testAddGoalShouldThrowIfAFieldDoesNotFitItsColumn($name, $pattern, $description)
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('General_ValidatorErrorCharacterTooLong');
+
+        $this->api->addGoal($this->idSite, $name, 'title', $pattern, 'contains', false, false, false, $description);
+    }
+
+    /**
+     * @dataProvider getTooLongGoalFields
+     */
+    public function testUpdateGoalShouldThrowIfAFieldDoesNotFitItsColumn($name, $pattern, $description)
+    {
+        $idGoal = $this->createAnyGoal();
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('General_ValidatorErrorCharacterTooLong');
+
+        $this->api->updateGoal($this->idSite, $idGoal, $name, 'title', $pattern, 'contains', false, false, false, $description);
+    }
+
+    public function getTooLongGoalFields(): iterable
+    {
+        yield 'name' => [str_repeat('a', 51), 'pattern', ''];
+        yield 'pattern' => ['MyName', str_repeat('a', 256), ''];
+        yield 'description' => ['MyName', 'pattern', str_repeat('a', 256)];
+    }
+
+    public function testAddGoalShouldThrowIfTheMatchAttributeDoesNotFitItsColumn()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('General_ValidatorErrorCharacterTooLong');
+
+        $this->api->addGoal($this->idSite, 'MyName', str_repeat('a', 21), 'pattern', 'contains');
+    }
+
+    public function testAddGoalShouldCountUnsanitizedCharactersOnly()
+    {
+        // a name of 50 characters is accepted by the goal form, so sanitizing it must not make it too long
+        $name = str_repeat('a', 46) . ' & b';
+
+        $idGoal = $this->api->addGoal($this->idSite, Common::sanitizeInputValue($name), 'title', 'pattern', 'contains');
+
+        $this->assertSame(1, $idGoal);
+    }
+
+    public function testAddGoalShouldThrowIfEventValueAsRevenueIsUsedForNonEventGoal()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("'useEventValueAsRevenue' can only be 1 if the goal matches an event attribute.");
+
+        $this->api->addGoal($this->idSite, 'MyName', 'url', 'http://www.test.de', 'exact', false, false, false, '', true);
+    }
+
+    public function testUpdateGoalShouldThrowIfEventValueAsRevenueIsUsedForNonEventGoal()
+    {
+        $idGoal = $this->createAnyGoal();
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("'useEventValueAsRevenue' can only be 1 if the goal matches an event attribute.");
+
+        $this->api->updateGoal($this->idSite, $idGoal, 'MyName', 'url', 'http://www.test.de', 'exact', false, false, false, '', true);
     }
 
     public function testAddGoalShouldSucceedIfExactPageTitle()
@@ -227,6 +303,40 @@ class APITest extends IntegrationTestCase
         $this->assertSame(1, $idGoal);
     }
 
+    /**
+     * @dataProvider getNonGoalIdGoals
+     */
+    public function testUpdateGoalShouldThrowIfTheSiteHasNoSuchGoal($idGoal)
+    {
+        $this->createAnyGoal();
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('There is no goal with id');
+
+        $this->api->updateGoal($this->idSite, $idGoal, 'UpdatedName', 'file', 'http://www.updatetest.de', 'contains');
+    }
+
+    public function testUpdateGoalShouldThrowIfTheGoalBelongsToAnotherSite()
+    {
+        $idGoal = $this->createAnyGoal();
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('There is no goal with id');
+
+        $this->api->updateGoal($this->idSiteTwo, $idGoal, 'UpdatedName', 'file', 'http://www.updatetest.de', 'contains');
+    }
+
+    public function testUpdateGoalShouldThrowIfTheGoalWasDeleted()
+    {
+        $idGoal = $this->createAnyGoal();
+        $this->api->deleteGoal($this->idSite, $idGoal);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('There is no goal with id');
+
+        $this->api->updateGoal($this->idSite, $idGoal, 'UpdatedName', 'file', 'http://www.updatetest.de', 'contains');
+    }
+
     public function testUpdateGoalShouldUpdateAllGivenFields()
     {
         $idGoal = $this->createAnyGoal();
@@ -274,6 +384,45 @@ class APITest extends IntegrationTestCase
 
         $this->api->deleteGoal($this->idSite, $idGoal);
         $this->assertHasNoGoals();
+    }
+
+    public function testDeleteGoalShouldDeleteTheConversionsOfThatGoal()
+    {
+        $idGoal = $this->createAnyGoal();
+        $this->trackedConversion($this->idSite, $idGoal);
+        $this->trackedConversion($this->idSiteTwo, $idGoal);
+
+        $this->api->deleteGoal($this->idSite, $idGoal);
+
+        $this->assertSame(0, $this->getConversionCount($this->idSite, $idGoal));
+        $this->assertSame(1, $this->getConversionCount($this->idSiteTwo, $idGoal));
+    }
+
+    /**
+     * @dataProvider getNonGoalIdGoals
+     */
+    public function testDeleteGoalShouldNotDeleteConversionsOfIdGoalsThatAreNoGoal($idGoal)
+    {
+        $this->createAnyGoal();
+        $this->trackedConversion($this->idSite, GoalManager::IDGOAL_ORDER);
+        $this->trackedConversion($this->idSite, GoalManager::IDGOAL_CART);
+
+        $this->api->deleteGoal($this->idSite, $idGoal);
+
+        $this->assertHasGoals();
+        $this->assertSame(1, $this->getConversionCount($this->idSite, GoalManager::IDGOAL_ORDER));
+        $this->assertSame(1, $this->getConversionCount($this->idSite, GoalManager::IDGOAL_CART));
+    }
+
+    public function getNonGoalIdGoals(): iterable
+    {
+        yield 'ecommerce order' => [GoalManager::IDGOAL_ORDER];
+        yield 'abandoned cart' => [GoalManager::IDGOAL_CART];
+        yield 'ecommerce order as string' => ['0'];
+        yield 'abandoned cart as string' => ['-1'];
+        yield 'ecommerce order label' => [Piwik::LABEL_ID_GOAL_IS_ECOMMERCE_ORDER];
+        yield 'abandoned cart label' => [Piwik::LABEL_ID_GOAL_IS_ECOMMERCE_CART];
+        yield 'unknown goal' => [999];
     }
 
     public function testGetGoalShouldThrowExceptionIfNotEnoughPermission()
@@ -386,6 +535,33 @@ class APITest extends IntegrationTestCase
     private function getGoals()
     {
         return $this->api->getGoals($this->idSite);
+    }
+
+    private function trackedConversion(int $idSite, int $idGoal): void
+    {
+        $this->idVisit++;
+
+        Db::query(
+            'INSERT INTO ' . Common::prefixTable('log_conversion')
+            . ' (idvisit, idsite, idvisitor, server_time, idgoal, buster, url) VALUES (?, ?, ?, ?, ?, ?, ?)',
+            [
+                $this->idVisit,
+                $idSite,
+                Common::hex2bin('0123456789abcdef'),
+                '2014-01-01 00:00:00',
+                $idGoal,
+                0,
+                'http://example.org',
+            ]
+        );
+    }
+
+    private function getConversionCount(int $idSite, int $idGoal): int
+    {
+        return (int) Db::fetchOne(
+            'SELECT COUNT(*) FROM ' . Common::prefixTable('log_conversion') . ' WHERE idsite = ? AND idgoal = ?',
+            [$idSite, $idGoal]
+        );
     }
 
     private function createAnyGoal()

--- a/plugins/Goals/tests/System/CalculateConversionPagesCommandTest.php
+++ b/plugins/Goals/tests/System/CalculateConversionPagesCommandTest.php
@@ -11,7 +11,9 @@ namespace Piwik\Plugins\Goals\tests\System;
 
 use Piwik\Common;
 use Piwik\Date;
+use Piwik\Access;
 use Piwik\Db;
+use Piwik\Plugins\Goals\API as GoalsApi;
 use Piwik\Tests\Fixtures\SomePageGoalVisitsWithConversions;
 use Piwik\Tests\Framework\TestCase\ConsoleCommandTestCase;
 
@@ -63,6 +65,49 @@ class CalculateConversionPagesCommandTest extends ConsoleCommandTestCase
 
         // Check conversions have been calculated
         $this->checkPageviewsBeforeValid('2009-01-06 07:54:00');
+    }
+
+    public function testCommandCalculatesForEveryGivenGoalWithLastN()
+    {
+        $this->unsetPageviewsBefore();
+
+        // a goal without conversions must not keep the other goals from being calculated
+        $idGoalWithoutConversions = Access::doAsSuperUser(function () {
+            return GoalsApi::getInstance()->addGoal(
+                self::$fixture->idSite,
+                'Without conversions',
+                'url',
+                'nothing-matches-this-pattern',
+                'contains'
+            );
+        });
+
+        try {
+            $this->applicationTester->setInputs(["N\n"]);
+            $result = $this->applicationTester->run([
+                'command' => 'core:calculate-conversion-pages',
+                '--last-n' => 100,
+                '--idsite' => self::$fixture->idSite,
+                '--idgoal' => $idGoalWithoutConversions . ',1',
+                '-vvv' => true,
+            ]);
+
+            $this->assertEquals(0, $result, $this->getCommandDisplayOutputErrorMessage());
+            $this->assertGreaterThan(0, $this->getCalculatedConversionCount(1));
+        } finally {
+            Access::doAsSuperUser(function () use ($idGoalWithoutConversions) {
+                GoalsApi::getInstance()->deleteGoal(self::$fixture->idSite, $idGoalWithoutConversions);
+            });
+        }
+    }
+
+    private function getCalculatedConversionCount(int $idGoal): int
+    {
+        return (int) Db::fetchOne(
+            'SELECT COUNT(*) FROM ' . Common::prefixTable('log_conversion')
+            . ' WHERE idsite = ? AND idgoal = ? AND pageviews_before IS NOT NULL',
+            [self::$fixture->idSite, $idGoal]
+        );
     }
 
     /**


### PR DESCRIPTION
### Description

Backport of #25200, trimmed to the changes that need no changelog record. The parameter type changes
of that PR (native `bool` parameters, native `int` `idGoal`) and their changelog entries are 6.x only,
so this PR carries the validation and behaviour fixes alone.

* **Validate the `idGoal` parameter in `Goals.deleteGoal`** — the id was passed on to the goal and
  conversion deletion without being checked, so ids that identify no goal of the site still reached
  it. It is now cast to an integer and the deletion is skipped unless the id belongs to an active
  goal of the site.
* **Check event value as revenue when adding a goal** — `updateGoal` rejects
  `event_value_as_revenue` for goals that do not match an event attribute, `addGoal` did not.
* **Document the match attributes a goal supports** — `visit_total_actions` and
  `visit_total_pageviews` have been documented since 3.11.0 but were never implemented. Verified
  across all 222 release tags: they appear in `plugins/Goals/API.php` from 3.11.0 on, and never once
  in `core/Tracker/GoalManager.php`, where `$NUMERIC_MATCH_ATTRIBUTES` has always been
  `['visit_duration']`. Documentation only, no validation added.
* **Fail when updating a goal the site does not have** — `updateGoal` updated no row but still
  reported success and cleared the goal and site attribute caches.
* **Validate that goal fields fit their columns** — name, description and pattern were stored
  truncated rather than rejected, as Matomo does not run MySQL in strict mode.
* **Use every requested goal and site for the `--last-n` date range** — in
  `core:calculate-conversion-pages` the query determining the start of the range compared `idgoal`
  and `idsite` against the whole option value, so a comma separated list was reduced to its first
  entry by the database. When that entry had no conversions the command calculated nothing and still
  reported success.

Deliberately **not** included: an allow list for `matchAttribute`. A plugin can store its own value
there and do its own matching in a request processor, and there is no event to extend such a list,
so enforcing one could break plugins.

### Review

* Reviewed and approved as part of #25200; only the parameter typing commits and the changelog
  entries they carried were left out here, so no `UIIntegrationTest_api_listing` screenshot update is
  needed on 5.x either.
* PHPCS reports no errors on the changed files.
* The two behaviour fixes were confirmed to fail without their change: reverting the `--last-n` fix
  makes the new test calculate 0 conversions, reverting the `deleteGoal` change makes 6 of the 7
  new data sets fail.
* Known limitation, stated in the commit as well: the length checks count unsanitized characters so
  the limits match the goal form, but the column stores the sanitized value, so a name near the
  limit containing eg. `&` can still be shortened.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
