### PR TITLE
Allow UI tests to opt into deterministic text rendering

### DIFF
--- a/tests/README.screenshots.md
+++ b/tests/README.screenshots.md
@@ -16,3 +16,18 @@ Chrome, whose screenshots will not match the expected ones.
 Bumping the pinned version changes rendering, so **all** expected screenshots -- core and plugins --
 have to be re-generated in the same change. Native linux/arm64 has no Chrome for Testing build and
 always uses a system browser, so expected screenshots cannot be generated there.
+
+### Deterministic text rendering
+
+Even on the pinned browser, Chrome may hint and subpixel-position text differently from one run to
+the next, moving individual line boxes by a pixel while the glyphs render identically. A run that
+does so fails every text-bearing screenshot in a spec at once.
+
+Setting `MATOMO_UI_DETERMINISTIC_TEXT=1` launches the browser with `--font-render-hinting=none`,
+`--disable-font-subpixel-positioning` and `--disable-lcd-text`, which removes that variation. It is
+off by default because it changes where text lands: expected screenshots generated without it will
+not match runs with it, and vice versa. Whoever turns it on re-generates the expected screenshots it
+affects in the same change.
+
+The variable is read once when the browser launches, so it applies to everything in that process --
+a workflow job or a whole local run, not one spec inside a test group.

--- a/tests/UI/config.dist.js
+++ b/tests/UI/config.dist.js
@@ -183,10 +183,15 @@ const browserConfig = {
 // moves individual line boxes by a pixel while the glyphs themselves render identically - enough to
 // fail every text-bearing screenshot in a spec at once. These flags take that freedom away.
 //
-// They are opt-in because turning them on changes how text lands in every screenshot, so a suite
-// has to regenerate its expected files once when it adopts them. Set MATOMO_UI_DETERMINISTIC_TEXT
-// for a suite that has done so.
-if (process.env.MATOMO_UI_DETERMINISTIC_TEXT) {
+// They are opt-in because turning them on changes how text lands in every screenshot, so whoever
+// enables them regenerates the affected expected files once. The switch is process-global, so the
+// granularities it actually supports are a workflow job (a plugin's UI job can set it in `env:`)
+// and the whole repository - not an individual core spec, which shares a process with the rest of
+// its test group. Note browserConfig is also used by the JavaScript unit-test runner.
+if (['1', 'true'].includes(process.env.MATOMO_UI_DETERMINISTIC_TEXT)) {
+    console.log('MATOMO_UI_DETERMINISTIC_TEXT is set: text rendering flags are on, so screenshots '
+        + 'only match expected files generated with them.');
+
     browserConfig.args.push(
         '--font-render-hinting=none',
         '--disable-font-subpixel-positioning',

--- a/tests/UI/config.dist.js
+++ b/tests/UI/config.dist.js
@@ -179,6 +179,21 @@ const browserConfig = {
     protocolTimeout: 300000
 };
 
+// Chrome is free to hint and subpixel-position text differently from one run to the next, which
+// moves individual line boxes by a pixel while the glyphs themselves render identically - enough to
+// fail every text-bearing screenshot in a spec at once. These flags take that freedom away.
+//
+// They are opt-in because turning them on changes how text lands in every screenshot, so a suite
+// has to regenerate its expected files once when it adopts them. Set MATOMO_UI_DETERMINISTIC_TEXT
+// for a suite that has done so.
+if (process.env.MATOMO_UI_DETERMINISTIC_TEXT) {
+    browserConfig.args.push(
+        '--font-render-hinting=none',
+        '--disable-font-subpixel-positioning',
+        '--disable-lcd-text',
+    );
+}
+
 const browserExecutablePath = resolveBrowserExecutablePath();
 if (browserExecutablePath) {
     browserConfig.executablePath = browserExecutablePath;


### PR DESCRIPTION
### Description

Chrome hints and subpixel-positions text differently from one run to the next, on the same runner image and the same browser build. When it does, individual line boxes move by a pixel while the glyphs render identically — enough to fail every text-bearing screenshot in a spec at once, with re-running as the only remedy.

Observed on plugin-HeatmapSessionRecording: across six attempts of one workflow run on 6.x-dev, five rendered the settings and heatmap pages matching their expected files and one rendered them shifted, failing eleven captures together (58,072 pixels on the settings card, 152 on several heatmap reports, 325,997 on the fold line). Both the shifted and unshifted attempts ran `ubuntu24/20260831.293` with Chrome `152.0.7977.82`, so neither the image nor the browser build explains it. Comparing a shifted capture against its expected file, every differing pixel is accounted for by a ±1px vertical shift of a line box, with none left over.

`--font-render-hinting=none`, `--disable-font-subpixel-positioning` and `--disable-lcd-text` take that freedom away. They are opt-in behind `MATOMO_UI_DETERMINISTIC_TEXT` because enabling them changes where text lands in every screenshot: a suite that adopts them regenerates its expected files once, and nothing changes for anyone who does not set the variable. That also lets one plugin prove the flags before core commits to a fleet-wide regeneration.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
