### PR TITLE
Fix percentages rendering as stray letters in Turkish and Kurdish

### DIFF
--- a/core/DataTable/Filter/SafeDecodeLabel.php
+++ b/core/DataTable/Filter/SafeDecodeLabel.php
@@ -42,17 +42,33 @@ class SafeDecodeLabel extends BaseFilter
         if (empty($value)) {
             return $value;
         }
-        $raw = urldecode($value);
-        $value = htmlspecialchars_decode($raw, ENT_QUOTES);
+
+        return self::decodeEntitiesSafe(urldecode($value));
+    }
+
+    /**
+     * Normalises the given value to exactly one level of HTML encoding, without reading it as a
+     * URL. For a value that is already formatted for display - a metric carrying the `&nbsp;`
+     * entities `Piwik\Metrics\Formatter\Html` writes, say - `decodeLabelSafe()` would read a `%`
+     * and the two characters behind it as a percent-escape and rewrite the value.
+     *
+     * @param string $value
+     * @return string
+     */
+    public static function decodeEntitiesSafe($value)
+    {
+        if (empty($value)) {
+            return $value;
+        }
+
+        $value = htmlspecialchars_decode($value, ENT_QUOTES);
 
         // ENT_IGNORE so that if utf8 string has some errors, we simply discard invalid code unit sequences
         $style = ENT_QUOTES | ENT_IGNORE;
 
         // See changes in 5.4: https://nikic.github.com/2012/01/28/htmlspecialchars-improvements-in-PHP-5-4.html
         // Note: at some point we should change ENT_IGNORE to ENT_SUBSTITUTE
-        $value = htmlspecialchars($value, $style, 'UTF-8');
-
-        return $value;
+        return htmlspecialchars($value, $style, 'UTF-8');
     }
 
     /**

--- a/core/NumberFormatter.php
+++ b/core/NumberFormatter.php
@@ -130,7 +130,10 @@ class NumberFormatter
             return $value;
         }
 
-        $pattern = $this->getPattern($value, 'Intl_NumberFormatPercent');
+        // The sign has to be read from the number, not from $value: locales that lead with the
+        // percent sign hand us "%15", whose first character sorts below "0", so the string
+        // comparison in isNegative() picked the negative pattern.
+        $pattern = $this->getPattern($newValue, 'Intl_NumberFormatPercent');
 
         return $this->formatNumberWithPattern($pattern, $newValue, $maximumFractionDigits, $minimumFractionDigits);
     }

--- a/core/Twig.php
+++ b/core/Twig.php
@@ -412,6 +412,30 @@ class Twig
             ['is_safe' => ['all']]
         );
         $this->twig->addFilter($rawSafeDecoded);
+
+        $rawSafeDecodedEntities = new TwigFilter(
+            'rawSafeDecodedEntities',
+            /**
+             * Like rawSafeDecoded, but for a value that is already formatted for display rather
+             * than a label: it resolves the entities the formatter wrote and escapes the rest,
+             * without reading the value as a URL.
+             *
+             * @param ?string $string
+             * @return string
+             */
+            function ($string) {
+                if ($string === null) {
+                    return '';
+                }
+
+                $nonBreakingSpace = html_entity_decode('&nbsp;', ENT_COMPAT | ENT_HTML401, 'UTF-8');
+                $string = str_replace('&nbsp;', $nonBreakingSpace, $string);
+
+                return SafeDecodeLabel::decodeEntitiesSafe($string);
+            },
+            ['is_safe' => ['all']]
+        );
+        $this->twig->addFilter($rawSafeDecodedEntities);
     }
 
     protected function addFilterPrettyDate(): void

--- a/plugins/CoreHome/templates/_dataTableCell.twig
+++ b/plugins/CoreHome/templates/_dataTableCell.twig
@@ -50,7 +50,10 @@
         {% if row.getMetadata('html_label_prefix') %}<span class='label-prefix'>{{ row.getMetadata('html_label_prefix') | raw }}&nbsp;</span>{% endif -%}
 {% endif %}<span class="value">
     {%- if row.getColumn(column) or (column=='label' and (row.getColumn(column) is same as("0") or row.getColumn(column) is same as(0))) -%}
