### PR TITLE
Encode the row identifier used as a comparison label

### DIFF
--- a/core/API/DataTableManipulator/LabelFilter.php
+++ b/core/API/DataTableManipulator/LabelFilter.php
@@ -197,16 +197,25 @@ class LabelFilter extends DataTableManipulator
                         if (!empty($comparisons)) {
                             $labelSeriesIndex = $this->labelSeries[$labelIndex];
 
-                            $originalLabel = $row->getColumn($this->labelColumn) ?: $row->getMetadata($this->labelColumn);
+                            $comparisonRow = $comparisons->getRowFromId($labelSeriesIndex);
 
-                            $row = $comparisons->getRowFromId($labelSeriesIndex);
+                            // labelSeries is supplied by the request, so it does not have to point at an
+                            // existing comparison row
+                            if ($comparisonRow !== false) {
+                                $originalLabel = $row->getColumn($this->labelColumn) ?: $row->getMetadata($this->labelColumn);
 
-                            // the suffix is appended after labels are sanitized, so encode it to match
-                            $comparisonSuffix = Common::sanitizeInputValue((string) $row->getMetadata('compareSeriesPretty'));
+                                // both parts are appended after labels are sanitized, so encode them to match.
+                                // the label column may be a report specific row identifier, which the label
+                                // sanitization does not cover
+                                $originalLabel = Common::sanitizeInputValue((string) $originalLabel);
+                                $comparisonSuffix = Common::sanitizeInputValue((string) $comparisonRow->getMetadata('compareSeriesPretty'));
 
-                            // add label and make sure it is the first column
-                            $columns = array_merge(['label' => $originalLabel . ' ' . $comparisonSuffix], $row->getColumns());
-                            $row->setColumns($columns);
+                                // add label and make sure it is the first column
+                                $columns = array_merge(['label' => $originalLabel . ' ' . $comparisonSuffix], $comparisonRow->getColumns());
+                                $comparisonRow->setColumns($columns);
+
+                                $row = $comparisonRow;
+                            }
                         }
                     }
 

--- a/tests/PHPUnit/Fixtures/PageViewsWithRawRowIdentifier.php
+++ b/tests/PHPUnit/Fixtures/PageViewsWithRawRowIdentifier.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Fixtures;
+
+use Piwik\DataTable;
+use Piwik\DataTable\Filter\Sort;
+use Piwik\DI;
+use Piwik\Plugins\Actions\API as ActionsApi;
+use Piwik\Request;
+
+/**
+ * Adds one site with several pageviews and gives Actions.getPageUrls a report specific row
+ * identifier, held as row metadata that is never passed through the label sanitization.
+ *
+ * No core report uses a row identifier other than 'label', so this is the only way to reach the
+ * code that builds a comparison label from a row identifier.
+ */
+class PageViewsWithRawRowIdentifier extends OneVisitSeveralPageViews
+{
+    public const ROW_IDENTIFIER_COLUMN = 'rawRowId';
+
+    /**
+     * Row identifier of the first row. Deliberately contains markup, so a test can tell whether
+     * it reaches the browser as markup or as text.
+     */
+    public const FIRST_ROW_IDENTIFIER = 'row zero <b>markup</b>';
+
+    public function provideContainerConfig()
+    {
+        return [
+            'observers.global' => DI::add([
+                ['API.Request.intercept', DI::value(
+                    function (&$returnedValue, $finalParameters, $pluginName, $methodName) {
+                        if ($pluginName !== 'Actions' || $methodName !== 'getPageUrls') {
+                            return;
+                        }
+
+                        $request = Request::fromRequest();
+
+                        // called directly so this observer does not see its own request again
+                        $table = ActionsApi::getInstance()->getPageUrls(
+                            $request->getIntegerParameter('idSite'),
+                            $request->getStringParameter('period'),
+                            $request->getStringParameter('date'),
+                            $request->getStringParameter('segment', '')
+                        );
+
+                        $table->filter(Sort::class, ['nb_hits']);
+                        $table->filter(function (DataTable $table) {
+                            $table->setMetadata(
+                                DataTable::ROW_IDENTIFIER_METADATA_NAME,
+                                self::ROW_IDENTIFIER_COLUMN
+                            );
+
+                            $position = 0;
+                            foreach ($table->getRows() as $row) {
+                                $row->setMetadata(
+                                    self::ROW_IDENTIFIER_COLUMN,
+                                    $position === 0 ? self::FIRST_ROW_IDENTIFIER : 'row ' . $position
+                                );
+                                $position++;
+                            }
+                        });
+
+                        $returnedValue = $table;
+                    }
+                )],
+            ]),
+        ];
+    }
+}

