### PR TITLE
Preserve archives that are still in use when purging deleted segments

### DIFF
--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -718,14 +718,17 @@ class Model
     {
         $idSite = (int)$segment['enable_only_idsite'];
         $segmentHash = $segment['hash'] ?? '';
-        // Valid segment hashes are md5 strings - just confirm that it is so it's safe for SQL injection
-        if (!ctype_xdigit($segmentHash)) {
+        // Valid segment hashes are md5 strings - confirm that it is one, so it is safe for SQL injection and
+        // the name clause below can only match the done flag of this one segment
+        if (strlen($segmentHash) !== 32 || !ctype_xdigit($segmentHash)) {
             throw new Exception($segmentHash . ' expected to be an md5 hash');
         }
 
         $nameClause = 'name LIKE "done' . $segmentHash . '%"';
         $idSiteClause = '';
-        if ($idSite > 0) {
+        // Only 0 (or NULL) means the segment was enabled for all websites. Every other value is applied as
+        // a site restriction.
+        if ($idSite !== 0) {
             $idSiteClause = ' AND idsite = ' . $idSite;
         } elseif (! empty($segment['idsites_to_preserve'])) {
             // A segment for all sites was deleted, but there are segments for a single site with the same definition

--- a/plugins/CoreAdminHome/tests/Integration/TasksTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/TasksTest.php
@@ -12,6 +12,8 @@ namespace Piwik\Plugins\CoreAdminHome\tests\Integration;
 use Piwik\Archive\ArchivePurger;
 use Piwik\ArchiveProcessor\Rules;
 use Piwik\Common;
+use Piwik\DataAccess\ArchiveTableCreator;
+use Piwik\DataAccess\ArchiveWriter;
 use Piwik\Date;
 use Piwik\Db;
 use Piwik\Mail;
@@ -19,6 +21,7 @@ use Piwik\Plugins\CoreAdminHome\Emails\JsTrackingCodeMissingEmail;
 use Piwik\Plugins\CoreAdminHome\Emails\TrackingFailuresEmail;
 use Piwik\Plugins\CoreAdminHome\Tasks;
 use Piwik\Plugins\CoreAdminHome\Tasks\ArchivesToPurgeDistributedList;
+use Piwik\Plugins\SegmentEditor\Model as SegmentModel;
 use Piwik\Scheduler\Task;
 use Piwik\Tests\Fixtures\RawArchiveDataWithTempAndInvalidated;
 use Piwik\Tests\Framework\Fixture;
@@ -113,6 +116,52 @@ class TasksTest extends IntegrationTestCase
 
         $wasPurged = $this->tasks->purgeOutdatedArchives();
         $this->assertTrue($wasPurged);
+    }
+
+    public function testPurgeOrphanedArchivesPreservesArchivesOfAStillUsedSegmentWithTheSameHash()
+    {
+        $idSite = Fixture::createWebsite('2015-01-01 00:00:00');
+
+        $segmentModel = new SegmentModel();
+
+        // A segment that is still in use, with a space in its definition written as %20
+        $idSegmentInUse = $segmentModel->createSegment([
+            'name' => 'Still in use',
+            'definition' => 'pageUrl=@a%20b',
+            'login' => 'user1',
+            'enable_only_idsite' => $idSite,
+        ]);
+
+        // A second segment with the same definition in a different encoding, which gets deleted
+        $idSegmentDeleted = $segmentModel->createSegment([
+            'name' => 'Deleted',
+            'definition' => 'pageUrl=@a+b',
+            'login' => 'user2',
+            'enable_only_idsite' => $idSite,
+        ]);
+        $segmentModel->deleteSegment($idSegmentDeleted);
+
+        // Both definitions have the same hash, which means both segments share the same archives
+        $hash = $segmentModel->getSegment($idSegmentInUse)['hash'];
+        $this->assertSame($hash, $segmentModel->getSegment($idSegmentDeleted)['hash']);
+
+        $numericTable = ArchiveTableCreator::getNumericTable($this->january, true);
+        Db::exec(sprintf(
+            "INSERT INTO `%s` (idarchive, idsite, name, value, date1, date2, period, ts_archived)"
+            . " VALUES (9001, %d, 'done%s.VisitsSummary', %d, '2015-01-03', '2015-01-03', 1, '2015-01-03 12:12:12')",
+            $numericTable,
+            $idSite,
+            $hash,
+            ArchiveWriter::DONE_OK
+        ));
+
+        $this->tasks->purgeOrphanedArchives();
+
+        $this->assertEquals(
+            1,
+            Db::fetchOne("SELECT COUNT(*) FROM `$numericTable` WHERE idarchive = 9001"),
+            'the archives of the segment that is still in use must not be purged'
+        );
     }
 
     public function testScheduleAddsRightAmountOfTasks()

--- a/plugins/SegmentEditor/Model.php
+++ b/plugins/SegmentEditor/Model.php
@@ -147,16 +147,12 @@ class Model
             return array();
         }
 
-        $existingSegments = $this->getExistingSegmentsLike($deletedSegments);
+        $existingSegments = $this->getExistingSegmentsSharingArchives($deletedSegments);
 
         foreach ($deletedSegments as $i => $deleted) {
             $deletedSegments[$i]['idsites_to_preserve'] = array();
             foreach ($existingSegments as $existing) {
-                if (
-                    $existing['definition'] != $deleted['definition'] &&
-                    $existing['definition'] != urlencode($deleted['definition']) &&
-                    $existing['definition'] != urldecode($deleted['definition'])
-                ) {
+                if (!$this->sharesArchivesWith($existing, $deleted)) {
                     continue;
                 }
 
@@ -164,8 +160,8 @@ class Model
                     $existing['enable_only_idsite'] == $deleted['enable_only_idsite']
                     || $existing['enable_only_idsite'] == 0
                 ) {
-                    // There is an identical segment (for either the specific site or for all sites) that is active
-                    // The archives for this segment will therefore still be needed
+                    // There is a segment sharing these archives (for either the specific site or for all
+                    // sites) that is active. The archives for this segment will therefore still be needed
                     unset($deletedSegments[$i]);
                     break;
                 } elseif ($deleted['enable_only_idsite'] == 0) {
@@ -179,7 +175,14 @@ class Model
         return $deletedSegments;
     }
 
-    private function getExistingSegmentsLike(array $segments)
+    /**
+     * Returns the segments that are still in use and share their archives with one of the given segments.
+     *
+     * Narrows down the candidates, {@see self::sharesArchivesWith()} then decides per pair of segments.
+     *
+     * @param array $segments Segments as returned by {@see self::getSegmentsDeletedSince()}
+     */
+    private function getExistingSegmentsSharingArchives(array $segments): array
     {
         if (empty($segments)) {
             return array();
@@ -187,28 +190,63 @@ class Model
 
         $whereClauses = array();
         $bind = array();
-        $definitionWhereClauseTemplate = '(definition = ? OR definition = ? OR definition = ?)';
         foreach ($segments as $segment) {
             // Sometimes they are stored encoded and sometimes they aren't
+            $matchWhereClause = '(definition = ? OR definition = ? OR definition = ?';
             $bind[] = $segment['definition'];
             $bind[] = urlencode($segment['definition']);
             $bind[] = urldecode($segment['definition']);
 
+            // Archives are keyed by the hash, so segments sharing it also share their archives
+            if (!empty($segment['hash'])) {
+                $matchWhereClause .= ' OR hash = ?';
+                $bind[] = $segment['hash'];
+            }
+            $matchWhereClause .= ')';
+
             if ($segment['enable_only_idsite'] == 0) {
-                // They deleted an all-sites segment, but there is a single-site segment with same definition?
+                // They deleted an all-sites segment, but there is a single-site segment sharing its archives?
                 // Need to handle this carefully so that the archives for the single-site segment are preserved
-                $whereClauses[] = "$definitionWhereClauseTemplate";
+                $whereClauses[] = $matchWhereClause;
             } else {
-                $whereClauses[] = "($definitionWhereClauseTemplate AND (enable_only_idsite = ? OR enable_only_idsite = 0))";
+                $whereClauses[] = "($matchWhereClause AND (enable_only_idsite = ? OR enable_only_idsite = 0))";
                 $bind[] = $segment['enable_only_idsite'];
             }
         }
         $whereClauses = implode(' OR ', $whereClauses);
 
-        // Check for any non-deleted segments with the same definition
-        $sql = "SELECT DISTINCT definition, enable_only_idsite FROM `" . Common::prefixTable('segment') . "`"
+        // Check for any non-deleted segments that share the archives of one of the deleted segments
+        $sql = "SELECT DISTINCT definition, enable_only_idsite, hash FROM `" . Common::prefixTable('segment') . "`"
             . " WHERE deleted = 0 AND (" . $whereClauses . ")";
         return Db::fetchAll($sql, $bind);
+    }
+
+    /**
+     * Whether an existing segment shares its archives with a deleted one, and therefore still needs them.
+     *
+     * Archives are tied to a segment by its hash, as the archive done flag is `done<hash>`, so any segment
+     * with the same hash shares them. The definitions are compared as well because they are stored in
+     * varying encodings, and {@see \Piwik\Segment::getSegmentHash()} resolves every encoding of a definition
+     * to a stored hash - two segments differing only in encoding can therefore end up sharing archives even
+     * when their stored hashes differ.
+     *
+     * The hashes are compared case insensitively to match the lookups this guards: the done flag is matched
+     * with a `LIKE` and the segment table is queried by hash, both case insensitive for the collations
+     * Matomo uses.
+     */
+    private function sharesArchivesWith(array $existing, array $deleted): bool
+    {
+        if (
+            !empty($deleted['hash'])
+            && !empty($existing['hash'])
+            && strcasecmp($existing['hash'], $deleted['hash']) === 0
+        ) {
+            return true;
+        }
+
+        return $existing['definition'] === $deleted['definition']
+            || $existing['definition'] === urlencode($deleted['definition'])
+            || $existing['definition'] === urldecode($deleted['definition']);
     }
 
     public function deleteSegment($idSegment)

--- a/plugins/SegmentEditor/tests/Integration/ModelTest.php
+++ b/plugins/SegmentEditor/tests/Integration/ModelTest.php
@@ -330,6 +330,116 @@ class ModelTest extends IntegrationTestCase
         $this->assertEmpty($segments);
     }
 
+    public function testGetSegmentsDeletedSinceDifferentlyEncodedSegmentWithSameHash()
+    {
+        // segment2 => still in use, with a space written as %20
+        $this->model->updateSegment($this->idSegment2, array(
+            'definition' => 'pageUrl=@a%20b',
+            'enable_only_idsite' => 1,
+            'deleted' => 0,
+            'ts_last_edit' => Date::factory('now')->toString('Y-m-d H:i:s'),
+        ));
+        // segment3 => deleted, same definition but with the space written as +
+        $this->model->updateSegment($this->idSegment3, array(
+            'definition' => 'pageUrl=@a+b',
+            'enable_only_idsite' => 1,
+            'deleted' => 1,
+            'ts_last_edit' => Date::factory('now')->toString('Y-m-d H:i:s'),
+        ));
+
+        $date = Date::factory('now')->subDay(8);
+        $segments = $this->model->getSegmentsDeletedSince($date);
+
+        // Both definitions have the same hash, so both segments share the same archives, which means the
+        // deleted one must not be returned
+        $this->assertEmpty($segments);
+    }
+
+    public function testGetSegmentsDeletedSinceDifferentlyEncodedSegmentWithSameHashForAnotherSite()
+    {
+        // segment2 => still in use for site 2, with a space written as %20
+        $this->model->updateSegment($this->idSegment2, array(
+            'definition' => 'pageUrl=@a%20b',
+            'enable_only_idsite' => 2,
+            'deleted' => 0,
+            'ts_last_edit' => Date::factory('now')->toString('Y-m-d H:i:s'),
+        ));
+        // segment3 => deleted for site 1, same definition but with the space written as +
+        $this->model->updateSegment($this->idSegment3, array(
+            'definition' => 'pageUrl=@a+b',
+            'enable_only_idsite' => 1,
+            'deleted' => 1,
+            'ts_last_edit' => Date::factory('now')->toString('Y-m-d H:i:s'),
+        ));
+
+        $date = Date::factory('now')->subDay(8);
+        $segments = $this->model->getSegmentsDeletedSince($date);
+
+        // The segment still in use is enabled for another site, so the archives of the deleted segment can be
+        // purged - but only for the site it was enabled for
+        $this->assertCount(1, $segments);
+        $this->assertEquals('pageUrl=@a+b', $segments[0]['definition']);
+        $this->assertEquals(1, $segments[0]['enable_only_idsite']);
+        $this->assertEquals(array(), $segments[0]['idsites_to_preserve']);
+    }
+
+    public function testGetSegmentsDeletedSinceDifferentlyEncodedSingleSiteSegmentWithSameHashAsDeletedAllSitesSegment()
+    {
+        // segment3 => still in use for site 1, with a space written as %20
+        $this->model->updateSegment($this->idSegment3, array(
+            'definition' => 'pageUrl=@a%20b',
+            'enable_only_idsite' => 1,
+            'deleted' => 0,
+            'ts_last_edit' => Date::factory('now')->toString('Y-m-d H:i:s'),
+        ));
+        // segment2 => deleted for all sites, same definition but with the space written as +
+        $this->model->updateSegment($this->idSegment2, array(
+            'definition' => 'pageUrl=@a+b',
+            'enable_only_idsite' => 0,
+            'deleted' => 1,
+            'ts_last_edit' => Date::factory('now')->toString('Y-m-d H:i:s'),
+        ));
+
+        $date = Date::factory('now')->subDay(8);
+        $segments = $this->model->getSegmentsDeletedSince($date);
+
+        // The site of the segment still in use has to be preserved, even though its definition is encoded
+        // differently, as both segments share the same archives
+        $this->assertCount(1, $segments);
+        $this->assertEquals('pageUrl=@a+b', $segments[0]['definition']);
+        $this->assertEquals(0, $segments[0]['enable_only_idsite']);
+        $this->assertEquals(array(1), $segments[0]['idsites_to_preserve']);
+    }
+
+    public function testGetSegmentsDeletedSinceSegmentWithSameHashInDifferentCase()
+    {
+        // segment2 => still in use, with a space written as %20
+        $this->model->updateSegment($this->idSegment2, array(
+            'definition' => 'pageUrl=@a%20b',
+            'enable_only_idsite' => 1,
+            'deleted' => 0,
+            'ts_last_edit' => Date::factory('now')->toString('Y-m-d H:i:s'),
+        ));
+        // Hashes are only ever written lower case, but the archives are looked up by a case insensitive LIKE
+        // on the done flag, so a hash stored in a different case still shares them
+        Db::query(
+            'UPDATE ' . Common::prefixTable('segment') . ' SET hash = UPPER(hash) WHERE idsegment = ?',
+            array($this->idSegment2)
+        );
+        // segment3 => deleted, same definition but with the space written as +
+        $this->model->updateSegment($this->idSegment3, array(
+            'definition' => 'pageUrl=@a+b',
+            'enable_only_idsite' => 1,
+            'deleted' => 1,
+            'ts_last_edit' => Date::factory('now')->toString('Y-m-d H:i:s'),
+        ));
+
+        $date = Date::factory('now')->subDay(8);
+        $segments = $this->model->getSegmentsDeletedSince($date);
+
+        $this->assertEmpty($segments);
+    }
+
     private function assertReturnedIdsMatch(array $expectedIds, array $resultSet)
     {
         $this->assertEquals(count($expectedIds), count($resultSet));

--- a/tests/PHPUnit/Integration/Archive/ArchivePurgerTest.php
+++ b/tests/PHPUnit/Integration/Archive/ArchivePurgerTest.php
@@ -214,6 +214,37 @@ class ArchivePurgerTest extends IntegrationTestCase
         $this->assertEquals(0, $deletedRowCount);
     }
 
+    public function testPurgeNoSegmentArchivesRejectsHashThatIsNotAFullMd5()
+    {
+        // Extra data set with segment and plugin archives
+        self::$fixture->insertSegmentArchives($this->january);
+
+        $segmentsToDelete = [
+            // A truncated hash would turn the name clause into a prefix match hitting unrelated segments
+            ['definition' => 'abcd1234abcd5678', 'enable_only_idsite' => 1, 'hash' => 'eb5d2797'],
+        ];
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('eb5d2797 expected to be an md5 hash');
+
+        $this->archivePurger->purgeDeletedSegmentArchives($this->january, $segmentsToDelete);
+    }
+
+    public function testPurgeNoSegmentArchivesDoesNotPurgeAllSitesForNegativeSiteId()
+    {
+        // Extra data set with segment and plugin archives
+        self::$fixture->insertSegmentArchives($this->january);
+
+        $segmentsToDelete = [
+            // Only 0 means "all websites", so a corrupt site ID must not widen the purge to every site
+            ['definition' => 'abcd1234abcd5678', 'enable_only_idsite' => -1, 'hash' => Segment::getSegmentHash('abcd1234abcd5678')],
+        ];
+
+        $deletedRowCount = $this->archivePurger->purgeDeletedSegmentArchives($this->january, $segmentsToDelete);
+
+        $this->assertEquals(0, $deletedRowCount);
+    }
+
     private function configureCustomRangePurging()
     {
         Config::getInstance()->General['purge_date_range_archives_after_X_days'] = 3;


### PR DESCRIPTION
When the weekly task purges the archives of deleted segments, it decided which archives to keep by a different criterion than the one it uses to select rows for deletion. Archives are tied to a segment by its hash, as the archive done flag is `done<hash>`, but the check for segments that are still in use compared stored definition strings. The two are not equivalent, so archives belonging to a segment that still exists could be selected for deletion.

The check now also treats segments with the same hash as still needing those archives, both when looking up the segments in use and when deciding which sites to keep archives for. The definition comparison is kept alongside it, because `Segment::getSegmentHash()` maps a definition to a stored hash rather than computing it, so it is not subsumed by hash equality and dropping it would stop preserving archives that are in use. The net effect is strictly fewer archives deleted than before, never more.

Two smaller robustness changes in the same code path:

- The archive name clause now requires a full 32 character md5, so it can only match the done flag of one segment.
- Only `enable_only_idsite = 0` (or `NULL`) is treated as "all websites"; every other value is applied as a site restriction.

No developer-facing surface changes, so no changelog entry: both altered helpers are private, and `getSegmentsDeletedSince()` keeps its return shape.

### Tests

Integration coverage for the purge decision in `SegmentEditor`, for the whole task end to end in `CoreAdminHome`, and for the two robustness changes in the core archive tests. All of them fail without this change.

```
ddev matomo:console tests:run --file=plugins/SegmentEditor/tests/Integration/ModelTest.php
ddev matomo:console tests:run --file=plugins/CoreAdminHome/tests/Integration/TasksTest.php
ddev matomo:console tests:run --file=tests/PHPUnit/Integration/Archive/ArchivePurgerTest.php
```

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
