### PR TITLE
Resolve relative report dates in the site's timezone

### DIFF
--- a/core/Date.php
+++ b/core/Date.php
@@ -177,7 +177,8 @@ class Date
 
     /**
      * Returns Date w/ UTC timestamp of time $dateString/$timezone.
-     * (Only applies to special strings, like 'now','today','yesterday','yesterdaySameTime'.
+     * (Only applies to the relative strings {@link getRelativeKeyword()} recognises, such as
+     * 'now', 'today', 'yesterday' and 'last-week'.)
      *
      * @param string $dateString
      * @param string $timezone
@@ -186,23 +187,52 @@ class Date
      */
     public static function factoryInTimezone($dateString, $timezone)
     {
-        if ($dateString === 'now') {
-            return self::nowInTimezone((string)$timezone);
-        } elseif ($dateString === 'today') {
-            return self::todayInTimezone((string)$timezone);
-        } elseif ($dateString === 'yesterday') {
-            return self::yesterdayInTimezone((string)$timezone);
-        } elseif ($dateString === 'yesterdaySameTime') {
-            return self::yesterdaySameTimeInTimezone((string)$timezone);
-        } elseif (preg_match('/^last[ -]?week$/i', urldecode($dateString))) {
-            return self::lastWeekInTimezone((string)$timezone);
-        } elseif (preg_match('/^last[ -]?month$/i', urldecode($dateString))) {
-            return self::lastMonthInTimezone((string)$timezone);
-        } elseif (preg_match('/^last[ -]?year$/i', urldecode($dateString))) {
-            return self::lastYearInTimezone((string)$timezone);
-        } else {
-            throw new \Exception("Date::factoryInTimezone() should not be used with $dateString.");
+        switch (self::getRelativeKeyword($dateString)) {
+            case 'now':
+                return self::nowInTimezone((string)$timezone);
+            case 'today':
+                return self::todayInTimezone((string)$timezone);
+            case 'yesterday':
+                return self::yesterdayInTimezone((string)$timezone);
+            case 'yesterdaysametime':
+                return self::yesterdaySameTimeInTimezone((string)$timezone);
+            case 'last-week':
+                return self::lastWeekInTimezone((string)$timezone);
+            case 'last-month':
+                return self::lastMonthInTimezone((string)$timezone);
+            case 'last-year':
+                return self::lastYearInTimezone((string)$timezone);
         }
+
+        throw new \Exception("Date::factoryInTimezone() should not be used with $dateString.");
+    }
+
+    /**
+     * Returns the normalised spelling of $dateString if it is one of the relative values
+     * {@link factoryInTimezone()} resolves, and `null` if it is not.
+     *
+     * These values reach Matomo as query parameters, so a padded, url-encoded or differently
+     * cased spelling is recognised the way a literal one is. Anything else is an absolute date
+     * and belongs in {@link factory()}.
+     *
+     * @param mixed $dateString
+     * @return string|null One of `'now'`, `'today'`, `'yesterday'`, `'yesterdaysametime'`,
+     *                     `'last-week'`, `'last-month'` or `'last-year'`.
+     * @ignore
+     */
+    public static function getRelativeKeyword($dateString): ?string
+    {
+        if (!is_string($dateString)) {
+            return null;
+        }
+
+        $keyword = strtolower(trim(urldecode($dateString)));
+
+        if (!preg_match('/^(?:now|today|yesterday|yesterdaysametime|last[ -]?(week|month|year))$/', $keyword, $matches)) {
+            return null;
+        }
+
+        return empty($matches[1]) ? $keyword : 'last-' . $matches[1];
     }
 
     private static function nowInTimezone(string $timezone): Date

--- a/core/Date.php
+++ b/core/Date.php
@@ -181,7 +181,7 @@ class Date
      * 'now', 'today', 'yesterday' and 'last-week'.)
      *
      * @param string $dateString
-     * @param string $timezone
+     * @param string|false $timezone An empty value means UTC.
      * @return Date
      * @ignore
      */

--- a/core/Period/Factory.php
+++ b/core/Period/Factory.php
@@ -64,7 +64,9 @@ abstract class Factory
      *
      * @param string $period `"day"`, `"week"`, `"month"`, `"year"`, `"range"`.
      * @param Date|string $date A date within the period or the range of dates.
-     * @param string $timezone Optional timezone that will be used only when $period is 'range' or $date is 'last|previous'
+     * @param string|false $timezone Timezone the date is resolved in; an empty value means UTC.
+     *                               Applies when $period is 'range', or when $date is a relative
+     *                               or multiple-period value such as 'today' or 'last7'.
      * @return \Piwik\Period
      */
     public static function build($period, $date, $timezone = 'UTC')
@@ -80,7 +82,12 @@ abstract class Factory
                 return new Range($period, $date, $timezone);
             }
 
