### PR TITLE
Base the app-specific token nesting check on call nesting

### DIFF
--- a/core/Request/AuthenticationToken.php
+++ b/core/Request/AuthenticationToken.php
@@ -120,7 +120,9 @@ class AuthenticationToken
 
     private function shouldSkipConflictingAuthValidation(): bool
     {
-        return ApiRequest::isRootRequestApiRequest() && !ApiRequest::isCurrentApiRequestTheRootApiRequest();
+        // Base this on the actual API call nesting rather than request-scoped cache state, which is
+        // not a reliable signal for this decision.
+        return ApiRequest::isCurrentApiRequestNestedInAnotherApiRequest();
     }
 
     /**

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -1540,8 +1540,10 @@ class API extends \Piwik\Plugin\API
         $expireHours = 0,
         bool $secureOnly = false
     ) {
-        // Only allowed as a top-level request, not nested within another API request.
-        if (ApiRequest::isRootRequestApiRequest() && !ApiRequest::isCurrentApiRequestTheRootApiRequest()) {
+        // Only allowed as a top-level request, not nested within another API request. Base this on
+        // the actual API call nesting rather than request-scoped cache state, which is not a
+        // reliable signal for this decision.
+        if (ApiRequest::isCurrentApiRequestNestedInAnotherApiRequest()) {
             throw new Exception(Piwik::translate('UsersManager_ExceptionCreateTokenAuthWithinNestedRequest'));
         }
 

--- a/plugins/UsersManager/tests/Integration/CreateAppSpecificTokenAuthNestedCacheFlushTest.php
+++ b/plugins/UsersManager/tests/Integration/CreateAppSpecificTokenAuthNestedCacheFlushTest.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\UsersManager\tests\Integration;
+
+use Piwik\API\Request as ApiRequest;
+use Piwik\Cache;
+use Piwik\DI;
+use Piwik\Plugins\UsersManager\API as UsersAPI;
+use Piwik\Plugins\UsersManager\Model;
+use Piwik\Tests\Framework\Mock\FakeAccess;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * createAppSpecificTokenAuth may only run as a top-level request. Whether it is nested must be
+ * decided from the actual API call nesting, not from request-scoped cache state that another API
+ * method may clear while the request is still running.
+ *
+ * @group UsersManager
+ */
+class CreateAppSpecificTokenAuthNestedCacheFlushTest extends IntegrationTestCase
+{
+    private const LOGIN = 'sometokenuser';
+
+    /**
+     * Generated per run so the test carries no fixed credential.
+     *
+     * @var string
+     */
+    private $password;
+
+    /**
+     * @var Model
+     */
+    private $model;
+
+    /**
+     * Whether the sibling sub-request clears all caches while it runs.
+     *
+     * @var bool
+     */
+    private $clearCachesInSiblingRequest = false;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        FakeAccess::clearAccess(true);
+
+        // A valid Matomo password, generated so no fixed credential is stored in the test.
+        $this->password = 'Aa1' . bin2hex(random_bytes(8));
+
+        $this->model = new Model();
+        UsersAPI::getInstance()->addUser(self::LOGIN, $this->password, self::LOGIN . '@matomo.org');
+
+        // Act as anonymous within the sub-request so that nothing but the nesting check can refuse
+        // the nested call.
+        FakeAccess::clearAccess(false, [], [], 'anonymous', [1]);
+    }
+
+    public function tearDown(): void
+    {
+        ApiRequest::setIsRootRequestApiRequest(null);
+        parent::tearDown();
+    }
+
+    public function testCreateAppSpecificTokenAuthIsRejectedAsAChildOfAnApiRequestWhenASiblingClearedAllCaches()
+    {
+        $this->clearCachesInSiblingRequest = true;
+
+        $result = $this->createTokenAuthWithinBulkRequest();
+
+        $this->assertNestedRequestWasRefused($result);
+    }
+
+    public function testCreateAppSpecificTokenAuthIsRejectedAsAChildOfAnApiRequestWithoutACacheClear()
+    {
+        $result = $this->createTokenAuthWithinBulkRequest();
+
+        $this->assertNestedRequestWasRefused($result);
+    }
+
+    /**
+     * @param mixed $result The decoded response of the nested sub-request.
+     */
+    private function assertNestedRequestWasRefused($result): void
+    {
+        // The strongest assertion first: whatever the response looks like, no token may exist.
+        $this->assertEmpty(
+            $this->model->getAllNonSystemTokensForLogin(self::LOGIN),
+            'a nested request created an app-specific token'
+        );
+
+        $this->assertIsArray($result, 'the nested request was answered instead of being refused');
+        $this->assertSame('error', $result['result'] ?? null);
+        // Development mode appends a debugging hint to the message, so match on the key only.
+        $this->assertStringContainsString(
+            'UsersManager_ExceptionCreateTokenAuthWithinNestedRequest',
+            (string) ($result['message'] ?? '')
+        );
+    }
+
+    /**
+     * Runs the API method as the second sub-request of a bulk request, ie as a nested API request.
+     *
+     * @return mixed The decoded response of that sub-request.
+     */
+    private function createTokenAuthWithinBulkRequest()
+    {
+        // Make the bulk request's children count as nested API requests.
+        ApiRequest::setIsRootRequestApiRequest('API.getBulkRequest');
+
+        $result = ApiRequest::processRequest('API.getBulkRequest', [
+            'urls' => [
+                // a sibling sub-request that may clear caches while it runs
+                'method=API.getMatomoVersion',
+                'method=UsersManager.createAppSpecificTokenAuth'
+                    . '&userLogin=' . self::LOGIN
+                    . '&passwordConfirmation=' . urlencode($this->password)
+                    . '&description=test',
+            ],
+        ]);
+
+        return $result[1] ?? null;
+    }
+
+    public function provideContainerConfig()
+    {
+        return [
+            'Piwik\Access' => new FakeAccess(),
+            'observers.global' => DI::add([
+                ['API.API.getMatomoVersion.end', DI::value(function () {
+                    if (!$this->clearCachesInSiblingRequest) {
+                        return;
+                    }
+
+                    // Some API methods clear caches while they run; model that here.
+                    Cache::getTransientCache()->flushAll();
+                })],
+            ]),
+        ];
+    }
+}

