### PR TITLE
Stop widget controls squeezing the report header title

### DIFF
--- a/plugins/CoreHome/vue/src/ReportHeader/ReportHeader.less
+++ b/plugins/CoreHome/vue/src/ReportHeader/ReportHeader.less
@@ -6,6 +6,8 @@
   gap: 20px;
   border-radius: 8px;
   padding: 20px;
+  // Anchor for the overlaid widget controls.
+  position: relative;
 
   .reportHeader__main {
     flex: auto;
@@ -85,9 +87,19 @@
 // maximised widget keeps them on. The hook is reference-only — see CSS rules, rule 31.
 .__reportHeader-onHover .reportHeader__widgetControls {
   opacity: 0;
+  // Overlaid, not in the row: reserving width crushed the title in narrow columns.
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  // Fade the title out behind the icons.
+  padding-left: 45px;
+  background: linear-gradient(to right, transparent, @theme-color-widget-title-background 45px);
+  // Invisible controls must not block clicks or the drag handle.
+  pointer-events: none;
 }
 
 .__reportHeader-onHover:hover .reportHeader__widgetControls,
 .__reportHeader-onHover:focus-within .reportHeader__widgetControls {
   opacity: 1;
+  pointer-events: auto;
 }

--- a/plugins/Dashboard/tests/UI/expected-screenshots/DashboardManager_small_screen.png
+++ b/plugins/Dashboard/tests/UI/expected-screenshots/DashboardManager_small_screen.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ae5c9e088d1afbaa11f81bbffbb7d549960fd479c82d3d275ac02bdbfc357db0
-size 226539
+oid sha256:4d209e692ef3618c17bfb4f2f905c52f3c60ed666e4a83ba3a2e733564d272b4
+size 221908

--- a/plugins/Dashboard/tests/UI/expected-screenshots/Dashboard_dashboard2.png
+++ b/plugins/Dashboard/tests/UI/expected-screenshots/Dashboard_dashboard2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:91a60014a2a8ef863a877dc994381de84befd3a2cbedb778e85cdd2a07c71c23
-size 655327
+oid sha256:f3bdd7f03f638ee6d64c2b3975bb9ee684a485a55fd0dfcc6f376e4f4e470641
+size 650053

--- a/plugins/Dashboard/tests/UI/expected-screenshots/Dashboard_dashboard3.png
+++ b/plugins/Dashboard/tests/UI/expected-screenshots/Dashboard_dashboard3.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:edfcdb94766b99d99aa468a299e98b75376bb64d3175a9029b90d32dbb078719
-size 1478040
+oid sha256:e5b28b0bd6332a186530fb5aeb38fb626f65c38f77d87997b6092e93b9ee65cf
+size 1471879

--- a/plugins/Dashboard/tests/UI/expected-screenshots/Dashboard_dashboard4.png
+++ b/plugins/Dashboard/tests/UI/expected-screenshots/Dashboard_dashboard4.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:144194657cf2ef2f03b7c1561bd3bd84fdf84de2079f16e35fcbd812b736f77f
-size 911889
+oid sha256:bc0cd2c002a28e365431b2d6f8cf290e87b79f4907d751ce2a2e286ce076717f
+size 889062

--- a/plugins/Dashboard/tests/UI/expected-screenshots/Dashboard_dashboard5.png
+++ b/plugins/Dashboard/tests/UI/expected-screenshots/Dashboard_dashboard5.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f5cb00a74221bd077cdab92c0c0e4443a0a439d37c50a1869945318b31a387e0
-size 440252
+oid sha256:5effa0018dadd5e0c47528950fbc56317f84be194fa85818fabe1e53712fb7c7
+size 434882


### PR DESCRIPTION
## Summary

Dashboard widget titles collapse to one character per line on narrow screens.

The widget control icons (refresh / minimise / maximise / close) are hidden with `opacity`, not `display`, so the `flex: none` column they sit in still reserved its full 104px in the header row. Together with the 20px padding either side and the 20px gap, 164px of the header was spoken for before the title got anything. In a three-column dashboard at a 662px viewport the widget is 190px wide, which left the title 24.7px — `overflow-wrap: break-word` then broke it one character per line, and "Premium Features & Services for Matomo" rendered 480px tall.

Before the header moved to Vue in #24780 the icons were `position: absolute` + `display: none` with a gradient mask, so they never took horizontal space from the `h3`. This restores that behaviour.

## Fix

In the `__reportHeader-onHover` scope only, the control row is overlaid at the header's top-right with a gradient fade to `@theme-color-widget-title-background`, plus `pointer-events: none` while it is invisible so it cannot swallow clicks or the widget drag handle. `.reportHeader` gains `position: relative` as the containing block.

Scoped deliberately: a maximised widget has the hook removed in `dashboardWidget.js:372` and keeps the controls beside the title, and the full-page, widgetized and preview contexts render no controls at all, so none of them change.

## Verification

Measured on a running instance:

| Viewport | Widget | Title area before | Title area after |
| --- | --- | --- | --- |
| 662px | 190px | 24.7px | 149px |
| 1280px | 324px | 158px | 282px |

At 1280px "Premium Features & Services for Matomo" goes from four lines to two, so this was costing title width at desktop sizes too, not only narrow ones.

Also checked: hovering reveals the icons and they receive clicks; while idle a hit test over the control area returns the title, so the drag handle and the SingleMetricView metric picker still work; the gradient resolves to `#fff` in light and `#202329` in dark with no grey haze. `ReportHeader.spec.ts` (26 tests) and `WidgetControls.spec.ts` (4 tests) pass.

## Screenshots

`Dashboard_dashboard2` to `dashboard5` and `DashboardManager_small_screen` are regenerated — headers are shorter, so the dashboards shrink by 72-240px. `Dashboard_dashboard1_mobile` is unchanged: at 480px the dashboard is single-column and the titles already fitted on one line.

### Checklist
[✔] I have understood, reviewed, and tested all AI outputs before use
[✔] All AI instructions respect security, IP, and privacy rules
