### PR TITLE
Centralise API request detection (backport of #25273)

### DIFF
--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -85,6 +85,8 @@ use Piwik\Log\LoggerInterface;
  */
 class Request
 {
+    private const ROOT_API_METHOD_CACHE_KEY = 'API.setIsRootRequestApiRequest';
+
     /**
      * The count of nested API request invocations. Used to determine if the currently executing request is the root or not.
      *
@@ -354,21 +356,21 @@ class Request
     /**
      * @ignore
      * @internal
-     * @param string $currentApiMethod
+     * @param string|null $currentApiMethod
      */
     public static function setIsRootRequestApiRequest($currentApiMethod)
     {
-        Cache::getTransientCache()->save('API.setIsRootRequestApiRequest', $currentApiMethod);
+        Cache::getTransientCache()->save(self::ROOT_API_METHOD_CACHE_KEY, $currentApiMethod);
     }
 
     /**
      * @ignore
      * @internal
-     * @return string current Api Method if it is an api request
+     * @return string|false|null current Api Method if it is an api request
      */
     public static function getRootApiRequestMethod()
     {
-        return Cache::getTransientCache()->fetch('API.setIsRootRequestApiRequest');
+        return Cache::getTransientCache()->fetch(self::ROOT_API_METHOD_CACHE_KEY);
     }
 
     /**
@@ -376,12 +378,10 @@ class Request
      * request within any request, have a look at {@link isApiRequest()}.
      *
      * @return bool
-     * @throws Exception
      */
     public static function isRootRequestApiRequest()
     {
-        $apiMethod = Cache::getTransientCache()->fetch('API.setIsRootRequestApiRequest');
-        return !empty($apiMethod);
+        return !empty(self::getRootApiRequestMethod());
     }
 
     /**
@@ -409,6 +409,24 @@ class Request
     public static function isCurrentApiRequestNestedInAnotherApiRequest(): bool
     {
         return self::$nestedApiInvocationCount > 1;
+    }
+
+    /**
+     * Whether the request being served is the API endpoint itself. The module dispatches the
+     * requested method through its index action; its other actions accept a method parameter
+     * without dispatching it.
+     *
+     * Reads the live request, so it is only meaningful before a nested API call overlays
+     * `module=API` onto the request parameters.
+     *
+     * @ignore
+     * @internal
+     */
+    public static function isApiHttpRequest(): bool
+    {
+        $action = Piwik::getAction();
+
+        return Piwik::getModule() === 'API' && (empty($action) || $action === 'index');
     }
 
     /**

--- a/core/API/ResponseBuilder.php
+++ b/core/API/ResponseBuilder.php
@@ -19,7 +19,6 @@ use Piwik\DataTable\Renderer;
 use Piwik\ExceptionHandler;
 use Piwik\Http\HttpCodeException;
 use Piwik\Http\SecurityHeaders;
-use Piwik\Piwik;
 use Piwik\Plugin\ReportsProvider;
 use Piwik\Plugins\Monolog\Processor\ExceptionToTextProcessor;
 use Piwik\Plugins\PrivacyManager\DataRounding;
@@ -37,6 +36,11 @@ class ResponseBuilder
     private $shouldPrintBacktrace = false;
 
     /**
+     * Captured up front: a nested API call overlays `module=API` while it runs, which would
+     * otherwise make a page's own response look like API output. The module is checked rather
+     * than the root API method, as that is unset when the method name does not parse and the
+     * error response for those is a data response too.
+     *
      * @var bool
      */
     private $isApiHttpRequest;
@@ -52,7 +56,7 @@ class ResponseBuilder
         $this->request      = $request;
         $this->apiRenderer  = ApiRenderer::factory($outputFormat, $request);
         $this->shouldPrintBacktrace = $shouldPrintBacktrace === null ? ExceptionHandler::shouldPrintBackTraceWithMessage() : $shouldPrintBacktrace;
-        $this->isApiHttpRequest = self::isApiHttpRequest();
+        $this->isApiHttpRequest = Request::isApiHttpRequest();
     }
 
     public function disableSendHeader()
@@ -288,23 +292,5 @@ class ResponseBuilder
         }
 
         $this->apiRenderer->sendHeader();
