### PR TITLE
Use the row link URL as-is in the Actions row actions

### DIFF
--- a/plugins/Actions/javascripts/rowactions.js
+++ b/plugins/Actions/javascripts/rowactions.js
@@ -10,24 +10,20 @@ $(function () {
 
         return isActionsModule(params) &&
             (action == 'getPageUrls' || action == 'getEntryPageUrls' || action == 'getExitPageUrls' || action == 'getPageUrlsFollowingSiteSearch');
-    };
+    }
 
     function isPageTitleReport(params) {
         var action = params.action;
 
         return isActionsModule(params) && (action == 'getPageTitles' || action == 'getPageTitlesFollowingSiteSearch');
-    };
+    }
 
     function getLinkForTransitionAndOverlayPopover(tr)
     {
         tr = getRealRowIfComparisonRow(tr);
 
-        var link = tr.find('> td:first > a').attr('href');
-        // replace all &, that are not part of a named character reference with a tailing semicolon, with a &amp;
-        // otherwise named character references without a tailing , (like &reg) would be replaced
-        link = link.replace(/&([a-z]+[^a-z;])/, '&amp;$1');
-        link = $('<textarea>').html(link).val(); // remove html entities
-        return link;
+        // the browser already decoded the entities when it parsed the href attribute
+        return tr.find('> td:first > a').attr('href');
     }
 
     if (window.DataTable_RowActions_Transitions) {
@@ -37,7 +33,7 @@ $(function () {
             },
             isAvailableOnRow: function (dataTableParams, tr) {
                 tr = getRealRowIfComparisonRow(tr);
-                return isPageUrlReport(dataTableParams) && tr.find('> td:first span.label').parent().is('a')
+                return isPageUrlReport(dataTableParams) && tr.find('> td:first span.label').parent().is('a');
             },
             trigger: function (tr, e, subTableLabel, originalRow) {
                 var overrideParams = $.extend({}, $(originalRow || tr).data('param-override'));
@@ -84,7 +80,7 @@ $(function () {
                 return {
                     link: getLinkForTransitionAndOverlayPopover(tr),
                     segment: null
-                }
+                };
             }
         });
     }

--- a/plugins/Actions/javascripts/rowactions.spec.js
+++ b/plugins/Actions/javascripts/rowactions.spec.js
@@ -1,0 +1,70 @@
+/*!
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+var fs = require('fs');
+var path = require('path');
+
+(function () {
+    describe('Actions row actions', function () {
+
+        var overlayReport;
+
+        beforeAll(async function () {
+            var registered = [];
+
+            window.DataTable_RowActions_Transitions = { registerReport: function () {} };
+            window.DataTable_RowActions_Overlay = {
+                registerReport: function (report) { registered.push(report); }
+            };
+
+            window.eval(fs.readFileSync(path.join(__dirname, 'rowactions.js'), 'utf8'));
+
+            // the file registers its reports from a jQuery ready handler
+            await new Promise(function (resolve) { setTimeout(resolve, 0); });
+
+            overlayReport = registered.filter(function (report) {
+                return report.isAvailableOnReport({ module: 'Actions', action: 'getPageUrls' });
+            })[0];
+        });
+
+        /**
+         * Builds a report row the way the reporting table does: _dataTableCell.twig writes the URL
+         * into the href with one level of HTML escaping, which the parser removes again on read.
+         */
+        function linkForRow(url) {
+            var escaped = url
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#039;');
+
+            var $row = $(
+                '<table><tbody><tr><td>'
+                + '<a href="' + escaped + '"><span class="label">row</span></a>'
+                + '</td></tr></tbody></table>'
+            ).find('tr');
+
+            return overlayReport.onClick($('<a>'), $row, {}).link;
+        }
+
+        var urls = [
+            'http://example.org/docs/manage-websites/',
+            'http://example.org/index?a=1&b=2',
+            // query parameters that look like named character references
+            'http://example.org/index?a=1&copy=2&reg=3',
+            // a literal &amp; in the tracked URL
+            'http://example.org/index?a=1&amp;b=2',
+        ];
+
+        urls.forEach(function (url) {
+            it('passes the row URL through unchanged: ' + url, function () {
+                expect(linkForRow(url)).to.equal(url);
+            });
+        });
+    });
+})();


### PR DESCRIPTION
DEV-20764

The Transitions and Page Overlay row actions read the page URL from the row's link, then decoded HTML entities from it a second time. The browser already does that when it parses the `href`, so the extra decode only corrupted the URL.

A tracked URL like `https://example.org/?a=1&copy=2` came back as `https://example.org/?a=1©=2`, so the row action looked up a page that doesn't exist and reported no data — on a row that otherwise looked fine.

The link is now used exactly as the DOM provides it. An older guard that shielded the first such sequence from the same decode is no longer needed, and goes with it. Also tidies a few stray semicolons and a missing trailing newline in the same file, and adds a spec for the URLs above.

### Review

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
