### PR TITLE
Validate the period and date used in the API reference examples

### DIFF
--- a/core/API/DocumentationGenerator.php
+++ b/core/API/DocumentationGenerator.php
@@ -12,6 +12,7 @@ namespace Piwik\API;
 use Exception;
 use Piwik\Common;
 use Piwik\Container\StaticContainer;
+use Piwik\Period;
 use Piwik\Piwik;
 use Piwik\Url;
 use ReflectionClass;
@@ -27,6 +28,10 @@ use ReflectionClass;
 class DocumentationGenerator
 {
     protected $countPluginsLoaded = 0;
+
+    private ?string $examplePeriod = null;
+
+    private ?string $exampleDate = null;
 
     /**
      * trigger loading all plugins with an API.php file in the Proxy
@@ -134,10 +139,11 @@ class DocumentationGenerator
         if ($token !== 'anonymous') {
             $token_auth_url .= "&force_api_session=1";
         }
+        // getExampleUrl() expects the values to be URL encoded already
         $parametersToSet = array(
             'idSite' => Common::getRequestVar('idSite', 1, 'int'),
-            'period' => Common::getRequestVar('period', 'day', 'string'),
-            'date' => Common::getRequestVar('date', 'today', 'string'),
+            'period' => urlencode($this->getPeriodForExamples()),
+            'date' => urlencode($this->getDateForExamples()),
         );
         $str = '';
         $str .= "<span class=\"example\">";
@@ -160,6 +166,48 @@ class DocumentationGenerator
         }
         $str .= "</span>";
         return $str;
+    }
+
+    /**
+     * Returns the period the example links should use, falling back to the default when the
+     * requested one isn't a valid period.
+     */
+    private function getPeriodForExamples(): string
+    {
+        if (null === $this->examplePeriod) {
+            $period = Common::getRequestVar('period', 'day', 'string');
+
+            try {
+                Period\Factory::checkPeriodIsEnabled($period);
+            } catch (Exception $e) {
+                $period = 'day';
+            }
+
+            $this->examplePeriod = $period;
+        }
+
+        return $this->examplePeriod;
+    }
+
+    /**
+     * Returns the date the example links should use, falling back to the default when the
+     * requested one isn't a valid date.
+     */
+    private function getDateForExamples(): string
+    {
+        if (null === $this->exampleDate) {
+            $date = Common::getRequestVar('date', 'today', 'string');
+
+            try {
+                Period::checkDateFormat($date);
+            } catch (Exception $e) {
+                $date = 'today';
+            }
+
+            $this->exampleDate = $date;
+        }
+
+        return $this->exampleDate;
     }
 
     /**
@@ -205,7 +253,7 @@ class DocumentationGenerator
      *
      * @param string $class the class
      * @param string $methodName the method
-     * @param array $parametersToSet parameters to set
+     * @param array $parametersToSet parameters to set, values need to be URL encoded already
      * @return string|bool when not possible
      */
     public function getExampleUrl($class, $methodName, $parametersToSet = array())

--- a/tests/PHPUnit/Integration/DocumentationGeneratorTest.php
+++ b/tests/PHPUnit/Integration/DocumentationGeneratorTest.php
@@ -12,14 +12,23 @@ namespace Piwik\Tests\Integration;
 use PHPUnit\Framework\TestCase;
 use Piwik\API\DocumentationGenerator;
 use Piwik\API\Proxy;
+use Piwik\API\Request;
 use Piwik\EventDispatcher;
 use ReflectionClass;
+use ReflectionMethod;
 
 /**
  * @group Core
  */
 class DocumentationGeneratorTest extends TestCase
 {
+    public function tearDown(): void
+    {
+        unset($_GET['period'], $_GET['date']);
+
+        parent::tearDown();
+    }
+
     public function testCheckIfModuleContainsHideAnnotation()
     {
         $reflection = new ReflectionClass(DocumentationGenerator::class);
@@ -69,5 +78,62 @@ class DocumentationGeneratorTest extends TestCase
             }
         );
         $this->assertEquals(Proxy::getInstance()->shouldHideAPIMethod($annotation), false);
+    }
+
+    public function testAddExamplesUsesTheRequestedPeriodAndDate()
+    {
+        $_GET['period'] = 'week';
+        $_GET['date'] = '2020-01-02';
+
+        $examples = $this->addExamples();
+
+        self::assertStringContainsString('&period=week&', $examples);
+        self::assertStringContainsString('&date=2020-01-02&', $examples);
+    }
+
+    public function testAddExamplesEncodesTheRequestedPeriodAndDate()
+    {
+        $_GET['period'] = 'range';
+        $_GET['date'] = '2020-01-02,2020-01-31';
+
+        $examples = $this->addExamples();
+
+        self::assertStringContainsString('&period=range&', $examples);
+        self::assertStringContainsString('&date=2020-01-02%2C2020-01-31&', $examples);
+    }
+
+    /**
+     * @dataProvider getInvalidPeriodsAndDates
+     */
+    public function testAddExamplesFallsBackToDefaultsForInvalidPeriodsAndDates($period, $date)
+    {
+        $_GET['period'] = $period;
+        $_GET['date'] = $date;
+
+        $examples = $this->addExamples();
+
+        self::assertStringNotContainsString('unexpected', $examples);
+        self::assertStringContainsString('&period=day&', $examples);
+        self::assertStringContainsString('&date=today&', $examples);
+    }
+
+    public function getInvalidPeriodsAndDates(): iterable
+    {
+        yield 'unknown period and date' => ['notaperiod', 'notadate'];
+        yield 'period and date containing a separator' => ['day&unexpected=1', 'today&unexpected=1'];
+        yield 'empty period and date' => ['', ''];
+    }
+
+    private function addExamples(): string
+    {
+        $documentationGenerator = new DocumentationGenerator();
+
+        $class = Request::getClassNameAPI('API');
+        Proxy::getInstance()->registerClass($class);
+
+        $addExamples = new ReflectionMethod($documentationGenerator, 'addExamples');
+        $addExamples->setAccessible(true);
+
+        return $addExamples->invoke($documentationGenerator, $class, 'get', '');
     }
 }