-    }
-
-    /**
-     * Whether the request being served is the API endpoint itself, so that its response can be
-     * sent as a data response. An API call made while rendering a page must not turn that page into
-     * one, as a page does need to run scripts, and the module also serves HTML pages (eg. listAllAPI)
-     * which send their headers through the view.
-     *
-     * Only meaningful before the response is built, as {@see Request::processRequest()} overlays
-     * `module=API` onto the request parameters while it runs. The module is checked rather than
-     * {@see Request::isRootRequestApiRequest()}, as that only knows requests whose method name
-     * parses, leaving the errors for the ones that do not.
-     */
-    private static function isApiHttpRequest(): bool
-    {
-        $action = Piwik::getAction();
-
-        return Piwik::getModule() === 'API' && (empty($action) || $action === 'index');
     }
 }

--- a/core/Access.php
+++ b/core/Access.php
@@ -162,7 +162,7 @@ class Access
 
         $result = null;
 
-        $isApiRequest = Piwik::getModule() === 'API' && (Piwik::getAction() === 'index' || !Piwik::getAction());
+        $isApiRequest = Request::isApiHttpRequest();
         $apiMethod = Request::getMethodIfApiRequest(null);
         $isGetApiRequest = !empty($apiMethod) && 1 === substr_count($apiMethod, '.') && strpos($apiMethod, '.get') > 0;
 

--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -1011,7 +1011,9 @@ class Plugin extends \Piwik\Plugin
 
     public function detectIsApiRequest(): void
     {
-        Request::setIsRootRequestApiRequest(Request::getMethodIfApiRequest($request = null));
+        Request::setIsRootRequestApiRequest(
+            Request::isApiHttpRequest() ? Request::getMethodIfApiRequest($request = null) : null
+        );
     }
 
     /**

--- a/plugins/API/tests/Integration/APITest.php
+++ b/plugins/API/tests/Integration/APITest.php
@@ -585,6 +585,39 @@ class APITest extends IntegrationTestCase
         }
     }
 
+    /**
+     * @dataProvider getDetectIsApiRequestCases
+     */
+    public function testDetectIsApiRequest(array $requestParams, ?string $expectedMethod)
+    {
+        $rootApiMethod = Request::getRootApiRequestMethod();
+        $get = $_GET;
+        $post = $_POST;
+
+        try {
+            $_GET = $requestParams;
+            $_POST = [];
+            (new \Piwik\Plugins\API\Plugin())->detectIsApiRequest();
+
+            $this->assertSame($expectedMethod, Request::getRootApiRequestMethod());
+            $this->assertSame(null !== $expectedMethod, Request::isRootRequestApiRequest());
+        } finally {
+            $_GET = $get;
+            $_POST = $post;
+            Request::setIsRootRequestApiRequest($rootApiMethod ?: '');
+        }
+    }
+
+    public function getDetectIsApiRequestCases(): iterable
+    {
+        yield 'no action' => [['module' => 'API', 'method' => 'API.get'], 'API.get'];
+        yield 'index action' => [['module' => 'API', 'action' => 'index', 'method' => 'API.get'], 'API.get'];
+        yield 'glossary action' => [['module' => 'API', 'action' => 'glossary', 'method' => 'API.get'], null];
+        yield 'get action' => [['module' => 'API', 'action' => 'get', 'method' => 'API.get'], null];
+        yield 'no method' => [['module' => 'API', 'action' => 'index'], null];
+        yield 'other module' => [['module' => 'CoreHome', 'action' => 'index', 'method' => 'API.get'], null];
+    }
+
     private function assertResponseIsPermissionError($response)
     {
         $this->assertSame('error', $response['result']);


### PR DESCRIPTION
### Description

The check for "is the request being served the API endpoint itself" was spelled out in three places and the copies had drifted. `ResponseBuilder` and `Access` require the module together with the action that dispatches a method; the root API method flag was set from the module and the method name alone. All three now call one helper, `Request::isApiHttpRequest()`.

The endpoint itself classifies exactly as before, as does every request to another module.

Also here: the transient cache key the flag is stored under becomes a constant, and `getRootApiRequestMethod()` documents the `false` the cache returns before the flag is populated.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)



Backport of #25273.