--- a/tests/PHPUnit/Unit/API/DataTableManipulator/LabelFilterTest.php
+++ b/tests/PHPUnit/Unit/API/DataTableManipulator/LabelFilterTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Unit\API\DataTableManipulator;
+
+use Piwik\API\DataTableManipulator\LabelFilter;
+use Piwik\DataTable;
+use Piwik\DataTable\Row;
+
+class LabelFilterTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * LabelFilter builds a comparison label after the queued SafeDecodeLabel filter has already
+     * sanitized the label column, so it has to sanitize what it writes there itself. A report
+     * specific row identifier is a copy of the label taken before that filter ran, so unlike the
+     * label column it is not sanitized when LabelFilter reads it.
+     */
+    public function testFilterSanitizesARowIdentifierBeforeUsingItAsAComparisonLabel()
+    {
+        $table = $this->makeTableWithComparisons('customLabel', 'the raw label <"');
+
+        $filter = new LabelFilter(false, false, ['compare' => 1, 'labelSeries' => '0'], 'customLabel');
+        $result = $filter->filter('the raw label <"', $table);
+
+        $this->assertSame(1, $result->getRowsCount());
+        $this->assertSame(
+            'the raw label &lt;&quot; (Segment X)',
+            $result->getFirstRow()->getColumn('label')
+        );
+    }
+
+    public function testFilterLeavesAnAlreadySanitizedComparisonLabelUnchanged()
+    {
+        $table = $this->makeTableWithComparisons('label', 'Search &amp; Social');
+
+        $filter = new LabelFilter(false, false, ['compare' => 1, 'labelSeries' => '0']);
+        $result = $filter->filter('Search &amp; Social', $table);
+
+        $this->assertSame(1, $result->getRowsCount());
+        $this->assertSame('Search &amp; Social (Segment X)', $result->getFirstRow()->getColumn('label'));
+    }
+
+    public function testFilterKeepsTheMatchedRowWhenLabelSeriesDoesNotSelectAComparisonRow()
+    {
+        $table = $this->makeTableWithComparisons('customLabel', 'the raw label <"');
+
+        $filter = new LabelFilter(false, false, ['compare' => 1, 'labelSeries' => '99'], 'customLabel');
+        $result = $filter->filter('the raw label <"', $table);
+
+        $this->assertSame(1, $result->getRowsCount());
+        $this->assertSame('the sanitized label', $result->getFirstRow()->getColumn('label'));
+    }
+
+    /**
+     * Builds a single row table whose row is identified by $labelColumn and carries one comparison
+     * row. When $labelColumn is not 'label' the value is only available as row metadata, which is
+     * how a report specific row identifier reaches LabelFilter.
+     */
+    private function makeTableWithComparisons(string $labelColumn, string $labelColumnValue): DataTable
+    {
+        // comparison rows only carry numeric metrics, ComparisonRowGenerator skips the label
+        // column, which is why LabelFilter has to add one
+        $comparisonRow = new Row([Row::COLUMNS => ['nb_visits' => 5]]);
+        $comparisonRow->setMetadata('compareSeriesPretty', '(Segment X)');
+
+        $comparisons = new DataTable();
+        $comparisons->addRow($comparisonRow);
+
+        $columns = ['label' => 'the sanitized label', 'nb_visits' => 3];
+        if ($labelColumn === 'label') {
+            $columns['label'] = $labelColumnValue;
+        }
+
+        $row = new Row([Row::COLUMNS => $columns]);
+        if ($labelColumn !== 'label') {
+            $row->setMetadata($labelColumn, $labelColumnValue);
+        }
+        $row->setComparisons($comparisons);
+
+        $table = new DataTable();
+        $table->addRow($row);
+
+        return $table;
+    }
+}

