### PR TITLE
Clear the license cache when repairing stale Marketplace state

### DIFF
--- a/plugins/Marketplace/Controller.php
+++ b/plugins/Marketplace/Controller.php
@@ -29,6 +29,7 @@ use Piwik\Plugins\Login\PasswordVerifier;
 use Piwik\Plugins\Marketplace\Input\PluginName;
 use Piwik\Plugins\Marketplace\Input\PurchaseType;
 use Piwik\Plugins\Marketplace\Input\Sort;
+use Piwik\Plugins\Marketplace\Plugins\InvalidLicenses;
 use Piwik\Plugins\Marketplace\PluginTrial\Service as PluginTrialService;
 use Piwik\ProxyHttp;
 use Piwik\Request;
@@ -61,6 +62,8 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
 
     private PasswordVerifier $passwordVerify;
 
+    private InvalidLicenses $expired;
+
     /**
      * @var array<int, array<string, mixed>>|null
      */
@@ -73,7 +76,8 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         Consumer $consumer,
         PluginInstaller $pluginInstaller,
         Environment $environment,
-        PasswordVerifier $passwordVerify
+        PasswordVerifier $passwordVerify,
+        InvalidLicenses $expired
     ) {
         $this->licenseKey = $licenseKey;
         $this->plugins = $plugins;
@@ -83,6 +87,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         $this->pluginManager = Plugin\Manager::getInstance();
         $this->environment = $environment;
         $this->passwordVerify = $passwordVerify;
+        $this->expired = $expired;
         $this->paidPlugins = null;
 
         parent::__construct();
@@ -96,6 +101,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         // this is also like a self-repair to clear the caches :)
         $this->marketplaceApi->clearAllCacheEntries();
         $this->consumer->clearCache();
+        $this->expired->clearCache();
         // invalidate cache for plugin/manager
         Plugin\Manager::getLicenseCache()->flushAll();
 

--- a/plugins/Marketplace/Marketplace.php
+++ b/plugins/Marketplace/Marketplace.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\Marketplace;
 
 use Piwik\Container\StaticContainer;
 use Piwik\Plugin;
+use Piwik\Plugins\Marketplace\Plugins\InvalidLicenses;
 use Piwik\Plugins\Marketplace\PluginTrial\Service as PluginTrialService;
 use Piwik\Request;
 use Piwik\SettingsPiwik;
@@ -50,6 +51,8 @@ class Marketplace extends \Piwik\Plugin
     {
         $marketplace = StaticContainer::get('Piwik\Plugins\Marketplace\Api\Client');
         $marketplace->clearAllCacheEntries();
+
+        StaticContainer::get(InvalidLicenses::class)->clearCache();
     }
 
     public function getStylesheetFiles(&$stylesheets)

--- a/plugins/Marketplace/tests/Integration/ControllerTest.php
+++ b/plugins/Marketplace/tests/Integration/ControllerTest.php
@@ -10,9 +10,11 @@
 namespace Piwik\Plugins\Marketplace\tests\Integration;
 
 use Piwik\Access;
+use Piwik\Cache;
 use Piwik\DI;
 use Piwik\FrontController;
 use Piwik\Plugins\Marketplace\Api\Service\Exception as ServiceException;
+use Piwik\Plugins\Marketplace\LicenseKey;
 use Piwik\Plugins\Marketplace\tests\Framework\Mock\Service;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
@@ -38,6 +40,8 @@ class ControllerTest extends IntegrationTestCase
      * @var string the list the 'plugins' action answers with, so a test can pick one that suits it
      */
     private $pluginsFixture = 'v2.0_plugins.json';
+
+    private $invalidLicensesCacheKey = 'Marketplace_ExpiredPlugins';
 
     public function setUp(): void
     {
@@ -197,6 +201,27 @@ class ControllerTest extends IntegrationTestCase
         return json_decode($this->dispatch('getPluginDetails', ['pluginName' => $pluginName]), true);
     }
 
+    public function testSubscriptionOverviewClearsTheInvalidLicensesCache()
+    {
+        // this action renders a full admin page, whose menu resolves a site
+        if (!Fixture::siteCreated(1)) {
+            Fixture::createWebsite('2012-01-01 00:00:00');
+        }
+
+        // a license key is what makes the page fetch the consumer and render its license banners
+        (new LicenseKey())->set('consumer2_paid1');
+
+        $stale = ['exceeded' => ['FooPlugin'], 'expired' => [], 'noLicense' => []];
+
+        Cache::getEagerCache()->save($this->invalidLicensesCacheKey, $stale);
+
+        $this->dispatch('subscriptionOverview');
+
+        // the page reads the licenses again while rendering its own banners, so the entry is
+        // repopulated rather than absent - what matters is that the stale value did not survive
+        self::assertNotSame($stale, Cache::getEagerCache()->fetch($this->invalidLicensesCacheKey));
+    }
+
     /**
      * @param array<string, string> $params
      */
@@ -252,6 +277,15 @@ class ControllerTest extends IntegrationTestCase
 
         if ($action === 'plugins') {
             return $this->pluginsFixture;
+        }
+
+        if ($action === 'consumer') {
+            return 'v2.0_consumer-access_token-consumer2_paid1.json';
+        }
+
+        if ($action === 'info') {
+            // the license banners an admin page renders resolve their login link from this
+            return 'emptyObjectResponse.json';
         }
 
         if ($action === 'plugins/NotOnTheMarketplace/info') {

--- a/plugins/Marketplace/tests/Integration/MarketplaceTest.php
+++ b/plugins/Marketplace/tests/Integration/MarketplaceTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Marketplace\tests\Integration;
+
+use Piwik\Cache;
+use Piwik\Plugins\Marketplace\Marketplace;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group Marketplace
+ * @group MarketplaceTest
+ * @group Plugins
+ */
+class MarketplaceTest extends IntegrationTestCase
+{
+    private $cacheKey = 'Marketplace_ExpiredPlugins';
+
+    public function testCheckForUpdatesClearsTheInvalidLicensesCache(): void
+    {
+        Cache::getEagerCache()->save($this->cacheKey, ['exceeded' => ['FooPlugin']]);
+
+        (new Marketplace())->checkForUpdates();
+
+        self::assertFalse(Cache::getEagerCache()->contains($this->cacheKey));
+    }
+}


### PR DESCRIPTION
### Description

Follow-up to #25209, from @AltamashShaikh's review.

A superuser who buys or renews a subscription and then opens the subscription overview, or uses "check for updates", could keep seeing a stale license warning for up to 12 hours. Both actions exist partly to repair that kind of staleness — the subscription overview clears the Marketplace, consumer and plugin-manager caches, and its own comment describes itself as a self-repair — but neither cleared the cache the license banners are read from, so the banner outlived the change it was meant to reflect.

Saving a license key, creating an account and starting a free trial already cleared it. Both remaining flows now do the same, so the banners agree with the subscription that is actually in force.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
