### PR TITLE
Only require the Marketplace plugin info keys that Matomo uses

### DIFF
--- a/plugins/Marketplace/tests/System/Api/ClientTest.php
+++ b/plugins/Marketplace/tests/System/Api/ClientTest.php
@@ -90,7 +90,12 @@ class ClientTest extends SystemTestCase
             'consumer');
 
         $this->assertNotEmpty($plugin);
-        $this->assertEquals($expectedPluginKeys, array_keys($plugin));
+
+        // the Marketplace adds fields without changing the API version, so only require the keys
+        // Matomo actually reads. a removed or renamed one still fails here
+        foreach ($expectedPluginKeys as $expectedPluginKey) {
+            $this->assertArrayHasKey($expectedPluginKey, $plugin);
+        }
         $this->assertSame('SecurityInfo', $plugin['name']);
         $this->assertSame('matomo-org', $plugin['owner']);
         $this->assertTrue(is_array($plugin['keywords']));
@@ -104,10 +109,11 @@ class ClientTest extends SystemTestCase
         $this->assertNotEmpty($plugin['category']);
 
         $lastVersion = $plugin['versions'][count($plugin['versions']) - 1];
-        $this->assertEquals(
-            array('name', 'release', 'requires', 'wordPressCompatible', 'onPremiseCompatible', 'numDownloads', 'license', 'repositoryChangelogUrl', 'readmeHtml', 'download'),
-            array_keys($lastVersion)
-        );
+        $expectedVersionKeys = array('name', 'release', 'requires', 'wordPressCompatible', 'onPremiseCompatible', 'numDownloads', 'license', 'repositoryChangelogUrl', 'readmeHtml', 'download');
+
+        foreach ($expectedVersionKeys as $expectedVersionKey) {
+            $this->assertArrayHasKey($expectedVersionKey, $lastVersion);
+        }
         $this->assertNotEmpty($lastVersion['download']);
     }
 


### PR DESCRIPTION
`ClientTest::testGetPluginInfoExistingPluginOnTheMarketplace` has been failing on `5.x-dev` since 2026-09-09, which blocks the required check on every 5.x PR. Nothing in Matomo caused it.

The test asks the live Marketplace for plugin info and checked that the response had exactly the keys it expected. The Marketplace has since added a `categories` field, so that check fails. Matomo never reads `categories`, so there is nothing to fix on our side and no reason for the test to look for it.

So instead of adding the new key to the list, the test now checks that the keys it expects are there. A missing or renamed field still fails, which is the case that would really break Matomo. A newly added one no longer does. The neighbouring `ServiceTest` already tests the same service this way.

6.x is unaffected: these tests are skipped there since #24800.

Verified against the live Marketplace, 14 tests and 844 assertions passing.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