### PR DESCRIPTION
### Description

The API reference page (`API.listAllMethods` and `API.listAllAPI`) renders an example link for every documented method, and it takes the `period` and `date` for those links straight from the request. Both values were handed to `Url::getQueryStringFromParameters()` unchanged, even though that helper documents that "values must already be URL encoded before you call this function". Whatever was requested therefore ended up in the generated links verbatim.

Two things change:

- **The values are validated.** `period` is checked against the periods enabled for the API and `date` against the supported date formats (`Period::checkDateFormat()`, so single dates, `lastN`/`previousN` and ranges all still work). Anything that isn't a usable value falls back to the documented default of `day` / `today` instead of being rendered into the examples as-is, which is also what the linked API call would have done with it.
- **The values are encoded.** They are URL encoded before they reach the query string builder, so the builder's contract holds regardless of what a value contains. `getExampleUrl()`'s docblock now states that expectation for its `$parametersToSet` argument.

`getExampleUrl()` itself keeps building the query string from raw values. It is public and the system test framework calls it directly with values it has already encoded, reading the result back with `UrlHelper::getArrayFromQueryString()`, which does not decode — encoding inside `getExampleUrl()` would double encode every system test URL. Encoding in the caller matches the existing contract instead of changing it.

Nothing changes for the defaults: `urlencode('day')` is `day`, so the page renders identically unless a `period` or `date` was requested.

### Verification

- New integration tests over `addExamples()`: a valid period and date are used as requested, a range date is encoded, and unusable values fall back to the defaults.
- Verified the new tests fail against the previous behaviour and pass with the change.
- Full API plugin suite passes (478 tests). PHPStan and PHPCS are clean on both files.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
