### PR TITLE
[automatic composer updates]

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -770,12 +770,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/matomo-org/referrer-spam-list.git",
-                "reference": "b1c66b3cbbd8fe243ff028a8932788da187b9934"
+                "reference": "e65db652cade6882aa9a76bbb65c9bb17e079f4b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matomo-org/referrer-spam-list/zipball/b1c66b3cbbd8fe243ff028a8932788da187b9934",
-                "reference": "b1c66b3cbbd8fe243ff028a8932788da187b9934",
+                "url": "https://api.github.com/repos/matomo-org/referrer-spam-list/zipball/e65db652cade6882aa9a76bbb65c9bb17e079f4b",
+                "reference": "e65db652cade6882aa9a76bbb65c9bb17e079f4b",
                 "shasum": ""
             },
             "replace": {
@@ -793,7 +793,7 @@
                 "issues": "https://github.com/matomo-org/referrer-spam-list/issues",
                 "source": "https://github.com/matomo-org/referrer-spam-list/tree/master"
             },
-            "time": "2026-08-20T14:26:27+00:00"
+            "time": "2026-09-04T07:25:36+00:00"
         },
         {
             "name": "matomo/searchengine-and-social-list",


### PR DESCRIPTION
composer update log:
```
Loading composer repositories with package information
Security advisory data could not be fetched from some repositories (ignored per policy.ignore-unreachable); matches may be incomplete:
  - curl error 28 while downloading https://packagist.org/api/security-advisories/: Operation timed out after 10006 milliseconds with 0 bytes received
Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading matomo/referrer-spam-list (dev-master b1c66b3 => dev-master e65db65)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Downloading matomo/referrer-spam-list (dev-master e65db65)
  - Upgrading matomo/referrer-spam-list (dev-master b1c66b3 => dev-master e65db65): Extracting archive
Package lox/xhprof is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
59 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
No security vulnerability advisories found.
```