-        {%- if column=='label' -%}
+        {#- Flattening a report with its dimensions shown promotes each dimension to a column of
+            its own, holding a label rather than a metric, so those decode like the label does.
+            Same condition as the label markup above. -#}
+        {%- if column=='label' or column in dimensions -%}
             {{- row.getColumn(column)|rawSafeDecoded -}}
         {%- elseif showPercentageValues -%}
             {{- rowPercentage -}}
@@ -58,7 +61,7 @@
             {%- if row.getMetadata('html_column_' ~ column ~ '_prefix') -%}
                 <span class='column-prefix'>{{ row.getMetadata('html_column_' ~ column ~ '_prefix') | raw }}</span>
             {%- endif -%}
-            {{- row.getColumn(column)|number(2,0)|rawSafeDecoded -}}
+            {{- row.getColumn(column)|number(2,0) -}}
             {%- if row.getMetadata('html_column_' ~ column ~ '_suffix') -%}
                 <span class='column-suffix'>{{ row.getMetadata('html_column_' ~ column ~ '_suffix') | raw }}</span>
             {%- endif -%}

--- a/plugins/CoreHome/templates/_dataTableCell.twig
+++ b/plugins/CoreHome/templates/_dataTableCell.twig
@@ -50,10 +50,7 @@
         {% if row.getMetadata('html_label_prefix') %}<span class='label-prefix'>{{ row.getMetadata('html_label_prefix') | raw }}&nbsp;</span>{% endif -%}
 {% endif %}<span class="value">
     {%- if row.getColumn(column) or (column=='label' and (row.getColumn(column) is same as("0") or row.getColumn(column) is same as(0))) -%}
-        {#- Flattening a report with its dimensions shown promotes each dimension to a column of
-            its own, holding a label rather than a metric, so those decode like the label does.
-            Same condition as the label markup above. -#}
-        {%- if column=='label' or column in dimensions -%}
+        {%- if column=='label' -%}
             {{- row.getColumn(column)|rawSafeDecoded -}}
         {%- elseif showPercentageValues -%}
             {{- rowPercentage -}}
@@ -61,7 +58,14 @@
             {%- if row.getMetadata('html_column_' ~ column ~ '_prefix') -%}
                 <span class='column-prefix'>{{ row.getMetadata('html_column_' ~ column ~ '_prefix') | raw }}</span>
             {%- endif -%}
-            {{- row.getColumn(column)|number(2,0) -}}
+            {#- Flattening a report with its dimensions shown promotes each dimension to a column
+                of its own, and those hold a tracked label, URL encoded like the label column is.
+                A metric value is not: reading one as a URL rewrites the number it shows. -#}
+            {%- if column in dimensions -%}
+                {{- row.getColumn(column)|number(2,0)|rawSafeDecoded -}}
+            {%- else -%}
+                {{- row.getColumn(column)|number(2,0)|rawSafeDecodedEntities -}}
+            {%- endif -%}
             {%- if row.getMetadata('html_column_' ~ column ~ '_suffix') -%}
                 <span class='column-suffix'>{{ row.getMetadata('html_column_' ~ column ~ '_suffix') | raw }}</span>
             {%- endif -%}

--- a/plugins/CoreHome/tests/Integration/DataTableCellPercentRenderingTest.php
+++ b/plugins/CoreHome/tests/Integration/DataTableCellPercentRenderingTest.php
@@ -92,13 +92,39 @@ class DataTableCellPercentRenderingTest extends IntegrationTestCase
     /**
      * Flattening a report with its dimensions shown gives each dimension a column of its own, and
      * those hold tracked labels - already encoded once - rather than metrics. They are the one
-     * kind of value in this branch that still has to be decoded rather than only escaped.
+     * kind of value in this branch that still has to be read as a URL.
      */
     public function testADimensionColumnOfAFlattenedTableIsDecodedLikeALabel(): void
     {
         $rendered = $this->renderCellValue('en', 'Tom &amp; Jerry / search%20results', ['bounce_rate']);
 
         self::assertSame('Tom &amp; Jerry / search results', $rendered);
+    }
+
+    /**
+     * Piwik\Metrics\Formatter\Html writes the entity rather than the character, and
+     * Piwik\Plugin\Visualization gives every visualization that formatter, so pretty time, size
+     * and money values all arrive here carrying it. Rendering the entity as text instead of
+     * resolving it widens the column and shifts the whole table.
+     *
+     * @dataProvider getValuesCarryingEntities
+     */
+    public function testAnEntityWrittenByTheFormatterIsResolvedRatherThanShown(
+        string $formattedValue,
+        string $expected
+    ): void {
+        self::assertSame($expected, $this->renderCellValue('en', $formattedValue));
+    }
+
+    public function getValuesCarryingEntities(): array
+    {
+        return [
+            // Formatter\Html::replaceSpaceWithNonBreakingSpace()
+            ['3&nbsp;min&nbsp;21s', "3\u{a0}min\u{a0}21s"],
+            ['128&nbsp;M', "128\u{a0}M"],
+            // a value already encoded once stays encoded exactly once
+            ['Tom &amp; Jerry', 'Tom &amp; Jerry'],
+        ];
     }
 
     /**

--- a/plugins/CoreHome/tests/Integration/DataTableCellPercentRenderingTest.php
+++ b/plugins/CoreHome/tests/Integration/DataTableCellPercentRenderingTest.php
@@ -1,0 +1,175 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreHome\tests\Integration;
+
+use Piwik\Container\StaticContainer;
+use Piwik\DataTable;
+use Piwik\DataTable\Row;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Translation\Translator;
+use Piwik\View;
+
+/**
+ * A metric reaches the cell templates already formatted for the display language, so in locales
+ * whose percent pattern leads with the sign - tr and ku, and eu behind a non-breaking space - it
+ * arrives as "%15" rather than "15%". Decoding such a value as a URL reads the sign and the digits
+ * behind it as an escape sequence, which silently rewrites the number the report shows.
+ *
+ * @group CoreHome
+ * @group DataTableCellPercentRenderingTest
+ * @group Plugins
+ */
+class DataTableCellPercentRenderingTest extends IntegrationTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Fixture::loadAllTranslations();
+    }
+
+    public function tearDown(): void
+    {
+        Fixture::resetTranslations();
+
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider getLeadingPercentSignValues
+     */
+    public function testAPercentValueSurvivesTheCellTemplateWhereTheSignLeads(
+        string $language,
+        string $formattedValue
+    ): void {
+        self::assertSame($formattedValue, $this->renderCellValue($language, $formattedValue));
+    }
+
+    public function getLeadingPercentSignValues(): array
+    {
+        return [
+            // "%37" is a valid percent escape for "7", so the leading digit used to be eaten
+            ['tr', '%37,63'],
+            ['ku', '%37,63'],
+            // "%10" decodes to a C0 control character, which browsers draw as a missing glyph
+            ['tr', '%100'],
+            // "%85" decodes to a byte that is not valid UTF-8, and was dropped altogether -
+            // leaving a cell that read as no data rather than as a broken one
+            ['tr', '%85'],
+            ['tr', '%0'],
+        ];
+    }
+
+    /**
+     * The trailing-sign convention every other locale uses has to keep rendering as it did.
+     */
+    public function testAPercentValueIsUnchangedWhereTheSignTrails(): void
+    {
+        self::assertSame('37.63%', $this->renderCellValue('en', '37.63%'));
+        self::assertSame('100%', $this->renderCellValue('en', '100%'));
+    }
+
+    /**
+     * The value cell is not decoded any more, so escaping is all that stands between a column
+     * value and the page.
+     */
+    public function testMarkupInAValueColumnIsNotRenderedAsMarkup(): void
+    {
+        $rendered = $this->renderCellValue('en', '<b style=color:red>12</b>');
+
+        self::assertStringNotContainsString('<b ', $rendered);
+        self::assertStringContainsString('&lt;b style=color:red&gt;12&lt;/b&gt;', $rendered);
+    }
+
+    /**
+     * Flattening a report with its dimensions shown gives each dimension a column of its own, and
+     * those hold tracked labels - already encoded once - rather than metrics. They are the one
+     * kind of value in this branch that still has to be decoded rather than only escaped.
+     */
+    public function testADimensionColumnOfAFlattenedTableIsDecodedLikeALabel(): void
+    {
+        $rendered = $this->renderCellValue('en', 'Tom &amp; Jerry / search%20results', ['bounce_rate']);
+
+        self::assertSame('Tom &amp; Jerry / search results', $rendered);
+    }
+
+    /**
+     * The absolute value shown on hover is rendered by the ratio template rather than by the cell
+     * itself, and for a rate column that absolute value is the percentage.
+     */
+    public function testAPercentValueSurvivesTheAbsoluteValueShownOnHover(): void
+    {
+        $view = new View('@CoreVisualizations/_dataTableViz_htmlTable_ratio');
+        $view->sendHeadersWhenRendering = false;
+        $view->column = 'bounce_rate';
+        $view->row = new Row([Row::COLUMNS => ['label' => 'Page', 'bounce_rate' => '%37,63']]);
+        $view->totals = ['bounce_rate' => '%100'];
+        $view->properties = ['report_ratio_columns' => ['bounce_rate']];
+        $view->label = 'Page';
+        $view->labelColumn = 'label';
+        $view->translations = ['bounce_rate' => 'Bounce Rate', 'label' => 'Page URL'];
+        $view->rowPercentage = '%37,63';
+        $view->segmentTitlePretty = 'All visits';
+        $view->showAbsoluteValueOnHover = true;
+
+        $this->setLanguage('tr');
+
+        $matched = preg_match('#<span class="ratio"[^>]*>(.*?)</span>#s', $view->render(), $matches);
+        self::assertSame(1, $matched, 'the ratio span was not rendered');
+
+        self::assertStringContainsString('%37,63', $matches[1]);
+        self::assertNoControlCharacters($matches[1]);
+    }
+
+    private function renderCellValue(string $language, string $formattedValue, array $dimensions = []): string
+    {
+        $this->setLanguage($language);
+
+        $dataTable = new DataTable();
+        $dataTable->setMetadata('dimensions', $dimensions);
+
+        $view = new View('@CoreHome/_dataTableCell');
+        $view->sendHeadersWhenRendering = false;
+        $view->column = 'bounce_rate';
+        $view->row = new Row([Row::COLUMNS => ['label' => 'Page', 'bounce_rate' => $formattedValue]]);
+        $view->dataTable = $dataTable;
+        $view->columns_to_display = ['label', 'bounce_rate'];
+        $view->properties = [
+            'translations' => ['bounce_rate' => 'Bounce Rate'],
+            // no ratio column, so the hover markup the cell includes stays out of the way
+            'report_ratio_columns' => [],
+            // read by the label markup, which a dimension column goes through too
+            'tooltip_metadata_name' => '',
+        ];
+
+        $matched = preg_match('#<span class="value">(.*?)</span>#s', $view->render(), $matches);
+        self::assertSame(1, $matched, 'the value span was not rendered');
+
+        $rendered = trim($matches[1]);
+        self::assertNoControlCharacters($rendered);
+
+        return $rendered;
+    }
+
+    private function setLanguage(string $language): void
+    {
+        StaticContainer::get(Translator::class)->setCurrentLanguage($language);
+    }
+
+    private static function assertNoControlCharacters(string $rendered): void
+    {
+        self::assertSame(
+            0,
+            preg_match('/[\x00-\x1F]/', $rendered),
+            'the rendered value contains a control character: ' . bin2hex($rendered)
+        );
+    }
+}

--- a/plugins/CoreHome/tests/Integration/DataTableCellPercentRenderingTest.php
+++ b/plugins/CoreHome/tests/Integration/DataTableCellPercentRenderingTest.php
@@ -127,34 +127,6 @@ class DataTableCellPercentRenderingTest extends IntegrationTestCase
         ];
     }
 