--- a/plugins/UsersManager/tests/Integration/CreateAppSpecificTokenAuthTest.php
+++ b/plugins/UsersManager/tests/Integration/CreateAppSpecificTokenAuthTest.php
@@ -58,6 +58,11 @@ class CreateAppSpecificTokenAuthTest extends IntegrationTestCase
         ]);
 
         $this->assertSame('error', $result[0]['result'] ?? null);
+        // Development mode appends a debugging hint to the message, so match on the key only.
+        $this->assertStringContainsString(
+            'UsersManager_ExceptionCreateTokenAuthWithinNestedRequest',
+            (string) ($result[0]['message'] ?? '')
+        );
         // No token may have been created for the user.
         $this->assertEmpty($this->model->getAllNonSystemTokensForLogin(self::LOGIN));
     }


### PR DESCRIPTION
### Description

`UsersManager.createAppSpecificTokenAuth` is only meant to run as a top-level API request, not nested inside another API request. That check was based on a request-scoped cache signal, which is not a reliable basis for the decision. Base it on the actual API call nesting instead.

**Changes**

- `plugins/UsersManager/API.php`: use `Request::isCurrentApiRequestNestedInAnotherApiRequest()` for the top-level-only check.
- `core/Request/AuthenticationToken.php`: use the same indicator for the nested-request skip in `shouldSkipConflictingAuthValidation()`, for consistency. The existing nested-request unit test already covers it.

**Tests / validation**

- New integration test asserting the check still holds for a nested request; it fails without the change and passes with it.
- Strengthened an existing nested-request assertion.
- Ran the related integration/unit/system suites, plus PHPCS and PHPStan on the changed files. All pass.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