--- a/tests/UI/specs/LabelFilterComparisonLabel_spec.js
+++ b/tests/UI/specs/LabelFilterComparisonLabel_spec.js
@@ -1,0 +1,58 @@
+/*!
+ * Matomo - free/libre analytics platform
+ *
+ * Checks that a report specific row identifier cannot reach the graph tooltip as markup when it is
+ * promoted to the label of a compared row.
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+describe("LabelFilterComparisonLabel", function () {
+    this.fixture = "Piwik\\Tests\\Fixtures\\PageViewsWithRawRowIdentifier";
+
+    // must match PageViewsWithRawRowIdentifier::FIRST_ROW_IDENTIFIER
+    const firstRowIdentifier = 'row zero <b>markup</b>';
+
+    // The label parameter is read with Common::getRequestVar(), which sanitizes it, so every
+    // character it would escape has to arrive percent encoded. On top of that '>' separates the
+    // parts of a recursive label and the label is urldecoded once per level of the recursive
+    // search, so a '>' that belongs to the label itself needs one extra level of encoding.
+    function labelParameter(label) {
+        return encodeURIComponent(encodeURIComponent(label).replace(/%3E/g, '%253E'));
+    }
+
+    // labelSeries selects by label index, so the first label supplies the x axis label while the
+    // second one supplies the series data. Both are needed for the graph to render a data point.
+    const url = "?module=Widgetize&action=iframe&moduleToWidgetize=Actions"
+        + "&actionToWidgetize=getPageUrls&idSite=1&period=day&date=2010-03-06"
+        + "&viewDataTable=graphVerticalBar&filter_limit=-1"
+        + "&compare=1&compareSegments[]=&labelSeries=0"
+        + "&label[]=" + labelParameter(firstRowIdentifier)
+        + "&label[]=" + labelParameter('row 1');
+
+    it("should render a row identifier promoted to a comparison label as text, not as markup", async function () {
+        await page.goto(url);
+        await page.waitForNetworkIdle();
+        await page.waitForSelector('.jqplot-target');
+
+        // jqplot fires jqplotDataHighlight when a bar is hovered, and jqplot.js turns that into the
+        // tooltip. Triggering the event directly skips only jqplot's hit detection on the canvas,
+        // which is not what this test is about, and keeps the test independent of bar geometry.
+        await page.evaluate(function () {
+            $('.jqplot-target').trigger('jqplotDataHighlight', [0, 0]);
+        });
+        await page.waitForSelector('.ui-tooltip-content h3');
+
+        const tooltip = await page.evaluate(function () {
+            const header = document.querySelector('.ui-tooltip-content h3');
+            return {
+                text: header.textContent,
+                elementCount: header.children.length,
+            };
+        });
+
+        expect(tooltip.elementCount).to.equal(0);
+        expect(tooltip.text).to.contain(firstRowIdentifier);
+    });
+});


### PR DESCRIPTION
### Description

A report can declare a row identifier other than the label column, and that value is a copy taken before row labels are encoded. When a request selects a single comparison series — `label` together with `labelSeries` and `compare=1` — that copy became the label of the compared row, so the encoding applied to row labels was lost for that row. It is now encoded the same way the comparison series suffix on the adjacent line already is.

The encoding is idempotent for the ordinary case where the row identifier *is* the label column, so no existing report output changes.

The same code also assumed the requested comparison series exists. An out-of-range `labelSeries` could interrupt the request; the row is now returned without its comparison promotion instead, which matches what a comparison request without `labelSeries` already returns.

**Tests**

`tests/PHPUnit/Unit/API/DataTableManipulator/LabelFilterTest.php` covers the encoding, its idempotence for an already-encoded label, and a `labelSeries` that selects no comparison row.

`tests/UI/specs/LabelFilterComparisonLabel_spec.js` covers the browser end: it renders the report as a bar chart, opens the tooltip and asserts the label is rendered as text. Core ships no report with a row identifier other than the label column, so `tests/PHPUnit/Fixtures/PageViewsWithRawRowIdentifier.php` gives one to `Actions.getPageUrls` through the same container hook `tests/PHPUnit/System/LabelFilterTest.php` already uses for this purpose.

Both new tests fail without the change. `System/LabelFilterTest` (17), `DataComparisonTest` (23 tests / 70 assertions) and `RowEvolutionTest` (17) pass unchanged, as does the unit suite.

No developer changelog entry: nothing here changes a documented HTTP API, plugin, theme or SDK contract.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