-            $dateObject = Date::factory($date);
+            // Date::factory() would resolve a relative date on UTC's day, not the timezone's.
+            $keyword = Date::getRelativeKeyword($date);
+
+            $dateObject = $keyword === null
+                ? Date::factory($date)
+                : Date::factoryInTimezone($keyword, $timezone);
         } elseif ($date instanceof Date) {
             $dateObject = $date;
         } else {

--- a/core/Period/Factory.php
+++ b/core/Period/Factory.php
@@ -155,8 +155,8 @@ abstract class Factory
      *                               Applies to relative values such as `'today'` or `'last-week'`,
      *                               and anchors a `'range'` on that timezone's current day.
      * @param string $period The period string: `"day"`, `"week"`, `"month"`, `"year"`, `"range"`.
-     * @param string|Date $date The date or date range string. Can be a special value including
-     *                     `'now'`, `'today'`, `'yesterday'`, `'yesterdaySameTime'`.
+     * @param string|Date $date The date or date range string. Can be a relative value such as
+     *                          `'now'`, `'today'`, `'yesterdaySameTime'` or `'last-week'`.
      * @return \Piwik\Period
      */
     public static function makePeriodFromQueryParams($timezone, $period, $date)

--- a/core/Period/Factory.php
+++ b/core/Period/Factory.php
@@ -144,8 +144,9 @@ abstract class Factory
     /**
      * Creates a Period instance using a period, date and timezone.
      *
-     * @param string $timezone The timezone of the date. Only used if `$date` is `'now'`, `'today'`,
-     *                         `'yesterday'` or `'yesterdaySameTime'`.
+     * @param string|false $timezone Timezone the date is resolved in; an empty value means UTC.
+     *                               Applies to relative values such as `'today'` or `'last-week'`,
+     *                               and anchors a `'range'` on that timezone's current day.
      * @param string $period The period string: `"day"`, `"week"`, `"month"`, `"year"`, `"range"`.
      * @param string|Date $date The date or date range string. Can be a special value including
      *                     `'now'`, `'today'`, `'yesterday'`, `'yesterdaySameTime'`.
@@ -161,11 +162,16 @@ abstract class Factory
 
         if ($period == 'range') {
             self::checkPeriodIsEnabled('range');
-            $oPeriod = new Range('range', $date, $timezone, Date::factory('today', $timezone));
+            // Not Date::factory(): it shifts the timestamp but labels the Date in UTC, so 'today'
+            // stays UTC's day and a relative range ends one day out for a site in another zone.
+            $oPeriod = new Range('range', $date, $timezone, Date::factoryInTimezone('today', $timezone));
         } else {
             if (!($date instanceof Date)) {
-                if (preg_match('/^(now|today|yesterday|yesterdaySameTime|last[ -]?(?:week|month|year))$/i', $date)) {
-                    $date = Date::factoryInTimezone($date, $timezone);
+                // A spelling that misses here falls through to factory() and resolves in UTC.
+                $keyword = Date::getRelativeKeyword($date);
+
+                if ($keyword !== null) {
+                    $date = Date::factoryInTimezone($keyword, $timezone);
                 }
                 $date = Date::factory($date);
             }

--- a/core/Period/Range.php
+++ b/core/Period/Range.php
@@ -254,15 +254,20 @@ class Range extends Period
         } elseif ($dateRange = Range::parseDateRange($this->strDate)) {
             $strDateStart = $dateRange[1];
             $strDateEnd = $dateRange[2];
-            $startDate = Date::factory($strDateStart);
+            // Only a keyword match separates a relative endpoint from an absolute date here,
+            // as 'last-week' carries a hyphen too. Date::factory() resolves it on UTC's day.
+            $startKeyword = Date::getRelativeKeyword($strDateStart);
+            $endKeyword = Date::getRelativeKeyword($strDateEnd);
 
-            // we set the timezone in the Date object only if the date is relative eg. 'today', 'yesterday', 'now'
-            $timezone = null;
-            if (strpos($strDateEnd, '-') === false) {
-                $timezone = $this->timezone;
-            }
+            $startDate = $startKeyword === null
+                ? Date::factory($strDateStart)
+                : Date::factoryInTimezone($startKeyword, $this->timezone);
 
-            $endDate = Date::factory($strDateEnd, $timezone)->setTime("00:00:00");
+            $endDate = $endKeyword === null
+                ? Date::factory($strDateEnd)
+                : Date::factoryInTimezone($endKeyword, $this->timezone);
+
+            $endDate = $endDate->setTime("00:00:00");
             $maxAllowedEndDate = Date::factory(self::getMaxAllowedEndTimestamp());
 
             if ($endDate->isLater($maxAllowedEndDate)) {
@@ -543,12 +548,13 @@ class Range extends Period
         $timezone = $site->getTimezone();
         $last30Relative = new Range($period, $lastN, $timezone);
 
-        if (strpos($endDate, '-') === false) {
-            // eg today, yesterday, ... needs the timezone
-            $endDate = Date::factoryInTimezone($endDate, $timezone);
-        } else {
-            $endDate = Date::factory($endDate);
-        }
+        // A hyphen does not mark an absolute date: 'last-week' carries one and is relative.
+        $keyword = Date::getRelativeKeyword($endDate);
+
+        $endDate = $keyword === null
+            ? Date::factory($endDate)
+            : Date::factoryInTimezone($keyword, $timezone);
+
         $last30Relative->setDefaultEndDate($endDate);
 
         $date = $last30Relative->getDateStart()->toString() . "," . $last30Relative->getDateEnd()->toString();

--- a/core/Period/Range.php
+++ b/core/Period/Range.php
@@ -446,14 +446,16 @@ class Range extends Period
      *
      * @param bool|string $date The date to get the last date of.
      * @param bool|string $period The period to use (either 'day', 'week', 'month', 'year');
+     * @param string|false $timezone The timezone a relative $date such as 'today' is resolved in;
+     *                               an empty value means UTC.
      *
      * @return array An array with two elements, a string for the date before $date and
      *               a Period instance for the period before $date.
      * @api
      */
-    public static function getLastDate($date = false, $period = false)
+    public static function getLastDate($date = false, $period = false, $timezone = false)
     {
-        return self::getDateXPeriodsAgo(1, $date, $period);
+        return self::getDateXPeriodsAgo(1, $date, $period, $timezone);
     }
 
     /**
@@ -464,12 +466,14 @@ class Range extends Period
      *                    day one year ago and change the value to 366 days therefore.
      * @param bool|string $date The date to get the last date of.
      * @param bool|string $period The period to use (either 'day', 'week', 'month', 'year');
+     * @param string|false $timezone The timezone a relative $date such as 'today' is resolved in;
+     *                               an empty value means UTC.
      *
      * @return array An array with two elements, a string for the date before $date and
      *               a Period instance for the period before $date.
      * @api
      */
-    public static function getDateXPeriodsAgo($subXPeriods, $date = false, $period = false)
+    public static function getDateXPeriodsAgo($subXPeriods, $date = false, $period = false, $timezone = false)
     {
         if ($date === false) {
             $date = Common::getRequestVar('date');
@@ -479,12 +483,18 @@ class Range extends Period
             $period = Common::getRequestVar('period');
         }
 
-        if (365 == $subXPeriods && 'day' == $period && Date::factory($date)->isLeapYear()) {
+        // A relative date resolves on the day $timezone is on, and Date::factory() would hand back
+        // UTC's. Keep the original spelling too: the lastN/previousN test below still has to see
+        // 'last-week' as a date it cannot compare against an earlier one.
+        $keyword = Date::getRelativeKeyword($date);
+        $resolvedDate = $keyword === null ? $date : Date::factoryInTimezone($keyword, $timezone)->toString();
+
+        if (365 == $subXPeriods && 'day' == $period && Date::factory($resolvedDate)->isLeapYear()) {
             $subXPeriods = 366;
         }
 
         if ($period === 'range') {
-            $rangePeriod = new Range($period, $date);
+            $rangePeriod = new Range($period, $date, $timezone);
             $daysDifference = self::getNumDaysDifference($rangePeriod->getDateStart(), $rangePeriod->getDateEnd());
             $end = $rangePeriod->getDateStart()->subDay(1);
             $from = $end->subDay($daysDifference);
@@ -499,14 +509,14 @@ class Range extends Period
             if (strpos($date, ',')) {
                 // date in the form of 2011-01-01,2011-02-02
 
-                $rangePeriod = new Range($period, $date);
+                $rangePeriod = new Range($period, $date, $timezone);
 
                 $lastStartDate = $rangePeriod->getDateStart()->subPeriod($subXPeriods, $period);
                 $lastEndDate   = $rangePeriod->getDateEnd()->subPeriod($subXPeriods, $period);
 
                 $strLastDate = "$lastStartDate,$lastEndDate";
             } else {
-                $lastPeriod  = Date::factory($date)->subPeriod($subXPeriods, $period);
+                $lastPeriod  = Date::factory($resolvedDate)->subPeriod($subXPeriods, $period);
                 $strLastDate = $lastPeriod->toString();
             }
         }

--- a/core/Period/Range.php
+++ b/core/Period/Range.php
@@ -11,10 +11,10 @@ namespace Piwik\Period;
 
 use Exception;
 use Piwik\Cache;
-use Piwik\Common;
 use Piwik\Container\StaticContainer;
 use Piwik\Date;
 use Piwik\Period;
+use Piwik\Request;
 
 /**
  * Arbitrary date range representation.
@@ -476,11 +476,11 @@ class Range extends Period
     public static function getDateXPeriodsAgo($subXPeriods, $date = false, $period = false, $timezone = false)
     {
         if ($date === false) {
-            $date = Common::getRequestVar('date');
+            $date = Request::fromRequest()->getStringParameter('date');
         }
 
         if ($period === false) {
-            $period = Common::getRequestVar('period');
+            $period = Request::fromRequest()->getStringParameter('period');
         }
 
         // A relative date resolves on the day $timezone is on, and Date::factory() would hand back

--- a/core/Period/Range.php
+++ b/core/Period/Range.php
@@ -49,8 +49,8 @@ class Range extends Period
      * @param string $strPeriod The type of period each subperiod is. Either `'day'`, `'week'`,
      *                          `'month'` or `'year'`.
      * @param string $strDate The date range, eg, `'2007-07-24,2013-11-15'`.
-     * @param string $timezone The timezone to use, eg, `'UTC'`.
-     * @param bool|Date $today The date to use as _today_. Defaults to `Date::factory('today', $timzeone)`.
+     * @param string|false $timezone The timezone to use, eg, `'UTC'`. An empty value means UTC.
+     * @param bool|Date $today The date to use as _today_. Defaults to `Date::factory('now', $timezone)`.
      * @api
      */
     public function __construct($strPeriod, $strDate, $timezone = 'UTC', $today = false)
@@ -459,11 +459,11 @@ class Range extends Period
     /**
      * Returns the date that is X periods before the supplied date.
      *
-     * @param bool|string $date The date to get the last date of.
-     * @param bool|string $period The period to use (either 'day', 'week', 'month', 'year');
      * @param int         $subXPeriods How many periods in the past the date should be, for instance 1 or 7.
      *                    If sub period is 365 days and the current year is a leap year we assume you want to get the
      *                    day one year ago and change the value to 366 days therefore.
+     * @param bool|string $date The date to get the last date of.
+     * @param bool|string $period The period to use (either 'day', 'week', 'month', 'year');
      *
      * @return array An array with two elements, a string for the date before $date and
      *               a Period instance for the period before $date.
@@ -538,7 +538,8 @@ class Range extends Period
      * @param string $period The sub period type, `'day'`, `'week'`, `'month'` and `'year'`.
      * @param int $lastN The number of periods of type `$period` that the result range should
      *                   span.
-     * @param string $endDate The desired end date of the range.
+     * @param string $endDate The desired end date of the range, either an absolute date or a
+     *                        relative value such as `'today'` or `'last-week'`.
      * @param \Piwik\Site $site The site whose timezone should be used.
      * @return string The date range string, eg, `'2012-01-02,2013-01-02'`.
      * @api

--- a/plugins/API/ProcessedReport.php
+++ b/plugins/API/ProcessedReport.php
@@ -533,14 +533,10 @@ class ProcessedReport
 
         $website = new Site($idSite);
 
-        // Label the report with the period the archive resolved, not one rebuilt from the
-        // query parameters: a module is free to select over a site set of its own making
-        // rather than over $idSite, and MultiSites.getAll does, so a period derived here
-        // from $idSite can name a different day than the rows were counted over. A Map
-        // spans several periods and carries no single one, so it keeps the derivation.
-        $resolvedPeriod = $dataTable instanceof DataTable
-            ? $dataTable->getMetadata(DataTableFactory::TABLE_METADATA_PERIOD_INDEX)
-            : null;
+        // Modules such as MultiSites.getAll select their own sites, so the requested site's
+        // timezone is not necessarily the one the rows were selected in.
+        $isMultiplePeriod = Period::isMultiplePeriod($date, $period);
+        $resolvedPeriod = $this->getPeriodFromTable($dataTable, $isMultiplePeriod);
 
         if ($resolvedPeriod instanceof Period) {
             $period = $resolvedPeriod->getLocalizedLongString();
@@ -550,7 +546,7 @@ class ProcessedReport
             // Of the two factory methods, only build() accepts a multiple-period date.
             $idSites  = Site::getIdSitesFromIdSitesString($idSite);
             $timezone = count($idSites) === 1 ? Site::getTimezoneFor($idSites[0]) : false;
-            $period = Period::isMultiplePeriod($date, $period)
+            $period = $isMultiplePeriod
                 ? Period\Factory::build($period, $date, $timezone)
                 : Period\Factory::makePeriodFromQueryParams($timezone, $period, $date);
             $period = $period->getLocalizedLongString();
@@ -569,6 +565,46 @@ class ProcessedReport
             $return['timerMillis'] = $timer->getTimeMs(0);
         }
         return $return;
+    }
+
+    private function getPeriodFromTable(DataTable|DataTable\Map $dataTable, bool $spanAsRange = false): ?Period
+    {
+        if ($dataTable instanceof DataTable) {
+            $period = $dataTable->getMetadata(DataTableFactory::TABLE_METADATA_PERIOD_INDEX);
+            return $period instanceof Period ? $period : null;
+        }
+
+        $firstPeriod = null;
+        $startDate = null;
+        $endDate = null;
+        foreach ($dataTable->getDataTables() as $table) {
+            $period = $this->getPeriodFromTable($table);
+            if ($period === null) {
+                return null;
+            }
+
+            $firstPeriod = $firstPeriod ?? $period;
+            // Compare calendar dates directly; each site's UTC boundaries can differ.
+            $start = $period->getDateStart()->toString();
+            $end = $period->getDateEnd()->toString();
+            $startDate = $startDate === null ? $start : min($startDate, $start);
+            $endDate = $endDate === null ? $end : max($endDate, $end);
+        }
+
+        // A multiple-period date was labelled as a range even when it covers a single period,
+        // so keep that shape rather than naming the one subperiod it reduced to.
+        if (
+            $firstPeriod === null
+            || (!$spanAsRange
+                && $startDate === $firstPeriod->getDateStart()->toString()
+                && $endDate === $firstPeriod->getDateEnd()->toString())
+        ) {
+            return $firstPeriod;
+        }
+
+        // Not Factory::build(): it rejects 'range' on an installation that disabled the period
+        // for the API, and this labels rows already selected rather than requesting a period.
+        return new Period\Range('range', $startDate . ',' . $endDate);
     }
 
     /**

--- a/plugins/API/ProcessedReport.php
+++ b/plugins/API/ProcessedReport.php
@@ -533,8 +533,28 @@ class ProcessedReport
 
         $website = new Site($idSite);
 
-        $period = Period\Factory::build($period, $date);
-        $period = $period->getLocalizedLongString();
+        // Label the report with the period the archive resolved, not one rebuilt from the
+        // query parameters: a module is free to select over a site set of its own making
+        // rather than over $idSite, and MultiSites.getAll does, so a period derived here
+        // from $idSite can name a different day than the rows were counted over. A Map
+        // spans several periods and carries no single one, so it keeps the derivation.
+        $resolvedPeriod = $dataTable instanceof DataTable
+            ? $dataTable->getMetadata(DataTableFactory::TABLE_METADATA_PERIOD_INDEX)
+            : null;
+
+        if ($resolvedPeriod instanceof Period) {
+            $period = $resolvedPeriod->getLocalizedLongString();
+        } else {
+            // The archive only uses a site timezone when the request names a single site, and
+            // reads it off the parsed list: $website's id does not survive an array idSite.
+            // Of the two factory methods, only build() accepts a multiple-period date.
+            $idSites  = Site::getIdSitesFromIdSitesString($idSite);
+            $timezone = count($idSites) === 1 ? Site::getTimezoneFor($idSites[0]) : false;
+            $period = Period::isMultiplePeriod($date, $period)
+                ? Period\Factory::build($period, $date, $timezone)
+                : Period\Factory::makePeriodFromQueryParams($timezone, $period, $date);
+            $period = $period->getLocalizedLongString();
+        }
 
         $return = array(
             'website'        => $website->getName(),

--- a/plugins/API/tests/Integration/ProcessedReportRelativeDateTimezoneTest.php
+++ b/plugins/API/tests/Integration/ProcessedReportRelativeDateTimezoneTest.php
@@ -227,11 +227,17 @@ class ProcessedReportRelativeDateTimezoneTest extends IntegrationTestCase
 
     /**
      * idSite does not decide the archive's scope for every module. MultiSites.getAll selects
-     * over every site the user can view, so a request naming one site still aggregates in UTC,
-     * and a label derived from that one site's timezone would name a day the rows do not cover.
+     * over every site the user can view, so a request naming one site can resolve relative
+     * dates using UTC. Each site still supplies archives for its own local calendar days.
+     *
+     * @param string[] $expectedDates
+     * @dataProvider getMultiSitesDates
      */
-    public function testAModuleThatSelectsItsOwnSiteSetIsLabelledOnTheTimezoneTheRowsUse(): void
-    {
+    public function testAModuleThatSelectsItsOwnSiteSetIsLabelledOnTheTimezoneTheRowsUse(
+        string $date,
+        string $expectedRange,
+        array $expectedDates
+    ): void {
         $idSite2 = Fixture::createWebsite(
             '2026-09-01 00:00:00',
             0,
@@ -251,16 +257,32 @@ class ProcessedReportRelativeDateTimezoneTest extends IntegrationTestCase
         $report = API::getInstance()->getProcessedReport(
             $this->idSite,
             'day',
-            'yesterday',
+            $date,
             'MultiSites',
             'getAll'
         );
 
+        if (count($expectedDates) > 1) {
+            self::assertInstanceOf(DataTable\Map::class, $report['reportData']);
+            self::assertEqualsCanonicalizing(
+                array_map([$this, 'prettyDateFor'], $expectedDates),
+                array_keys($report['reportData']->getDataTables())
+            );
+        }
+
         self::assertSame(
-            $this->prettyDateFor(self::UTC_YESTERDAY),
+            PeriodFactory::build('range', $expectedRange)->getLocalizedLongString(),
             $report['prettyDate'],
             'prettyDate took the named site\'s timezone for rows the module selected in UTC.'
         );
+    }
+
+    public function getMultiSitesDates(): array
+    {
+        return [
+            ['yesterday', '2026-09-07,2026-09-07', ['2026-09-07']],
+            ['last2', '2026-09-07,2026-09-08', ['2026-09-07', '2026-09-08']],
+        ];
     }
 
     /**

--- a/plugins/API/tests/Integration/ProcessedReportRelativeDateTimezoneTest.php
+++ b/plugins/API/tests/Integration/ProcessedReportRelativeDateTimezoneTest.php
@@ -22,7 +22,8 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 /**
  * getProcessedReport resolves a relative date twice: once for the rows, once for
  * prettyDate. Both have to resolve in the site's timezone, or the label names a
- * different day than the report counts.
+ * different day than the report counts. A relative range resolves an anchor day of
+ * its own, which has to land in the site's timezone for the same reason.
  *
  * @group API
  * @group Plugins
@@ -37,6 +38,9 @@ class ProcessedReportRelativeDateTimezoneTest extends IntegrationTestCase
 
     private const AUCKLAND_YESTERDAY = '2026-09-08';
     private const UTC_YESTERDAY = '2026-09-07';
+
+    /** The seven days ending on Auckland's yesterday. */
+    private const AUCKLAND_PREVIOUS7 = '2026-09-02,2026-09-08';
 
     private int $idSite;
 
@@ -128,6 +132,28 @@ class ProcessedReportRelativeDateTimezoneTest extends IntegrationTestCase
 
         self::assertSame(2, $this->visitsInReport($report['reportData']));
         self::assertSame($this->prettyDateFor(self::AUCKLAND_YESTERDAY), $report['prettyDate']);
+    }
+
+    /**
+     * A relative range is measured back from a "today" of its own. The fixture holds 2 visits on
+     * the site's yesterday and 1 the day before, so a window anchored a day early counts 1, not 3.
+     */
+    public function testARelativeRangeIsCountedAndLabelledOnTheSitesOwnDays(): void
+    {
+        $report = API::getInstance()->getProcessedReport(
+            $this->idSite,
+            'range',
+            'previous7',
+            'VisitsSummary',
+            'get'
+        );
+
+        self::assertSame(3, $this->visitsInReport($report['reportData']));
+        self::assertSame(
+            PeriodFactory::build('range', self::AUCKLAND_PREVIOUS7)->getLocalizedLongString(),
+            $report['prettyDate'],
+            'previous7 did not end on the site\'s yesterday.'
+        );
     }
 
     /** A comma date is a multiple period, so it stays labelled as a range. */

--- a/plugins/API/tests/Integration/ProcessedReportRelativeDateTimezoneTest.php
+++ b/plugins/API/tests/Integration/ProcessedReportRelativeDateTimezoneTest.php
@@ -1,0 +1,293 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+declare(strict_types=1);
+
+namespace Piwik\Plugins\API\tests\Integration;
+
+use Piwik\API\Request;
+use Piwik\DataTable;
+use Piwik\Date;
+use Piwik\Period\Factory as PeriodFactory;
+use Piwik\Plugins\API\API;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * getProcessedReport resolves a relative date twice: once for the rows, once for
+ * prettyDate. Both have to resolve in the site's timezone, or the label names a
+ * different day than the report counts.
+ *
+ * @group API
+ * @group Plugins
+ */
+class ProcessedReportRelativeDateTimezoneTest extends IntegrationTestCase
+{
+    /** UTC+12 with no DST transition near NOW. */
+    private const SITE_TIMEZONE = 'Pacific/Auckland';
+
+    /** 01:00 the next day in Auckland, so the two zones disagree on "yesterday". */
+    private const NOW = '2026-09-08 13:00:00';
+
+    private const AUCKLAND_YESTERDAY = '2026-09-08';
+    private const UTC_YESTERDAY = '2026-09-07';
+
+    private int $idSite;
+
+    private ?int $originalNow = null;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Otherwise getLocalizedLongString() compares raw Intl_ keys.
+        Fixture::loadAllTranslations();
+
+        Fixture::createSuperUser(true);
+        $this->idSite = Fixture::createWebsite(
+            '2026-09-01 00:00:00',
+            0,
+            'Timezone probe',
+            false,
+            1,
+            null,
+            null,
+            self::SITE_TIMEZONE
+        );
+
+        // Visit times are UTC: Auckland's 2026-09-08 starts at 2026-09-07 12:00 UTC,
+        // so both of these fall on Auckland's yesterday and UTC's 2026-09-07.
+        foreach (['2026-09-07 13:00:00', '2026-09-07 14:00:00'] as $when) {
+            $tracker = Fixture::getTracker($this->idSite, $when);
+            Fixture::checkResponse($tracker->doTrackPageView('/auckland-yesterday'));
+        }
+
+        // One on the Auckland day before, so the candidate days differ by count too.
+        $tracker = Fixture::getTracker($this->idSite, '2026-09-06 13:00:00');
+        Fixture::checkResponse($tracker->doTrackPageView('/auckland-day-before'));
+
+        $this->originalNow = Date::$now;
+        Date::$now = (int) strtotime(self::NOW . ' UTC');
+    }
+
+    public function tearDown(): void
+    {
+        Date::$now = $this->originalNow;
+
+        parent::tearDown();
+    }
+
+    public function testTheTwoCandidateDaysHoldDifferentVisitCounts(): void
+    {
+        self::assertSame(2, $this->visitsOn(self::AUCKLAND_YESTERDAY));
+        self::assertSame(1, $this->visitsOn(self::UTC_YESTERDAY));
+    }
+
+    public function testRelativeDateSelectsRowsInTheSitesTimezone(): void
+    {
+        self::assertSame(
+            2,
+            $this->visitsOn('yesterday'),
+            'The archive resolved "yesterday" somewhere other than the site timezone.'
+        );
+    }
+
+    public function testPrettyDateNamesTheDayTheRowsActuallyCoverOnARelativeDate(): void
+    {
+        $report = API::getInstance()->getProcessedReport(
+            $this->idSite,
+            'day',
+            'yesterday',
+            'VisitsSummary',
+            'get'
+        );
+
+        self::assertSame(2, $this->visitsInReport($report['reportData']));
+        self::assertSame(
+            $this->prettyDateFor(self::AUCKLAND_YESTERDAY),
+            $report['prettyDate'],
+            'prettyDate names a different day than the rows it is attached to.'
+        );
+    }
+
+    public function testAnAbsoluteDateIsLabelledConsistently(): void
+    {
+        $report = API::getInstance()->getProcessedReport(
+            $this->idSite,
+            'day',
+            self::AUCKLAND_YESTERDAY,
+            'VisitsSummary',
+            'get'
+        );
+
+        self::assertSame(2, $this->visitsInReport($report['reportData']));
+        self::assertSame($this->prettyDateFor(self::AUCKLAND_YESTERDAY), $report['prettyDate']);
+    }
+
+    /** A comma date is a multiple period, so it stays labelled as a range. */
+    public function testAMultiPeriodDateIsStillLabelledAsARange(): void
+    {
+        $report = API::getInstance()->getProcessedReport(
+            $this->idSite,
+            'day',
+            self::UTC_YESTERDAY . ',' . self::AUCKLAND_YESTERDAY,
+            'VisitsSummary',
+            'get'
+        );
+
+        self::assertSame(
+            [
+                $this->prettyDateFor(self::UTC_YESTERDAY) => 1,
+                $this->prettyDateFor(self::AUCKLAND_YESTERDAY) => 2,
+            ],
+            $this->visitsPerTable($report['reportData'])
+        );
+        self::assertSame(
+            PeriodFactory::build('range', self::UTC_YESTERDAY . ',' . self::AUCKLAND_YESTERDAY)
+                ->getLocalizedLongString(),
+            $report['prettyDate']
+        );
+    }
+
+    /**
+     * Both sites share the site timezone, so this pins the rule rather than a disagreement
+     * between them: the archive selects rows in UTC whenever the request names more than one
+     * site, so the label has to stay in UTC too.
+     */
+    public function testAMultiSiteRequestIsLabelledInTheTimezoneTheRowsUse(): void
+    {
+        $idSite2 = Fixture::createWebsite(
+            '2026-09-01 00:00:00',
+            0,
+            'Timezone probe two',
+            false,
+            1,
+            null,
+            null,
+            self::SITE_TIMEZONE
+        );
+
+        // getProcessedReport re-keys the result on the period label, so every site's table
+        // collides on one key and all but the last are dropped. Pre-existing, not fixed here.
+        // Give site two a visit on the UTC-resolved day so the surviving table is non-empty.
+        $tracker = Fixture::getTracker($idSite2, '2026-09-07 02:00:00');
+        Fixture::checkResponse($tracker->doTrackPageView('/site-two-utc-yesterday'));
+
+        $report = API::getInstance()->getProcessedReport(
+            $this->idSite . ',' . $idSite2,
+            'day',
+            'yesterday',
+            'VisitsSummary',
+            'get'
+        );
+
+        // Assert the per-site counts here once that keying is fixed.
+        foreach ($this->visitsPerTable($report['reportData']) as $label => $visits) {
+            self::assertGreaterThan(0, $visits, "The report table \"$label\" counts no visits.");
+        }
+
+        self::assertSame(
+            $this->prettyDateFor(self::UTC_YESTERDAY),
+            $report['prettyDate'],
+            'prettyDate took a site timezone for a request whose rows were selected in UTC.'
+        );
+    }
+
+    /**
+     * idSite does not decide the archive's scope for every module. MultiSites.getAll selects
+     * over every site the user can view, so a request naming one site still aggregates in UTC,
+     * and a label derived from that one site's timezone would name a day the rows do not cover.
+     */
+    public function testAModuleThatSelectsItsOwnSiteSetIsLabelledOnTheTimezoneTheRowsUse(): void
+    {
+        $idSite2 = Fixture::createWebsite(
+            '2026-09-01 00:00:00',
+            0,
+            'Timezone probe two',
+            false,
+            1,
+            null,
+            null,
+            self::SITE_TIMEZONE
+        );
+
+        // On UTC's yesterday, so the aggregate the UTC-resolved day covers is non-empty.
+        $tracker = Fixture::getTracker($idSite2, '2026-09-07 02:00:00');
+        Fixture::checkResponse($tracker->doTrackPageView('/site-two-utc-yesterday'));
+
+        // One site named, two sites archived.
+        $report = API::getInstance()->getProcessedReport(
+            $this->idSite,
+            'day',
+            'yesterday',
+            'MultiSites',
+            'getAll'
+        );
+
+        self::assertSame(
+            $this->prettyDateFor(self::UTC_YESTERDAY),
+            $report['prettyDate'],
+            'prettyDate took the named site\'s timezone for rows the module selected in UTC.'
+        );
+    }
+
+    /**
+     * A prettyDate assertion only says something when the report it labels holds rows.
+     *
+     * @param DataTable|DataTable\Map $reportData
+     */
+    private function visitsInReport($reportData): int
+    {
+        self::assertInstanceOf(DataTable::class, $reportData);
+
+        $row = $reportData->getFirstRow();
+        self::assertNotFalse($row, 'The report holds no rows, so prettyDate describes no data.');
+
+        return (int) $row->getColumn('nb_visits');
+    }
+
+    /**
+     * @param DataTable|DataTable\Map $reportData
+     * @return int[] visits per table, keyed by the label the report data uses
+     */
+    private function visitsPerTable($reportData): array
+    {
+        self::assertInstanceOf(DataTable\Map::class, $reportData);
+
+        $visits = [];
+        foreach ($reportData->getDataTables() as $label => $table) {
+            $row = $table->getFirstRow();
+            self::assertNotFalse($row, "The report table \"$label\" holds no rows.");
+            $visits[$label] = (int) $row->getColumn('nb_visits');
+        }
+
+        self::assertNotEmpty($visits, 'The report came back without a single table.');
+
+        return $visits;
+    }
+
+    private function visitsOn(string $date): int
+    {
+        $table = Request::processRequest('VisitsSummary.getVisits', [
+            'idSite' => $this->idSite,
+            'period' => 'day',
+            'date' => $date,
+            'format' => 'original',
+        ]);
+        $row = $table->getFirstRow();
+
+        return $row === false ? 0 : (int) $row->getColumn('nb_visits');
+    }
+
+    /** Built the way getProcessedReport builds it, so only the date is compared. */
+    private function prettyDateFor(string $date): string
+    {
+        return PeriodFactory::build('day', $date)->getLocalizedLongString();
+    }
+}

--- a/plugins/Goals/Reports/Get.php
+++ b/plugins/Goals/Reports/Get.php
@@ -123,7 +123,7 @@ class Get extends Base
 
     public function configureView(ViewDataTable $view)
     {
-        $idGoal = Common::getRequestVar('idGoal', 0, 'string');
+        $idGoal = \Piwik\Request::fromRequest()->getStringParameter('idGoal', '0');
 
         $idSite = $this->getIdSite();
 
@@ -131,7 +131,7 @@ class Get extends Base
             /** @var Sparklines $view */
             $isEcommerceEnabled = $this->isEcommerceEnabled($idSite);
 
-            $onlySummary = Common::getRequestVar('only_summary', 0, 'int');
+            $onlySummary = \Piwik\Request::fromRequest()->getIntegerParameter('only_summary', 0);
 
             if ($onlySummary && !empty($idGoal)) {
                 if (is_numeric($idGoal)) {
@@ -169,7 +169,7 @@ class Get extends Base
                 };
             }
 
-            $allowMultiple = Common::getRequestVar('allow_multiple', 0, 'int');
+            $allowMultiple = \Piwik\Request::fromRequest()->getIntegerParameter('allow_multiple', 0);
 
             if ($allowMultiple) {
                 $view->config->addSparklineMetric(['nb_conversions', 'nb_visits_converted'], $order = 10);
@@ -213,7 +213,7 @@ class Get extends Base
 
                     $currentPeriod     = PeriodFactory::build(
                         Piwik::getPeriod(),
-                        Common::getRequestVar('date'),
+                        \Piwik\Request::fromRequest()->getStringParameter('date'),
                         $timezone
                     );
                     $currentPrettyDate = ($currentPeriod instanceof Month ? $currentPeriod->getLocalizedLongString(

--- a/plugins/Goals/Reports/Get.php
+++ b/plugins/Goals/Reports/Get.php
@@ -199,10 +199,11 @@ class Get extends Base
             }
 
             // Add evolution values to sparklines
-            [$lastPeriodDate, $ignore] = Range::getLastDate();
+            $timezone = Site::getTimezoneFor($idSite);
+            [$lastPeriodDate, $ignore] = Range::getLastDate(false, false, $timezone);
             if ($lastPeriodDate !== false) {
                 // Using a filter here ensures the additional request is only performed when the view is rendered
-                $view->config->filters[] = function ($datatable) use ($view, $lastPeriodDate, $idSite) {
+                $view->config->filters[] = function ($datatable) use ($view, $lastPeriodDate, $idSite, $timezone) {
                     /** @var DataTable $previousData */
                     $previousData    = Request::processRequest(
                         'Goals.get',
@@ -210,10 +211,14 @@ class Get extends Base
                     );
                     $previousDataRow = $previousData->getFirstRow();
 
-                    $currentPeriod     = PeriodFactory::build(Piwik::getPeriod(), Common::getRequestVar('date'));
+                    $currentPeriod     = PeriodFactory::build(
+                        Piwik::getPeriod(),
+                        Common::getRequestVar('date'),
+                        $timezone
+                    );
                     $currentPrettyDate = ($currentPeriod instanceof Month ? $currentPeriod->getLocalizedLongString(
                     ) : $currentPeriod->getPrettyString());
-                    $lastPeriod        = PeriodFactory::build(Piwik::getPeriod(), $lastPeriodDate);
+                    $lastPeriod        = PeriodFactory::build(Piwik::getPeriod(), $lastPeriodDate, $timezone);
                     $lastPrettyDate    = ($currentPeriod instanceof Month ? $lastPeriod->getLocalizedLongString(
                     ) : $lastPeriod->getPrettyString());
                     $metricTranslations = $view->config->translations;

--- a/plugins/Insights/API.php
+++ b/plugins/Insights/API.php
@@ -12,6 +12,7 @@ namespace Piwik\Plugins\Insights;
 use Piwik\API\Request as ApiRequest;
 use Piwik\DataTable;
 use Piwik\Piwik;
+use Piwik\Site;
 
 /**
  * Provides API methods for insight and mover/shaker comparisons between report periods.
@@ -229,7 +230,7 @@ class API extends \Piwik\Plugin\API
         $currentReport  = $this->model->requestReport($idSite, $period, $date, $reportUniqueId, $metric, $segment);
         $this->checkReportIsValid($currentReport);
 
-        $lastDate       = $this->model->getLastDate($date, $period, $comparedToXPeriods);
+        $lastDate       = $this->model->getLastDate($date, $period, $comparedToXPeriods, Site::getTimezoneFor($idSite));
         $lastTotalValue = $this->model->getTotalValue($idSite, $period, $lastDate, $metric, $segment);
         $lastReport     = $this->model->requestReport($idSite, $period, $lastDate, $reportUniqueId, $metric, $segment);
         $this->checkReportIsValid($lastReport);
@@ -289,7 +290,7 @@ class API extends \Piwik\Plugin\API
         $currentReport  = $this->model->requestReport($idSite, $period, $date, $reportUniqueId, $metric, $segment);
         $this->checkReportIsValid($currentReport);
 
-        $lastDate       = $this->model->getLastDate($date, $period, $comparedToXPeriods);
+        $lastDate       = $this->model->getLastDate($date, $period, $comparedToXPeriods, Site::getTimezoneFor($idSite));
         $lastTotalValue = $this->model->getTotalValue($idSite, $period, $lastDate, $metric, $segment);
         $lastReport     = $this->model->requestReport($idSite, $period, $lastDate, $reportUniqueId, $metric, $segment);
         $this->checkReportIsValid($lastReport);

--- a/plugins/Insights/Model.php
+++ b/plugins/Insights/Model.php
@@ -53,9 +53,9 @@ class Model
         return $table;
     }
 
-    public function getLastDate($date, $period, $comparedToXPeriods)
+    public function getLastDate($date, $period, $comparedToXPeriods, $timezone = false)
     {
-        $pastDate = Range::getDateXPeriodsAgo(abs($comparedToXPeriods), $date, $period);
+        $pastDate = Range::getDateXPeriodsAgo(abs($comparedToXPeriods), $date, $period, $timezone);
 
         if (empty($pastDate[0])) {
             throw new \Exception('Not possible to compare this date/period combination');

--- a/plugins/Insights/tests/Integration/ModelTest.php
+++ b/plugins/Insights/tests/Integration/ModelTest.php
@@ -10,6 +10,7 @@
 namespace Piwik\Plugins\Insights\tests\Integration;
 
 use Piwik\Container\StaticContainer;
+use Piwik\Date;
 use Piwik\DataTable;
 use Piwik\Plugins\Insights\Model;
 use Piwik\Plugins\Insights\tests\Fixtures\SomeVisitsDifferentPathsOnTwoDays;
@@ -37,6 +38,15 @@ class ModelTest extends SystemTestCase
         parent::setUp();
 
         $this->model = StaticContainer::getContainer()->make('Piwik\Plugins\Insights\Model');
+
+        Date::$now = null;
+    }
+
+    public function tearDown(): void
+    {
+        Date::$now = null;
+
+        parent::tearDown();
     }
 
     public function testRequestReportShouldReturnTheDataTableOfTheReportAndContainReportTotals()
@@ -112,6 +122,34 @@ class ModelTest extends SystemTestCase
         $total = $this->model->getMetricTotalValue($table, 'unknown_metric');
 
         $this->assertEquals(0, $total);
+    }
+
+    /**
+     * @dataProvider getRelativeDateSpellings
+     */
+    public function testGetLastDateResolvesARelativeDateInTheGivenTimezone($date)
+    {
+        // 04:37 on the 25th for the site, still the 24th for the server.
+        Date::$now = strtotime('2020-12-24 16:37:00');
+
+        $this->assertEquals('2020-12-24', $this->model->getLastDate($date, 'day', 1, 'UTC+12'));
+    }
+
+    public function getRelativeDateSpellings()
+    {
+        return [
+            ['today'],
+            // The date comes from the request, so it arrives in whatever spelling was sent.
+            ['TODAY'],
+            [' today '],
+        ];
+    }
+
+    public function testGetLastDateWithoutATimezoneComparesAgainstTheServerDay()
+    {
+        Date::$now = strtotime('2020-12-24 16:37:00');
+
+        $this->assertEquals('2020-12-23', $this->model->getLastDate('today', 'day', 1));
     }
 
     public function testGetLastDateShouldThrowExceptionIfNotPossibleToGetLastDate()

--- a/plugins/Live/VisitorDetails.php
+++ b/plugins/Live/VisitorDetails.php
@@ -258,14 +258,18 @@ class VisitorDetails extends VisitorDetailsAbstract
      */
     private function getVisitorProfileVisitSummary($visit, Site $site): array
     {
-        $today = Date::factory('today', $site->getTimezone());
+        $today = Date::factoryInTimezone('today', $site->getTimezone());
         $firstActionTimestamp = $visit->getColumn('firstActionTimestamp');
         $firstActionDate = Date::factory($firstActionTimestamp, $site->getTimezone());
+        // Count the days between the two calendar days, not the hours since the visit itself:
+        // a visit at 10:00 two days ago is 1.58 days back and would otherwise truncate to one.
+        $startOfVisitDay = $firstActionDate->getStartOfDay();
+        $daysAgo = Date::secondsToDays($today->getTimestamp() - $startOfVisitDay->getTimestamp());
 
         return [
             'date'            => $firstActionTimestamp,
             'prettyDate'      => $firstActionDate->getLocalized(Date::DATE_FORMAT_LONG),
-            'daysAgo'         => (int) Date::secondsToDays($today->getTimestamp() - $firstActionDate->getTimestamp()),
+            'daysAgo'         => (int) $daysAgo,
             'referrerType'    => $visit->getColumn('referrerType'),
             'referrerUrl'     => $visit->getColumn('referrerUrl') ?: '',
             'referralSummary' => self::getReferrerSummaryForVisit($visit),

--- a/plugins/MultiSites/API.php
+++ b/plugins/MultiSites/API.php
@@ -354,7 +354,11 @@ class API extends \Piwik\Plugin\API
 
         // if the period isn't a range & a lastN/previousN date isn't used, we get the same
         // data for the last period to show the evolution of visits/actions/revenue
-        [$strLastDate, $lastPeriod] = Range::getLastDate($date, $period);
+        // The archive above resolves a relative date in the site timezone whenever the request
+        // is for a single site, so anchor the comparison period the same way, or the two land
+        // on different days for a site whose date differs from UTC's.
+        $timezone = count($idSites) === 1 ? Site::getTimezoneFor($idSites[0]) : false;
+        [$strLastDate, $lastPeriod] = Range::getLastDate($date, $period, $timezone);
 
         if ($strLastDate !== false) {
             if ($lastPeriod !== false) {

--- a/plugins/MultiSites/tests/Integration/MultiSitesTest.php
+++ b/plugins/MultiSites/tests/Integration/MultiSitesTest.php
@@ -10,6 +10,7 @@
 namespace Piwik\Plugins\MultiSites\tests\Integration;
 
 use Piwik\Access;
+use Piwik\Date;
 use Piwik\FrontController;
 use Piwik\Plugins\MultiSites\API as APIMultiSites;
 use Piwik\Plugins\SitesManager\API as APISitesManager;
@@ -35,6 +36,50 @@ class MultiSitesTest extends IntegrationTestCase
 
         \Piwik\Plugin\Manager::getInstance()->loadPlugins(['MultiSites', 'VisitsSummary', 'Actions']);
         \Piwik\Plugin\Manager::getInstance()->installLoadedPlugins();
+
+        Date::$now = null;
+    }
+
+    public function tearDown(): void
+    {
+        Date::$now = null;
+
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider getTimezonesAndTheirPreviousDay
+     */
+    public function testGetOneComparesAgainstThePreviousDayOfTheSiteTimezone($timezone, $expectedLastDate)
+    {
+        // 04:37 on the 25th for a site twelve hours ahead, still the 24th for the server.
+        Date::$now = strtotime('2020-12-24 16:37:00');
+
+        $idSite = APISitesManager::getInstance()->addSite(
+            'timezone site',
+            'http://timezone.example',
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            $timezone
+        );
+
+        $dataTable = APIMultiSites::getInstance()->getOne($idSite, 'day', 'today');
+
+        $this->assertEquals($expectedLastDate, $dataTable->getMetadata('last_period_date')->toString());
+    }
+
+    public function getTimezonesAndTheirPreviousDay()
+    {
+        return [
+            // The archive resolves 'today' on the site's own day, so the period it is compared
+            // against has to come from the same day rather than from the server's.
+            ['UTC+12', '2020-12-24'],
+            ['UTC', '2020-12-23'],
+        ];
     }
 
     /**

--- a/plugins/Referrers/Reports/Get.php
+++ b/plugins/Referrers/Reports/Get.php
@@ -25,6 +25,7 @@ use Piwik\Plugin\ViewDataTable;
 use Piwik\Plugins\CoreVisualizations\Visualizations\Sparklines;
 use Piwik\Plugins\Referrers\Archiver;
 use Piwik\Report\ReportWidgetFactory;
+use Piwik\Site;
 use Piwik\Widget\WidgetsList;
 
 class Get extends Base
@@ -78,7 +79,10 @@ class Get extends Base
             $view->config->addTranslations($this->getSparklineTranslations());
 
             // add evolution values
-            [$lastPeriodDate, $ignore] = Range::getLastDate();
+            // The archive resolves a relative date on the site's own day, so anchor the
+            // comparison period there too, or the two land on different days.
+            $timezone = Site::getTimezoneFor(Common::getRequestVar('idSite', null, 'int'));
+            [$lastPeriodDate, $ignore] = Range::getLastDate(false, false, $timezone);
             if ($lastPeriodDate !== false) {
                 $date = Common::getRequestVar('date');
 

--- a/plugins/Referrers/Reports/Get.php
+++ b/plugins/Referrers/Reports/Get.php
@@ -81,10 +81,10 @@ class Get extends Base
             // add evolution values
             // The archive resolves a relative date on the site's own day, so anchor the
             // comparison period there too, or the two land on different days.
-            $timezone = Site::getTimezoneFor(Common::getRequestVar('idSite', null, 'int'));
+            $timezone = Site::getTimezoneFor(\Piwik\Request::fromRequest()->getIntegerParameter('idSite'));
             [$lastPeriodDate, $ignore] = Range::getLastDate(false, false, $timezone);
             if ($lastPeriodDate !== false) {
-                $date = Common::getRequestVar('date');
+                $date = \Piwik\Request::fromRequest()->getStringParameter('date');
 
                 /** @var DataTable $previousData */
                 $previousData = Request::processRequest('Referrers.get', ['date' => $lastPeriodDate]);

--- a/plugins/SegmentEditor/API.php
+++ b/plugins/SegmentEditor/API.php
@@ -19,6 +19,7 @@ use Piwik\DataTable\Filter\CalculateEvolutionFilter;
 use Piwik\Date;
 use Piwik\Period\Range;
 use Piwik\Piwik;
+use Piwik\Site;
 use Piwik\Config;
 use Piwik\Segment;
 use Piwik\Plugins\VisitsSummary;
@@ -628,7 +629,7 @@ class API extends \Piwik\Plugin\API
         $data = VisitsSummary\API::getInstance()
             ->get($idSite, $period, $date, $segmentDefinition)
             ->getFirstRow()->getArrayCopy();
-        [$previousDate] = Range::getLastDate($date, $period);
+        [$previousDate] = Range::getLastDate($date, $period, Site::getTimezoneFor($idSite));
         $pastNbVisits = VisitsSummary\API::getInstance()
             ->getVisits($idSite, $period, $previousDate, $segmentDefinition)
             ->getFirstRow()->getColumn('nb_visits');

--- a/plugins/VisitsSummary/Reports/Get.php
+++ b/plugins/VisitsSummary/Reports/Get.php
@@ -120,10 +120,10 @@ class Get extends \Piwik\Plugin\Report
             };
 
             // Add evolution values to sparklines
-            $timezone = Site::getTimezoneFor(Common::getRequestVar('idSite', 0, 'int'));
+            $timezone = Site::getTimezoneFor(\Piwik\Request::fromRequest()->getIntegerParameter('idSite', 0));
             list($lastPeriodDate, $ignore) = Range::getLastDate(false, false, $timezone);
             if ($lastPeriodDate !== false) {
-                $currentPeriod = Period\Factory::build(Piwik::getPeriod(), Common::getRequestVar('date'), $timezone);
+                $currentPeriod = Period\Factory::build(Piwik::getPeriod(), \Piwik\Request::fromRequest()->getStringParameter('date'), $timezone);
                 $currentPrettyDate = ($currentPeriod instanceof Month ? $currentPeriod->getLocalizedLongString() : $currentPeriod->getPrettyString());
                 $lastPeriod = Period\Factory::build(Piwik::getPeriod(), $lastPeriodDate, $timezone);
                 $lastPrettyDate = ($currentPeriod instanceof Month ? $lastPeriod->getLocalizedLongString() : $lastPeriod->getPrettyString());

--- a/plugins/VisitsSummary/Reports/Get.php
+++ b/plugins/VisitsSummary/Reports/Get.php
@@ -120,11 +120,12 @@ class Get extends \Piwik\Plugin\Report
             };
 
             // Add evolution values to sparklines
-            list($lastPeriodDate, $ignore) = Range::getLastDate();
+            $timezone = Site::getTimezoneFor(Common::getRequestVar('idSite', 0, 'int'));
+            list($lastPeriodDate, $ignore) = Range::getLastDate(false, false, $timezone);
             if ($lastPeriodDate !== false) {
-                $currentPeriod = Period\Factory::build(Piwik::getPeriod(), Common::getRequestVar('date'));
+                $currentPeriod = Period\Factory::build(Piwik::getPeriod(), Common::getRequestVar('date'), $timezone);
                 $currentPrettyDate = ($currentPeriod instanceof Month ? $currentPeriod->getLocalizedLongString() : $currentPeriod->getPrettyString());
-                $lastPeriod = Period\Factory::build(Piwik::getPeriod(), $lastPeriodDate);
+                $lastPeriod = Period\Factory::build(Piwik::getPeriod(), $lastPeriodDate, $timezone);
                 $lastPrettyDate = ($currentPeriod instanceof Month ? $lastPeriod->getLocalizedLongString() : $lastPeriod->getPrettyString());
 
                 /** @var DataTable $previousData */

--- a/tests/PHPUnit/Integration/Period/FactoryTest.php
+++ b/tests/PHPUnit/Integration/Period/FactoryTest.php
@@ -96,6 +96,42 @@ class FactoryTest extends UnitTestCase
             ['2020-12-23 03:37:00', 'America/Chicago', 'week', 'last-month', 'week', '2020-11-16,2020-11-22'],
             ['2020-12-24 03:37:00', 'America/Chicago', 'day', 'last-year', 'day', '2019-12-23,2019-12-23'],
             ['2020-12-24 03:37:00', 'America/Chicago', 'day', '2020-12-23', 'day', '2020-12-23,2020-12-23'],
+
+            // A relative range is measured back from a "today" of its own, which is the day
+            // the timezone is on, not the one UTC is on.
+            ['2020-12-24 16:37:00', 'UTC+12', 'range', 'previous7', 'range', '2020-12-18,2020-12-24'],
+            ['2020-12-24 16:37:00', 'UTC+12', 'range', 'last7', 'range', '2020-12-19,2020-12-25'],
+            ['2020-12-24 03:37:00', 'America/Chicago', 'range', 'previous7', 'range', '2020-12-16,2020-12-22'],
+            ['2020-12-24 03:37:00', 'America/Chicago', 'range', 'last7', 'range', '2020-12-17,2020-12-23'],
+
+            // A relative range end has to land on that same day.
+            ['2020-12-24 16:37:00', 'UTC+12', 'range', '2020-12-01,today', 'range', '2020-12-01,2020-12-25'],
+            ['2020-12-24 20:00:00', 'America/Chicago', 'range', '2020-12-01,today', 'range', '2020-12-01,2020-12-24'],
+
+            // The patterns that admit these keywords are case-insensitive, so resolving them
+            // has to be too, in a range end and on its own.
+            ['2020-12-24 20:00:00', 'America/Chicago', 'range', '2020-12-01,Today', 'range', '2020-12-01,2020-12-24'],
+            ['2020-12-24 16:37:00', 'UTC+12', 'range', '2020-12-01,YESTERDAY', 'range', '2020-12-01,2020-12-24'],
+            ['2020-12-24 03:37:00', 'America/Chicago', 'day', 'Today', 'day', '2020-12-23,2020-12-23'],
+            ['2020-12-24 03:37:00', 'America/Chicago', 'day', 'Last-Week', 'day', '2020-12-16,2020-12-16'],
+
+            // A relative endpoint is a keyword, not a shape, and a start resolves like an end.
+            // NOW is 2020-12-23 in Chicago and 2020-12-24 in UTC, so UTC lands a day late.
+            ['2020-12-24 03:37:00', 'America/Chicago', 'range', '2020-12-01,last-week', 'range', '2020-12-01,2020-12-16'],
+            ['2020-12-24 03:37:00', 'America/Chicago', 'range', '2020-12-01,last week', 'range', '2020-12-01,2020-12-16'],
+            ['2020-12-24 03:37:00', 'America/Chicago', 'range', 'last-week,today', 'range', '2020-12-16,2020-12-23'],
+            ['2020-12-24 03:37:00', 'America/Chicago', 'range', 'last week,today', 'range', '2020-12-16,2020-12-23'],
+
+            // A padded or url-encoded spelling arrives from the request like any other. One
+            // that is not recognised falls through to a UTC-resolved date, a day off here.
+            ['2020-12-24 03:37:00', 'America/Chicago', 'day', 'today ', 'day', '2020-12-23,2020-12-23'],
+            ['2020-12-24 03:37:00', 'America/Chicago', 'day', ' TODAY', 'day', '2020-12-23,2020-12-23'],
+            ['2020-12-24 03:37:00', 'America/Chicago', 'day', 'yesterday ', 'day', '2020-12-22,2020-12-22'],
+            ['2020-12-24 03:37:00', 'America/Chicago', 'day', 'last%20week', 'day', '2020-12-16,2020-12-16'],
+            ['2020-12-24 03:37:00', 'America/Chicago', 'day', 'LAST%20WEEK', 'day', '2020-12-16,2020-12-16'],
+            ['2020-12-24 03:37:00', 'America/Chicago', 'day', 'today%20', 'day', '2020-12-23,2020-12-23'],
+            ['2020-12-24 16:37:00', 'UTC+12', 'day', ' today ', 'day', '2020-12-25,2020-12-25'],
+            ['2020-12-24 16:37:00', 'UTC+12', 'week', 'last%20month', 'week', '2020-11-23,2020-11-29'],
         ];
     }
 

--- a/tests/PHPUnit/Integration/Period/FactoryTest.php
+++ b/tests/PHPUnit/Integration/Period/FactoryTest.php
@@ -136,6 +136,39 @@ class FactoryTest extends UnitTestCase
     }
 
     /**
+     * @dataProvider getTestDataForBuildWithRelativeDate
+     */
+    public function testBuildResolvesRelativeDatesInTheGivenTimezone($now, $timezone, $period, $date, $expectedRange)
+    {
+        Date::$now = strtotime($now);
+
+        $this->assertEquals($expectedRange, Period\Factory::build($period, $date, $timezone)->getRangeString());
+    }
+
+    public function getTestDataForBuildWithRelativeDate()
+    {
+        return [
+            // NOW is 2020-12-23 in Chicago and 2020-12-25 on UTC+12, so a date left to resolve
+            // in UTC lands a day out in either direction.
+            ['2020-12-24 03:37:00', 'America/Chicago', 'day', 'today', '2020-12-23,2020-12-23'],
+            ['2020-12-24 16:37:00', 'UTC+12', 'day', 'today', '2020-12-25,2020-12-25'],
+            ['2020-12-24 03:37:00', 'America/Chicago', 'day', 'yesterday', '2020-12-22,2020-12-22'],
+            ['2020-12-24 16:37:00', 'UTC+12', 'day', 'yesterday', '2020-12-24,2020-12-24'],
+            ['2020-12-24 03:37:00', 'America/Chicago', 'day', 'last-week', '2020-12-16,2020-12-16'],
+            ['2020-12-24 03:37:00', 'America/Chicago', 'day', 'last week', '2020-12-16,2020-12-16'],
+            ['2020-12-24 03:37:00', 'America/Chicago', 'day', 'last%20week', '2020-12-16,2020-12-16'],
+            ['2020-12-24 16:37:00', 'UTC+12', 'week', 'today', '2020-12-21,2020-12-27'],
+            ['2020-12-24 16:37:00', 'UTC+12', 'month', 'last-month', '2020-11-01,2020-11-30'],
+
+            // An empty timezone means UTC, the way the parameter's other callers read it.
+            ['2020-12-24 16:37:00', false, 'day', 'today', '2020-12-24,2020-12-24'],
+
+            // An absolute date is unaffected by the timezone.
+            ['2020-12-24 03:37:00', 'America/Chicago', 'day', '2020-12-24', '2020-12-24,2020-12-24'],
+        ];
+    }
+
+    /**
      * @dataProvider getBuildTestData
      */
     public function testBuildCreatesCorrectPeriodInstances(

--- a/tests/PHPUnit/Unit/DateTest.php
+++ b/tests/PHPUnit/Unit/DateTest.php
@@ -538,6 +538,54 @@ class DateTest extends \PHPUnit\Framework\TestCase
             ['lastyear', 'UTC+5', '2011-12-31 00:00:00', '2012-12-31 14:00:00'],
             ['last year', 'UTC+5', '2012-01-01 00:00:00', '2012-12-31 19:00:00'],
             ['last-year', 'Antarctica/Mawson', '2012-01-01 00:00:00', '2012-12-31 19:00:00'],
+
+            // The callers recognise these keywords in a query parameter, which can arrive
+            // padded or url-encoded, so every spelling they accept has to resolve here too.
+            ['TODAY', 'UTC+5', '2013-01-01 00:00:00', '2012-12-31 19:00:00'],
+            [' today ', 'UTC+5', '2013-01-01 00:00:00', '2012-12-31 19:00:00'],
+            ['YESTERDAY ', 'UTC+5', '2012-12-31 00:00:00', '2012-12-31 19:00:00'],
+            ['YesterdaySameTime', 'UTC+5', '2012-12-31 01:00:00', '2012-12-31 20:00:00'],
+            ['last%20week', 'UTC+5', '2012-12-25 00:00:00', '2012-12-31 19:00:00'],
+            ['LAST-WEEK', 'UTC+5', '2012-12-25 00:00:00', '2012-12-31 19:00:00'],
+            ['  last%20month', 'UTC+5', '2012-12-01 00:00:00', '2012-12-31 19:00:00'],
+            ['Last%20Year ', 'UTC+5', '2012-01-01 00:00:00', '2012-12-31 19:00:00'],
+        ];
+    }
+
+    /**
+     * @dataProvider getTestDataForGetRelativeKeyword
+     */
+    public function testGetRelativeKeyword($dateString, $expected)
+    {
+        $this->assertSame($expected, Date::getRelativeKeyword($dateString));
+    }
+
+    public function getTestDataForGetRelativeKeyword()
+    {
+        return [
+            ['now', 'now'],
+            ['today', 'today'],
+            ['TODAY', 'today'],
+            [' today ', 'today'],
+            ['yesterday', 'yesterday'],
+            ['yesterdaySameTime', 'yesterdaysametime'],
+            ['lastWeek', 'last-week'],
+            ['last week', 'last-week'],
+            ['last-week', 'last-week'],
+            ['last%20week', 'last-week'],
+            ['LAST%20WEEK', 'last-week'],
+            ['last month', 'last-month'],
+            ['last-year', 'last-year'],
+
+            // Anything else is an absolute date and belongs in factory().
+            ['2012-02-03', null],
+            ['last7', null],
+            ['previous30', null],
+            ['2012-02-03,today', null],
+            ['tomorrow', null],
+            ['', null],
+            [1356998400, null],
+            [null, null],
         ];
     }
 

--- a/tests/PHPUnit/Unit/Period/RangeTest.php
+++ b/tests/PHPUnit/Unit/Period/RangeTest.php
@@ -1433,6 +1433,64 @@ class RangeTest extends BasePeriodTest
         ];
     }
 
+    /**
+     * @dataProvider getRelativeComparisonDateSpellings
+     */
+    public function testGetLastDateResolvesARelativeDateOnTheGivenTimezoneDay($date)
+    {
+        // 04:37 on the 25th for the given timezone, still the 24th for the server.
+        Date::$now = strtotime('2020-12-24 16:37:00');
+
+        [$strLastDate, $lastPeriod] = Range::getLastDate($date, 'day', 'UTC+12');
+
+        $this->assertEquals('2020-12-24', $strLastDate);
+        $this->assertEquals('2020-12-24', $lastPeriod->toString());
+    }
+
+    public function getRelativeComparisonDateSpellings()
+    {
+        return [
+            ['today'],
+            // The date comes from the request, so it arrives in whatever spelling the caller
+            // sent, and each spelling has to compare against the same earlier day.
+            ['TODAY'],
+            [' today '],
+        ];
+    }
+
+    public function testGetLastDateWithoutATimezoneComparesAgainstTheServerDay()
+    {
+        Date::$now = strtotime('2020-12-24 16:37:00');
+
+        [$strLastDate] = Range::getLastDate('today', 'day');
+
+        $this->assertEquals('2020-12-23', $strLastDate);
+    }
+
+    /**
+     * @dataProvider getDatesWithoutAComparisonPeriod
+     */
+    public function testGetLastDateStillRefusesADateItCannotCompare($date)
+    {
+        Date::$now = strtotime('2020-12-24 16:37:00');
+
+        [$strLastDate, $lastPeriod] = Range::getLastDate($date, 'day', 'UTC+12');
+
+        $this->assertFalse($strLastDate);
+        $this->assertFalse($lastPeriod);
+    }
+
+    public function getDatesWithoutAComparisonPeriod()
+    {
+        return [
+            ['last7'],
+            ['previous30'],
+            // Resolving the keyword must not turn this into a date with a comparison period.
+            ['last-week'],
+            ['last week'],
+        ];
+    }
+
     private function setUpSiteAheadOfTheServerDay()
     {
         // 04:37 on the 25th for the site, still the 24th for the server.

--- a/tests/PHPUnit/Unit/Period/RangeTest.php
+++ b/tests/PHPUnit/Unit/Period/RangeTest.php
@@ -15,6 +15,7 @@ use Piwik\Period\Month;
 use Piwik\Period\Range;
 use Piwik\Period\Week;
 use Piwik\Period\Year;
+use Piwik\Site;
 
 /**
  * @group Core
@@ -1382,5 +1383,68 @@ class RangeTest extends BasePeriodTest
 
         $this->assertEquals(1, $range->getNumberOfSubperiods());
         $this->assertEquals($expected->getRangeString(), $range->getRangeString());
+    }
+
+    /**
+     * @dataProvider getRelativeEndDateSpellings
+     */
+    public function testGetRelativeToEndDateResolvesBothSpellingsOnTheSiteDay($endDate)
+    {
+        $this->setUpSiteAheadOfTheServerDay();
+
+        $range = Range::getRelativeToEndDate('day', 'last7', $endDate, new Site(1));
+
+        $this->assertEquals('2020-12-12,2020-12-18', $range);
+    }
+
+    public function getRelativeEndDateSpellings()
+    {
+        return [
+            ['last week'],
+            ['last-week'],
+            // The endpoint arrives in whatever spelling the caller sent, and every spelling
+            // resolves to the same keyword, so all of them end on the same day.
+            ['last%20week'],
+            ['last+week'],
+            [' last week '],
+            ['LAST-WEEK'],
+        ];
+    }
+
+    /**
+     * @dataProvider getRelativeEndDateTodaySpellings
+     */
+    public function testGetRelativeToEndDateResolvesATodaySpellingOnTheSiteDay($endDate)
+    {
+        $this->setUpSiteAheadOfTheServerDay();
+
+        $range = Range::getRelativeToEndDate('day', 'last7', $endDate, new Site(1));
+
+        $this->assertEquals('2020-12-19,2020-12-25', $range);
+    }
+
+    public function getRelativeEndDateTodaySpellings()
+    {
+        return [
+            ['today'],
+            ['today '],
+            ['%74oday'],
+            ['TODAY'],
+        ];
+    }
+
+    private function setUpSiteAheadOfTheServerDay()
+    {
+        // 04:37 on the 25th for the site, still the 24th for the server.
+        Date::$now = strtotime('2020-12-24 16:37:00');
+        Site::setSites([1 => [
+            'idsite' => 1,
+            'name' => 'Site',
+            'timezone' => 'UTC+12',
+            'ecommerce' => 0,
+            'sitesearch' => 0,
+            'exclude_unknown_urls' => 0,
+            'keep_url_fragment' => 0,
+        ]]);
     }
 }


### PR DESCRIPTION
Refs ID-278

Relative dates such as `yesterday`, `previous7` and `2026-09-01,today` resolved partly in UTC rather than in the site's timezone, so a report could be labelled with a day it did not cover, a relative range could be counted over one, and an evolution percentage could be compared against a period one day off from the one it labels. Six separate things caused it, and a site whose local day differs from UTC's is exposed to all six.

- **The date label ignored the site timezone.** `ProcessedReport::getProcessedReport()` built the period behind `prettyDate` with `Period\Factory::build($period, $date)` and no timezone, while the rows that label describes come from the archive, which resolves the date in the site's timezone. On a UTC+12 site, `date=yesterday` counted the site's yesterday and named UTC's for half of every day.
- **A relative range was anchored on UTC's day.** `Period\Factory::makePeriodFromQueryParams()` passed `Date::factory('today', $timezone)` as the range's default end date, and `Date::factory()` shifts the timestamp but hands back a UTC-labelled `Date`, so `previous7` and `last7` measured back from UTC's today. It now uses `Date::factoryInTimezone()`, the way the non-range branch of the same method already did.
- **A relative range endpoint was recognised by shape rather than by keyword.** `Range::generate()` and `Range::getRelativeToEndDate()` treated an endpoint as relative only when it contained no hyphen, so `last-week` read as an absolute date and resolved a day away from what `last week` resolved to. Both now match the same keyword pattern their callers use, and a relative range *start* resolves in the timezone too.
- **`Period\Factory::build()` dropped the timezone for a relative date.** It applied `$timezone` when `$period` is `range` and when `$date` is a multiple-period value such as `last7`, and resolved `today`, `yesterday` and `last-week` through `Date::factory()`, which reads UTC's day. It now routes a relative date through `Date::factoryInTimezone()`, so every caller that has a timezone to pass gets it and not only the ones going through `makePeriodFromQueryParams()`.
- **The period an evolution is compared against was resolved on UTC's day.** `Range::getLastDate()` and `Range::getDateXPeriodsAgo()` resolved their date through `Date::factory()`, so on a site off UTC's day the current period came from the site's day and the period before it from UTC's, and the two were a day apart. Both now take an optional timezone and resolve a relative date in it, and the callers pass the timezone the archive itself used: the Visits Summary, Goals and Referrers sparklines, `Insights` and its mover/shaker reports, `SegmentEditor.getSegmentData`, and `MultiSites`, which passes one only when the request resolves to a single site, because that is when the archive applies a site timezone.
- **The visitor profile counted its days from UTC's day.** `Live\VisitorDetails` read _today_ through `Date::factory('today', $timezone)`, which shifts the timestamp but labels the `Date` in UTC, and then subtracted the visit's own timestamp rather than the start of the visit's day, so the count truncated: a visit at 10:00 two days ago is 1.58 days back and read as one day ago. It resolves today with `Date::factoryInTimezone()` and counts the whole days between the two calendar days.

Recognising a relative date is now a single method, `Date::getRelativeKeyword()`. It url-decodes, trims and lowercases its argument and returns a canonical spelling or `null`, and `Date::factoryInTimezone()`, `Period\Factory::build()`, `Period\Factory::makePeriodFromQueryParams()`, `Range::generate()`, `Range::getDateXPeriodsAgo()` and `Range::getRelativeToEndDate()` all recognise a keyword through it. These values come straight from the request, so `TODAY`, `last%20week` and a padded `today ` now resolve the way a literal `today` does; each previously missed the check at its own call site and fell through to `Date::factory()`, silently in UTC and a day off.

`prettyDate` is now read from the period metadata of the table the report actually returned, and built from the request parameters only when the table carries none. `idSite` does not decide the archive's scope for every module: `MultiSites.getAll` selects over every site the user can view, and the archive applies a site timezone only when the request resolves to a single site, so the label follows the period that was resolved instead of the one that was requested. A `DataTable\Map` spanning several periods is labelled with a range from the earliest start to the latest end.

### Where this shows up

- **The whole reporting UI, for anyone whose default report date is a relative range.** "Report to load by default" in personal settings offers *Last 7 days*, *Last 30 days*, *Previous 7 days* and *Previous 30 days*, and `UsersManager\Controller::getDefaultDates()` maps all four onto `period=range`. Such a user loads every page as `period=range&date=last30`, which is exactly the request the anchoring fix changes.
- **Emailed and downloaded reports.** `ScheduledReports\API::generateReport()` takes `prettyDate` straight from `API.getProcessedReport` and uses it for the "Date range" line on the front page of the HTML and PDF renderers and for the download filename. The scheduled cron run passes an absolute date and is unaffected; the magic keywords `generateReport` documents (`today`, `yesterday`, `lastWeek`, ...) are the affected input.
- **The All Websites report.** `ScheduledReports` requests `MultiSites.getAll` for it, which is the module that selects its own site set rather than the requested one, so it is the practical case for reading the label off the resolved period. Its evolution columns, and those of `getOne` and `getAllWithGroups`, come from the period recorded in `last_period_date`, which is now anchored on the day the archive used.
- **The sparkline evolutions on the Visitors, Goals and Referrers overviews.** Each builds its "vs previous period" figure from `Range::getLastDate()` and labels it with `Period\Factory::build()`, and both sides of that comparison now resolve on the site's day.
- **Insights and the mover/shaker reports, and the visit evolution in the segment editor.** They compare a report against an earlier period resolved through the same two `Range` methods.
- **The visitor profile.** The "N days ago" beside the first and last visit is counted from the site's own day, and a visit that happened earlier in the day two days ago no longer reads as one day ago.
- **Plugin code that resolves a report date against a site timezone.** `Period\Factory::build()` is the public entry point for that, and it honoured the timezone only for a range or a `lastN`/`previousN` date.
- **Evolution graphs, sparklines, and the graphs embedded in emailed reports.** `JqplotGraph\Evolution`, `Sparklines\Config`, `ImageGraph` and `Controller::getGraphParamsModified()` all resolve their window through `Range::getRelativeToEndDate()`, so they are what the keyword-versus-hyphen fix reaches. `last-week`, `last-month` and `last-year` are the spellings that were wrong; `today` and `yesterday` already worked, since they carry no hyphen for the old check to trip over.

### Notes

- The range anchoring fix changes report data and not only labels. `ArchiveQueryFactory::getPeriodInfoFromQueryParam()` resolves the periods it queries the archive for through the same `makePeriodFromQueryParams()`, and `Period::isMultiplePeriod()` returns false whenever the period is `range`, so `period=range&date=previous7` takes the branch that changed. On a site that is not on UTC's day it now covers a different window and reads a different archive. The new integration test asserts the visit count as well as the label for that request, so a window anchored a day early fails on the count.
- `Range::getLastDate()`, `Range::getDateXPeriodsAgo()` and `Insights\Model::getLastDate()` take a new optional trailing `$timezone`. It defaults to `false`, which resolves in UTC and is what a caller that passes nothing already got, so no existing call changes meaning. `Date::getRelativeKeyword()` is new and `@ignore`d, and `Date::factoryInTimezone()` and `Period\Factory::build()` widen what they accept rather than narrowing it: the keywords they now take are the ones their callers already matched before dispatching. `build()` resolves a relative date in UTC when no timezone is passed, which is what it did before.
- `Insights\API::canGenerateInsights()` resolves without a timezone, because it takes no site and only tests whether a comparison period exists at all rather than which day it falls on.
- `getProcessedReport()` keys its result on the period label, so in a multi-site request every site's table collides on one key and all but the last are dropped. That is pre-existing and out of scope here; the new test asserts only that the surviving table holds data, with a note on what to assert once the keying is fixed.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