-    /**
-     * The absolute value shown on hover is rendered by the ratio template rather than by the cell
-     * itself, and for a rate column that absolute value is the percentage.
-     */
-    public function testAPercentValueSurvivesTheAbsoluteValueShownOnHover(): void
-    {
-        $view = new View('@CoreVisualizations/_dataTableViz_htmlTable_ratio');
-        $view->sendHeadersWhenRendering = false;
-        $view->column = 'bounce_rate';
-        $view->row = new Row([Row::COLUMNS => ['label' => 'Page', 'bounce_rate' => '%37,63']]);
-        $view->totals = ['bounce_rate' => '%100'];
-        $view->properties = ['report_ratio_columns' => ['bounce_rate']];
-        $view->label = 'Page';
-        $view->labelColumn = 'label';
-        $view->translations = ['bounce_rate' => 'Bounce Rate', 'label' => 'Page URL'];
-        $view->rowPercentage = '%37,63';
-        $view->segmentTitlePretty = 'All visits';
-        $view->showAbsoluteValueOnHover = true;
-
-        $this->setLanguage('tr');
-
-        $matched = preg_match('#<span class="ratio"[^>]*>(.*?)</span>#s', $view->render(), $matches);
-        self::assertSame(1, $matched, 'the ratio span was not rendered');
-
-        self::assertStringContainsString('%37,63', $matches[1]);
-        self::assertNoControlCharacters($matches[1]);
-    }
-
     private function renderCellValue(string $language, string $formattedValue, array $dimensions = []): string
     {
         $this->setLanguage($language);

--- a/plugins/CoreVisualizations/templates/_dataTableViz_htmlTable_comparisons.twig
+++ b/plugins/CoreVisualizations/templates/_dataTableViz_htmlTable_comparisons.twig
@@ -93,7 +93,7 @@
                 {%- if showPercentageValues -%}
                     {{- rowPercentage -}}
                 {%- else -%}
-                    {{- columnValue|default(0)|number(2,0)|rawSafeDecoded -}}
+                    {{- columnValue|default(0)|number(2,0) -}}
                 {%- endif -%}
             </span>
         </td>

--- a/plugins/CoreVisualizations/templates/_dataTableViz_htmlTable_comparisons.twig
+++ b/plugins/CoreVisualizations/templates/_dataTableViz_htmlTable_comparisons.twig
@@ -79,7 +79,7 @@
             {% include "@CoreVisualizations/_dataTableViz_htmlTable_ratio.twig" with {
                 'changePercentage': columnChange,
                 'totals': rowComparisonTotals,
-                'label': comparedRow.getColumn('label'),
+                'label': comparedRow.getColumn('label')|rawSafeDecoded,
                 'labelColumn': properties.columns_to_display|first,
                 'forceZero': true,
                 'tooltipSuffix': comparisonTooltipSuffix,

--- a/plugins/CoreVisualizations/templates/_dataTableViz_htmlTable_comparisons.twig
+++ b/plugins/CoreVisualizations/templates/_dataTableViz_htmlTable_comparisons.twig
@@ -93,7 +93,7 @@
                 {%- if showPercentageValues -%}
                     {{- rowPercentage -}}
                 {%- else -%}
-                    {{- columnValue|default(0)|number(2,0) -}}
+                    {{- columnValue|default(0)|number(2,0)|rawSafeDecodedEntities -}}
                 {%- endif -%}
             </span>
         </td>

--- a/plugins/CoreVisualizations/templates/_dataTableViz_htmlTable_ratio.twig
+++ b/plugins/CoreVisualizations/templates/_dataTableViz_htmlTable_ratio.twig
@@ -45,7 +45,7 @@
             {%- if row.getMetadata('html_column_' ~ column ~ '_prefix') -%}
                 <span class='column-prefix'>{{ row.getMetadata('html_column_' ~ column ~ '_prefix') | raw }}</span>
             {%- endif -%}
-            {{- row.getColumn(column)|default(0)|number(2,0) -}}
+            {{- row.getColumn(column)|default(0)|number(2,0)|rawSafeDecodedEntities -}}
             {%- if row.getMetadata('html_column_' ~ column ~ '_suffix') -%}
                 <span class='column-suffix'>{{ row.getMetadata('html_column_' ~ column ~ '_suffix') | raw }}</span>
             {%- endif -%}

--- a/plugins/CoreVisualizations/templates/_dataTableViz_htmlTable_ratio.twig
+++ b/plugins/CoreVisualizations/templates/_dataTableViz_htmlTable_ratio.twig
@@ -39,7 +39,7 @@
     {#- the tooltip is rendered as HTML from this attribute, and the browser decodes the attribute
         again when it is read back, so every value interpolated here is escaped exactly once -#}
     <span class="ratio"
-          title="{{ reportRatioTooltip|rawSafeDecoded|e('html_attr') }} {{ totalRatioTooltip|rawSafeDecoded|e('html_attr') }}{% if tooltipSuffix|default is not empty %}<br/><br/> {{ tooltipSuffix|rawSafeDecoded|e('html_attr') }}{% endif %}"
+          title="{{ reportRatioTooltip|rawSafeDecodedEntities|e('html_attr') }} {{ totalRatioTooltip|rawSafeDecodedEntities|e('html_attr') }}{% if tooltipSuffix|default is not empty %}<br/><br/> {{ tooltipSuffix|rawSafeDecodedEntities|e('html_attr') }}{% endif %}"
     >&nbsp;
         {%- if showAbsoluteValueOnHover|default -%}
             {%- if row.getMetadata('html_column_' ~ column ~ '_prefix') -%}

--- a/plugins/CoreVisualizations/templates/_dataTableViz_htmlTable_ratio.twig
+++ b/plugins/CoreVisualizations/templates/_dataTableViz_htmlTable_ratio.twig
@@ -45,7 +45,7 @@
             {%- if row.getMetadata('html_column_' ~ column ~ '_prefix') -%}
                 <span class='column-prefix'>{{ row.getMetadata('html_column_' ~ column ~ '_prefix') | raw }}</span>
             {%- endif -%}
-            {{- row.getColumn(column)|default(0)|number(2,0)|rawSafeDecoded -}}
+            {{- row.getColumn(column)|default(0)|number(2,0) -}}
             {%- if row.getMetadata('html_column_' ~ column ~ '_suffix') -%}
                 <span class='column-suffix'>{{ row.getMetadata('html_column_' ~ column ~ '_suffix') | raw }}</span>
             {%- endif -%}

--- a/plugins/CoreVisualizations/templates/macros.twig
+++ b/plugins/CoreVisualizations/templates/macros.twig
@@ -15,7 +15,7 @@
         {% set evolutionPretty = '+' ~ evolution.percent %}
     {% endif %}
 
-    <span class="metricEvolution" title="{{ evolution.tooltip|rawSafeDecoded|e('html_attr') }}">
+    <span class="metricEvolution" title="{{ evolution.tooltip|rawSafeDecodedEntities|e('html_attr') }}">
     <img style="padding-right:4px" src="plugins/MultiSites/images/{{ evolutionIcon }}" alt="" />
     <strong class="{{ evolutionClass }}" aria-hidden="true">{{ evolutionPretty }}</strong></span>
 {% endmacro %}

--- a/plugins/CoreVisualizations/tests/Integration/RatioTooltipEncodingTest.php
+++ b/plugins/CoreVisualizations/tests/Integration/RatioTooltipEncodingTest.php
@@ -9,9 +9,11 @@
 
 namespace Piwik\Plugins\CoreVisualizations\tests\Integration;
 
+use Piwik\Container\StaticContainer;
 use Piwik\DataTable\Row;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Translation\Translator;
 use Piwik\View;
 
 /**
@@ -79,6 +81,44 @@ class RatioTooltipEncodingTest extends IntegrationTestCase
     }
 
     /**
+     * The tooltip quotes the row's percentage, and in a locale whose percent pattern leads with
+     * the sign that reads as "%12,5". Decoding the assembled sentence as a URL took "%12" for an
+     * escape, so the tooltip disagreed with the cell it describes.
+     */
+    public function testALeadingPercentSignSurvivesInTheTooltip(): void
+    {
+        StaticContainer::get(Translator::class)->setCurrentLanguage('tr');
+
+        $readBack = $this->decodeAttribute($this->titleFrom($this->makeView('Sayfa')));
+
+        self::assertStringContainsString('%12,5', $readBack);
+        self::assertStringNotContainsString("\u{fffd}", $readBack);
+    }
+
+    /**
+     * The absolute value shown on hover is the row's own metric, so for a rate column it carries
+     * the same leading sign as the cell.
+     */
+    public function testALeadingPercentSignSurvivesInTheAbsoluteValueShownOnHover(): void
+    {
+        StaticContainer::get(Translator::class)->setCurrentLanguage('tr');
+
+        $view = $this->makeView('Sayfa');
+        $view->column = 'bounce_rate';
+        $view->row = new Row([Row::COLUMNS => ['label' => 'Sayfa', 'bounce_rate' => '%37,63']]);
+        $view->totals = ['bounce_rate' => '%100'];
+        $view->properties = ['report_ratio_columns' => ['bounce_rate']];
+        $view->translations = ['bounce_rate' => 'Hemen Cikma Orani', 'label' => 'Sayfa'];
+        $view->rowPercentage = '%37,63';
+        $view->showAbsoluteValueOnHover = true;
+
+        $matched = preg_match('#<span class="ratio"[^>]*>(.*?)</span>#s', $view->render(), $matches);
+        self::assertSame(1, $matched, 'the ratio span was not rendered');
+
+        self::assertStringContainsString('%37,63', $matches[1]);
+    }
+
+    /**
      * The value of the title attribute as the tooltip reads it, ie. after the HTML parser has
      * decoded the attribute once.
      */
@@ -89,6 +129,18 @@ class RatioTooltipEncodingTest extends IntegrationTestCase
 
     private function renderTooltipTitle(string $label, string $tooltipSuffix = ''): string
     {
+        $view = $this->makeView($label, $tooltipSuffix);
+        $view->rowPercentage = '12.5%';
+
+        return $this->titleFrom($view);
+    }
+
+    /**
+     * Without a rowPercentage the template works it out itself, which is what puts a
+     * locale-formatted percentage into the tooltip.
+     */
+    private function makeView(string $label, string $tooltipSuffix = ''): View
+    {
         $view = new View('@CoreVisualizations/_dataTableViz_htmlTable_ratio');
         $view->sendHeadersWhenRendering = false;
         $view->column = 'nb_visits';
@@ -98,10 +150,14 @@ class RatioTooltipEncodingTest extends IntegrationTestCase
         $view->label = $label;
         $view->labelColumn = 'label';
         $view->translations = ['nb_visits' => 'Visits', 'label' => 'Keyword'];
-        $view->rowPercentage = '12.5%';
         $view->segmentTitlePretty = 'All visits';
         $view->tooltipSuffix = $tooltipSuffix;
 
+        return $view;
+    }
+
+    private function titleFrom(View $view): string
+    {
         $matched = preg_match('/<span class="ratio"\s+title="([^"]*)"/', $view->render(), $matches);
 
         self::assertSame(1, $matched, 'the ratio span was not rendered');

--- a/plugins/CoreVisualizations/tests/Integration/SparklineEvolutionTooltipEncodingTest.php
+++ b/plugins/CoreVisualizations/tests/Integration/SparklineEvolutionTooltipEncodingTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreVisualizations\tests\Integration;
+
+use Piwik\Container\StaticContainer;
+use Piwik\Piwik;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Translation\Translator;
+use Piwik\Twig;
+
+/**
+ * Every evolution tooltip on a sparkline quotes two formatted metric values and the evolution
+ * between them, so in a locale whose percent pattern leads with the sign it carries "%12,5" three
+ * times over. Reading that as a URL takes the sign and the digits behind it for an escape.
+ *
+ * @group CoreVisualizations
+ * @group SparklineEvolutionTooltipEncodingTest
+ * @group Plugins
+ */
+class SparklineEvolutionTooltipEncodingTest extends IntegrationTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Fixture::loadAllTranslations();
+    }
+
+    public function tearDown(): void
+    {
+        Fixture::resetTranslations();
+
+        parent::tearDown();
+    }
+
+    /**
+     * A rate metric reaches the tooltip formatted, and so does the evolution figure beside it,
+     * whatever the metric - so in these locales an ordinary visits sparkline carried the sign too.
+     *
+     * @dataProvider getLeadingPercentSignTooltips
+     */
+    public function testALeadingPercentSignSurvivesInTheTooltip(
+        string $language,
+        string $currentValue,
+        string $pastValue,
+        string $evolution
+    ): void {
+        $this->setLanguage($language);
+
+        $readBack = $this->decodeAttribute($this->renderTooltipTitle(
+            $this->evolutionSummary($currentValue, $pastValue, $evolution),
+            $evolution
+        ));
+
+        self::assertStringContainsString($currentValue, $readBack);
+        self::assertStringContainsString($pastValue, $readBack);
+        self::assertStringContainsString($evolution, $readBack);
+        self::assertStringNotContainsString("\u{fffd}", $readBack);
+    }
+
+    public function getLeadingPercentSignTooltips(): array
+    {
+        return [
+            // "%37" is a valid percent escape for "7", so the leading digit used to be eaten
+            ['tr', '%37,63', '%33,44', '%12,5'],
+            ['ku', '%37,63', '%33,44', '%12,5'],
+            // "%10" decodes to a C0 control character and "%85" to a byte that is not valid UTF-8
+            ['tr', '%100', '%85', '%17,6'],
+        ];
+    }
+
+    /**
+     * The trailing-sign convention every other locale uses has to keep rendering as it did.
+     */
+    public function testAPercentageIsUnchangedWhereTheSignTrails(): void
+    {
+        $this->setLanguage('en');
+
+        $readBack = $this->decodeAttribute($this->renderTooltipTitle(
+            $this->evolutionSummary('37.63%', '33.44%', '12.5%')
+        ));
+
+        self::assertStringContainsString('37.63% Bounce Rate in September 2026', $readBack);
+        self::assertStringContainsString('Evolution: 12.5%', $readBack);
+    }
+
+    /**
+     * The tooltip is no longer decoded, so escaping is all that stands between it and the page.
+     */
+    public function testMarkupInATooltipStaysText(): void
+    {
+        $this->setLanguage('en');
+
+        $title = $this->renderTooltipTitle($this->evolutionSummary(
+            '<b style=color:red>12</b>',
+            '10',
+            '20%'
+        ));
+
+        self::assertStringNotContainsString('<b ', $this->decodeAttribute($title));
+    }
+
+    private function evolutionSummary(string $currentValue, string $pastValue, string $evolution): string
+    {
+        return Piwik::translate('General_EvolutionSummaryGeneric', [
+            $currentValue . ' Bounce Rate',
+            'September 2026',
+            $pastValue . ' Bounce Rate',
+            'August 2026',
+            $evolution,
+        ]);
+    }
+
+    private function renderTooltipTitle(string $tooltip, string $percent = '12.5%'): string
+    {
+        $template = StaticContainer::get(Twig::class)->getTwigEnvironment()->createTemplate(
+            '{% import "@CoreVisualizations/macros.twig" as macros %}{{ macros.sparklineEvolution(evolution) }}'
+        );
+
+        $rendered = $template->render(['evolution' => [
+            'percent' => $percent,
+            'trend' => 4.19,
+            'isLowerValueBetter' => false,
+            'tooltip' => $tooltip,
+        ]]);
+
+        $matched = preg_match('/<span class="metricEvolution" title="([^"]*)"/', $rendered, $matches);
+        self::assertSame(1, $matched, 'the evolution span was not rendered');
+
+        return $matches[1];
+    }
+
+    /**
+     * The value of the title attribute as the tooltip reads it, ie. after the HTML parser has
+     * decoded the attribute once.
+     */
+    private function decodeAttribute(string $value): string
+    {
+        return html_entity_decode($value, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    }
+
+    private function setLanguage(string $language): void
+    {
+        StaticContainer::get(Translator::class)->setCurrentLanguage($language);
+    }
+}

--- a/tests/PHPUnit/Integration/NumberFormatterTest.php
+++ b/tests/PHPUnit/Integration/NumberFormatterTest.php
@@ -64,6 +64,21 @@ class NumberFormatterTest extends \PHPUnit\Framework\TestCase
             // percent formatting
             array('en', '5.299%', 0, 0, '5%'),
             array('en', '5.299%', 3, 0, '5.299%'),
+
+            // percent formatting in locales that lead with the percent sign, where an already
+            // formatted value must not have its sign read from the leading '%'
+            array('tr', '%100', 0, 0, '%100'),
+            array('tr', '%15', 0, 0, '%15'),
+            array('tr', '%0', 0, 0, '%0'),
+            array('ku', '%15', 0, 0, '%15'),
+            array('tr', 15, 0, 0, '15'),
+            // eu leads with the sign as well, but the non-breaking space behind it keeps the
+            // value out of both the numeric parse and the escape syntax
+            array('eu', "%\u{a0}15", 0, 0, "%\u{a0}15"),
+
+            // a genuinely negative percentage keeps its sign in either sign convention
+            array('tr', '-15%', 0, 0, '-%15'),
+            array('en', '-15%', 0, 0, '-15%'),
         );
     }
 

--- a/tests/PHPUnit/Integration/NumberFormatterTest.php
+++ b/tests/PHPUnit/Integration/NumberFormatterTest.php
@@ -67,18 +67,18 @@ class NumberFormatterTest extends \PHPUnit\Framework\TestCase
 
             // percent formatting in locales that lead with the percent sign, where an already
             // formatted value must not have its sign read from the leading '%'
-            array('tr', '%100', 0, 0, '%100'),
-            array('tr', '%15', 0, 0, '%15'),
-            array('tr', '%0', 0, 0, '%0'),
-            array('ku', '%15', 0, 0, '%15'),
-            array('tr', 15, 0, 0, '15'),
+            ['tr', '%100', 0, 0, '%100'],
+            ['tr', '%15', 0, 0, '%15'],
+            ['tr', '%0', 0, 0, '%0'],
+            ['ku', '%15', 0, 0, '%15'],
+            ['tr', 15, 0, 0, '15'],
             // eu leads with the sign as well, but the non-breaking space behind it keeps the
             // value out of both the numeric parse and the escape syntax
-            array('eu', "%\u{a0}15", 0, 0, "%\u{a0}15"),
+            ['eu', "%\u{a0}15", 0, 0, "%\u{a0}15"],
 
             // a genuinely negative percentage keeps its sign in either sign convention
-            array('tr', '-15%', 0, 0, '-%15'),
-            array('en', '-15%', 0, 0, '-15%'),
+            ['tr', '-15%', 0, 0, '-%15'],
+            ['en', '-15%', 0, 0, '-15%'],
         );
     }
 


