### PR TITLE
Use one encoding for every part of the report ratio tooltip

### DIFF
--- a/plugins/CoreVisualizations/templates/_dataTableViz_htmlTable_ratio.twig
+++ b/plugins/CoreVisualizations/templates/_dataTableViz_htmlTable_ratio.twig
@@ -19,7 +19,7 @@
 
     {% set metricTitle   = translations[column]|default(column) %}
 
-    {% set reportRatioTooltip = 'General_ReportRatioTooltip'|translate(label, rowPercentage|e('html_attr'), reportTotal|e('html_attr'), metricTitle|e('html_attr'), '"' ~ segmentTitlePretty ~ '"', translations[labelColumn]|default(labelColumn)|e('html_attr')) %}
+    {% set reportRatioTooltip = 'General_ReportRatioTooltip'|translate(label, rowPercentage, reportTotal, metricTitle, '"' ~ segmentTitlePretty ~ '"', translations[labelColumn]|default(labelColumn)) %}
 
     {% if totalPercentage|default is empty %}
         {% if row.getMetadata(column ~ '_site_total_percentage') != false %}
@@ -36,8 +36,10 @@
         {% set totalRatioTooltip = '' %}
     {% endif %}
 
+    {#- the tooltip is rendered as HTML from this attribute, and the browser decodes the attribute
+        again when it is read back, so every value interpolated here is escaped exactly once -#}
     <span class="ratio"
-          title="{{ reportRatioTooltip|rawSafeDecoded|raw }} {{ totalRatioTooltip|rawSafeDecoded|e('html_attr') }}{% if tooltipSuffix|default is not empty %}<br/><br/> {{ tooltipSuffix|rawSafeDecoded|e('html_attr') }}{% endif %}"
+          title="{{ reportRatioTooltip|rawSafeDecoded|e('html_attr') }} {{ totalRatioTooltip|rawSafeDecoded|e('html_attr') }}{% if tooltipSuffix|default is not empty %}<br/><br/> {{ tooltipSuffix|rawSafeDecoded|e('html_attr') }}{% endif %}"
     >&nbsp;
         {%- if showAbsoluteValueOnHover|default -%}
             {%- if row.getMetadata('html_column_' ~ column ~ '_prefix') -%}

--- a/plugins/CoreVisualizations/tests/Integration/RatioTooltipEncodingTest.php
+++ b/plugins/CoreVisualizations/tests/Integration/RatioTooltipEncodingTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreVisualizations\tests\Integration;
+
+use Piwik\DataTable\Row;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\View;
+
+/**
+ * The ratio tooltip is not the tooltip the browser shows for a title attribute: the data table
+ * renders that attribute as HTML (see handleCellTooltips() in dataTable.js), and the browser has
+ * decoded it once by the time it is read back - so a row label encoded only once is markup again.
+ *
+ * @group CoreVisualizations
+ * @group RatioTooltipEncodingTest
+ * @group Plugins
+ */
+class RatioTooltipEncodingTest extends IntegrationTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Fixture::loadAllTranslations();
+    }
+
+    public function tearDown(): void
+    {
+        Fixture::resetTranslations();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Row labels come from the tracker, so they reach the template HTML encoded once.
+     */
+    public function testMarkupInARowLabelStaysTextInTheTooltip(): void
+    {
+        $title = $this->renderTooltipTitle('&lt;b style=color:red&gt;label&lt;/b&gt;');
+
+        $readBack = $this->decodeAttribute($title);
+
+        self::assertStringNotContainsString('<b ', $readBack);
+        self::assertStringContainsString('&lt;b style=color:red&gt;label&lt;/b&gt;', $readBack);
+    }
+
+    /**
+     * Encoding the tooltip twice would be just as wrong as encoding it once: the entities would
+     * then be what the user reads.
+     */
+    public function testTheTooltipStillReadsAsPlainTextForAnOrdinaryLabel(): void
+    {
+        $title = $this->renderTooltipTitle('Ben &amp; Jerry&#039;s');
+
+        $displayed = $this->decodeAttribute($this->decodeAttribute($title));
+
+        self::assertStringContainsString('\'Ben & Jerry\'s\' represents 12.5% of 1234 Visits', $displayed);
+        self::assertStringContainsString('in segment "All visits"', $displayed);
+    }
+
+    /**
+     * Comparison rows append a second sentence, separated by the line breaks the template writes
+     * into the attribute itself. Those have to stay markup while the sentence around them does not.
+     */
+    public function testTheSeparatorStaysMarkupWhileTheAppendedSentenceDoesNot(): void
+    {
+        $title = $this->renderTooltipTitle('Keyword', '2.5% more than &lt;b&gt;All visits&lt;/b&gt;');
+
+        self::assertStringContainsString('<br/><br/>', $title);
+        self::assertStringNotContainsString('<b>', $this->decodeAttribute($title));
+    }
+
+    /**
+     * The value of the title attribute as the tooltip reads it, ie. after the HTML parser has
+     * decoded the attribute once.
+     */
+    private function decodeAttribute(string $value): string
+    {
+        return html_entity_decode($value, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    }
+
+    private function renderTooltipTitle(string $label, string $tooltipSuffix = ''): string
+    {
+        $view = new View('@CoreVisualizations/_dataTableViz_htmlTable_ratio');
+        $view->sendHeadersWhenRendering = false;
+        $view->column = 'nb_visits';
+        $view->row = new Row([Row::COLUMNS => ['label' => $label, 'nb_visits' => 154]]);
+        $view->totals = ['nb_visits' => 1234];
+        $view->properties = ['report_ratio_columns' => ['nb_visits']];
+        $view->label = $label;
+        $view->labelColumn = 'label';
+        $view->translations = ['nb_visits' => 'Visits', 'label' => 'Keyword'];
+        $view->rowPercentage = '12.5%';
+        $view->segmentTitlePretty = 'All visits';
+        $view->tooltipSuffix = $tooltipSuffix;
+
+        $matched = preg_match('/<span class="ratio"\s+title="([^"]*)"/', $view->render(), $matches);
+
+        self::assertSame(1, $matched, 'the ratio span was not rendered');
+
+        return $matches[1];
+    }
+}


### PR DESCRIPTION
### Description

The `title` of the ratio span in `_dataTableViz_htmlTable_ratio.twig` is assembled from up to three translated sentences, and they were not built the same way. The total ratio sentence and the comparison suffix are encoded once, as a whole, at the attribute (`|rawSafeDecoded|e('html_attr')`). The report ratio sentence instead encoded its arguments one by one and was then written out with `|raw`.

Two ways of building the same attribute is a maintenance hazard on its own, and the two are not equivalent: values passed into that sentence end up carrying a different amount of encoding than the values in the sentences beside them, so the tooltip does not necessarily show them the way the rest of the report does.

**Changes**

- Encode the report ratio sentence as a whole at the attribute, exactly like the total ratio sentence and the comparison suffix next to it.
- Drop the per-argument `e('html_attr')` calls, which double-encode once the assembled sentence is encoded - the tooltip would read `33.3&#x25;` instead of `33.3%`. This matches how the total ratio sentence is already built, from plain arguments.
- The literal `<br/><br/>` separator the template writes between the sentences stays markup, as before.

**Tests**

`plugins/CoreVisualizations/tests/Integration/RatioTooltipEncodingTest.php` renders the partial and covers what can go wrong in either direction: a label whose characters need encoding, an ordinary label with `&` and `'` next to a percentage (the over-encoding direction), and the line-break separator used by comparison rows. The first fails without this change.

Also verified manually in the browser, and `tests:run-ui DataTable` passes (18/18), which covers percentage values, subtables, recursively searched reports and comparison rows.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Backport of #25213.