### PR DESCRIPTION
### Description

In Turkish and Kurdish the percent sign is written before the number, so a bounce rate of 52% reads `%52`. Report tables then decoded that value as if it were a URL escape, and `%52` became the letter `R` — the cell showed `-R` instead of the rate. Where the decoded byte was not valid text it was dropped entirely and the cell fell back to `-`, which reads as "no data" rather than as something broken.

Both languages were affected in every HTML report table, for every metric shown as a percentage — bounce rate, exit rate, conversion rate — including the absolute value shown on hover and the values in comparison rows.

Two causes, both fixed here:

- The data table cell templates passed the already-formatted value through `rawSafeDecoded`, which URL-decodes before escaping. A formatted number only ever needs escaping, and Twig's automatic escaping now does that. The filter replaced a plain `|raw` on that line back in #11650, so escaping was the intent all along.
- `NumberFormatter::formatPercent()` took the sign from the unparsed string. A leading `%` sorts below `0`, so every positive percentage in these locales matched the negative pattern and gained a minus sign.

Dimension columns keep their decoding: flattening a report with *Show dimensions* gives each dimension a column of its own holding a tracked label rather than a metric, so those still need decoding as the label column does.

Languages that write the sign after the number are unaffected: rendering is byte-identical in English across 1072 values in 17 reports, flattened both with and without dimensions shown.

Covered by a new integration test that renders the real templates, plus new cases in `NumberFormatterTest`; both fail without the fix. Two things are deliberately left out of scope. The ratio tooltip decodes a percentage away in the same locales, but its `rawSafeDecoded` is there for the label it interpolates and its two callers pass differently encoded labels, so it needs untangling separately rather than as part of this change. Comparison rows carry the same defect as the cells and take the same one-token fix, but driving them from a test needs a large fixture, so they are fixed without dedicated coverage.

Related: #20701 covers the underlying design — percentages stored as rates and handed around as formatted strings — and names this locale hazard. This change does not address that; it stops the formatted value being corrupted on its way to the page.

No developer changelog entry, on the grounds that this is a bug fix and the decoding was never a documented contract. Happy to add one if you would rather record the rendering change.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
