### PR TITLE
Id 247 implement web search in ai providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
     commands and scheduled tasks, because 120s exceeds PHP's default `max_execution_time`.
   * Grounding is not a marginal cost: every provider charges per search and bills the retrieved page
     content as input tokens on top.
+* `AIProviderResponse::getStopReason()` now reports a value for Google completions, which previously
+  always returned `null`. Google's `finishReason` is mapped onto the same vocabulary the conversation
+  API already uses (`STOP` becomes `end_turn`, `MAX_TOKENS` becomes `max_tokens`, `SAFETY` and
+  `RECITATION` become `guardrail_intervened`), so it matches AWS Bedrock and Anthropic. OpenAI keeps
+  reporting `stop` / `length` on both its grounded and ungrounded paths. A caller that treats an
+  unrecognised stop reason as a failure will start seeing Google values.
 * The new `Piwik\Http\SecurityHeaders::sendForDataResponse()` sends the header set for a response that is data rather than application UI: `X-Content-Type-Options: nosniff`, `Referrer-Policy: no-referrer`, `X-Frame-Options: deny` unless `[General] enable_framed_pages` allows embedding, and a `Content-Security-Policy` that allows no scripts, forms or base URI, only inline styles and images from Matomo itself (built by the new `Piwik\View\SecurityPolicy::restrictToDataResponse()`). Core sends it for the API endpoint itself, report exports, inline report previews, and the API module's `listAllMethods` and `listSegments` actions, which return HTML without a view; `action=listAllAPI`, which renders one, keeps the headers of a regular page. Call it in a plugin that streams an export or a report, before writing any output.
 * Two new events let plugins customise the "No data has been recorded yet" page, on both the standalone page and its embedding in the reporting UI:
   * `Template.siteWithoutData.afterTrackingMethods` collects additional HTML rendered below the tracking methods list and the section for temporarily hiding the page.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 ## Matomo 5.14.0
 
 ### Breaking Changes
-* The non-functional placeholder `Piwik\Plugins\AIProviders\Provider\AIProvider::isWebSearchUsed()`
-  has been removed now that provider web search is implemented. It always returned `false` and no
-  bundled provider overrode it, so a subclass overriding it had no effect on the response. Providers
-  now declare the capability with `supportsWebSearch()` instead.
+* The placeholder `Piwik\Plugins\AIProviders\Provider\AIProvider::isWebSearchUsed()` has been removed
+  now that provider web search is implemented. Its base implementation always returned `false` and no
+  bundled provider overrode it, but the value it returned was passed into the response, so a
+  third-party provider that overrode it did control `AIProviderResponse::isWebSearchEnabled()`. Such a
+  provider must now override `supportsWebSearch()` to declare the capability and pass a
+  `Piwik\Plugins\AIProviders\WebSearchUsage` to `buildResponse()`, which reports the searches, queries
+  and citations the completion actually produced. Overriding the removed method has no effect and
+  raises no error, so check for it when upgrading a provider plugin.
 * The interface `Piwik\Settings\Interfaces\PolicyComparisonInterface` gained four methods used by the granular compliance dashboard: `getPolicySettingId()`, `isExternallyManagedByPolicyPage()`, `getWhatItDoes()` and `getImpact()`. Plugins that implement the interface directly must implement them. Plugins using `Piwik\Settings\Interfaces\Traits\PolicyComparisonTrait` (as all known implementers do) inherit default implementations and are not affected.
 * Exporting a report for a single goal (a goals table or a bar/pie/evolution chart showing one goal's
   conversions or revenue) now returns only the columns shown in the UI, by adding `showColumns` to the
@@ -76,26 +80,6 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 * `UsersManager.setUserAccess` now requires `passwordConfirmation` to grant the `admin` role, in either the string or the array form of `access`, on top of the existing check for granting the anonymous user `view` access. As before this applies only to session-authenticated requests, which includes any request sending `force_api_session=1`; plain `token_auth`, `Authorization: Bearer` and CLI calls are unaffected.
 
 ### New APIs
-* `Piwik\Plugins\AIProviders` now implements provider-side web search, also called grounding, so an AI
-  feature can ask the provider to search the web before answering and then read the sources it used.
-  `Piwik\Plugins\AIProviders\AIRequest::withWebSearchEnabled()` is no longer advisory: Anthropic,
-  Google and OpenAI honour it, and AWS Bedrock and the custom provider reject a grounded request with
-  an `AIProviderClientException` rather than silently answering ungrounded.
-  * `AIProviderService::canUseWebSearch($callerPluginName, $requestedProviderId = null)` reports
-    whether a grounded completion can run, answered for the provider `complete()` would actually
-    resolve to, so a feature can degrade before spending anything. The provider entries returned by
-    `getProviderStatusesForCaller()` gained a matching `supportsWebSearch` key.
-  * `AIProviderResponse::wasWebSearchUsed()` reports whether a search actually ran, which is not the
-    same as whether one was requested: given the tool, a model can decide the prompt needs none.
-    `getWebSearchCitations()` returns the deduplicated `url`, `title` and `domain` of each source,
-    `getWebSearchRequestCount()` the number of searches billed, and `getWebSearchQueries()` the
-    queries the model issued where the provider echoes them. The new `Piwik\Plugins\AIProviders\WebSearchUsage`
-    normalises the three providers' incompatible grounding shapes into that one shape.
-  * `AIRequest::withTimeoutSeconds()` overrides the provider HTTP timeout, which now defaults to 120s
-    for a grounded completion and stays at 30s otherwise. Grounded completions are intended for CLI
-    commands and scheduled tasks, because 120s exceeds PHP's default `max_execution_time`.
-  * Grounding is not a marginal cost: every provider charges per search and bills the retrieved page
-    content as input tokens on top.
 * The sparklines visualization has been redesigned as a responsive card grid of metric tiles. Plugin-facing additions that come with it:
   * The new `Piwik\Plugins\CoreVisualizations\Visualizations\Sparklines\Config::$use_metric_labels_as_titles` property lets a sparklines view use its own metric translations as the card titles instead of the generic metric names. Intended for views that relabel shared columns with section-specific names, e.g. the Ecommerce Overview.
   * The `sparkline(src, width, height)` Twig helper accepts optional `width`/`height` display-size parameters (in px, defaults `Piwik\Visualization\Sparkline::DEFAULT_WIDTH`/`DEFAULT_HEIGHT`); the sparkline PNG is rendered at twice the displayed size for hi-DPI screens.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 ## Matomo 5.14.0
 
 ### Breaking Changes
+* The non-functional placeholder `Piwik\Plugins\AIProviders\Provider\AIProvider::isWebSearchUsed()`
+  has been removed now that provider web search is implemented. It always returned `false` and no
+  bundled provider overrode it, so a subclass overriding it had no effect on the response. Providers
+  now declare the capability with `supportsWebSearch()` instead.
 * The interface `Piwik\Settings\Interfaces\PolicyComparisonInterface` gained four methods used by the granular compliance dashboard: `getPolicySettingId()`, `isExternallyManagedByPolicyPage()`, `getWhatItDoes()` and `getImpact()`. Plugins that implement the interface directly must implement them. Plugins using `Piwik\Settings\Interfaces\Traits\PolicyComparisonTrait` (as all known implementers do) inherit default implementations and are not affected.
 * Exporting a report for a single goal (a goals table or a bar/pie/evolution chart showing one goal's
   conversions or revenue) now returns only the columns shown in the UI, by adding `showColumns` to the
@@ -17,10 +21,43 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 * The `UserCountry_distinctCountries` metric, returned by `UserCountry.getNumberOfDistinctCountries` and plotted by the distinct-countries sparkline widget on the Locations page, is now declared as a numeric metric and is therefore subject to CNIL data rounding. On installations with CNIL rounding enabled the returned count is rounded to the same scale as other counts instead of being passed through unrounded, so a value of `18` now reads as `20`. Installations without CNIL rounding are unaffected.
 
 ### New APIs
+* `Piwik\Plugins\AIProviders` now implements provider-side web search, also called grounding, so an AI
+  feature can ask the provider to search the web before answering and then read the sources it used.
+  `Piwik\Plugins\AIProviders\AIRequest::withWebSearchEnabled()` is no longer advisory: Anthropic,
+  Google and OpenAI honour it, while AWS Bedrock and the custom provider reject a grounded request with
+  an `AIProviderClientException` rather than silently answering ungrounded.
+  * `AIProviderService::canUseWebSearch($callerPluginName, $requestedProviderId = null)` reports whether
+    a grounded completion can run, answered for the provider `complete()` would actually resolve to, so
+    a feature can degrade before spending anything. The provider entries returned by
+    `getProviderStatusesForCaller()` gained a matching `supportsWebSearch` key.
+  * `AIProviderResponse::wasWebSearchUsed()` reports whether a search actually ran, which is not the
+    same as whether one was requested: given the tool, a model can decide the prompt needs none.
+    `getWebSearchCitations()` returns the deduplicated `url`, `title` and `domain` of each source,
+    `getWebSearchRequestCount()` the number of searches billed, and `getWebSearchQueries()` the queries
+    the model issued where the provider echoes them. Citation titles and queries are untrusted model
+    output, length-capped but otherwise verbatim, so escape them where they are rendered. The new
+    `Piwik\Plugins\AIProviders\WebSearchUsage` normalises the three providers' incompatible grounding
+    shapes into that one shape.
+  * `AIRequest::withTimeoutSeconds()` overrides the provider HTTP timeout, which now defaults to 120s
+    for a grounded completion and stays at 30s otherwise. Grounded completions are intended for CLI
+    commands and scheduled tasks, because 120s exceeds PHP's default `max_execution_time`.
+  * Grounding is not a marginal cost: every provider charges per search and bills the retrieved page
+    content as input tokens on top.
 * The new `Piwik\Http\SecurityHeaders::sendForDataResponse()` sends the header set for a response that is data rather than application UI: `X-Content-Type-Options: nosniff`, `Referrer-Policy: no-referrer`, `X-Frame-Options: deny` unless `[General] enable_framed_pages` allows embedding, and a `Content-Security-Policy` that allows no scripts, forms or base URI, only inline styles and images from Matomo itself (built by the new `Piwik\View\SecurityPolicy::restrictToDataResponse()`). Core sends it for the API endpoint itself, report exports, inline report previews, and the API module's `listAllMethods` and `listSegments` actions, which return HTML without a view; `action=listAllAPI`, which renders one, keeps the headers of a regular page. Call it in a plugin that streams an export or a report, before writing any output.
 * Two new events let plugins customise the "No data has been recorded yet" page, on both the standalone page and its embedding in the reporting UI:
   * `Template.siteWithoutData.afterTrackingMethods` collects additional HTML rendered below the tracking methods list and the section for temporarily hiding the page.
   * `SitesManager.siteWithoutData.showInviteTeamMemberLink` lets a plugin hide the "Invite Team Member" link by setting the posted flag to `false`.
+
+### Deprecations
+* `Piwik\Plugins\AIProviders\AIProviderResponse::isWebSearchEnabled()` is deprecated in favour of
+  `wasWebSearchUsed()`, and the `webSearchEnabled` key of `AIProviderResponse::toArray()` in favour of
+  the new `webSearchUsed` key. The name reads as request state, but both report what the provider
+  actually did, while `AIRequest::isWebSearchEnabled()` keeps the request meaning. Both will be removed
+  in Matomo 6.
+* The `$webSearchEnabled` parameter of the `AIProviderResponse` constructor is ignored. Pass a
+  `Piwik\Plugins\AIProviders\WebSearchUsage` as the new trailing `$webSearch` parameter instead. The
+  parameter is kept in place so positional callers written against Matomo 5.13.0 keep working, and will
+  be removed in Matomo 6.
 
 ### HTTP API
 * A new `keep_flattened_dimension_columns` parameter keeps the columns a flattened report adds for its
@@ -39,6 +76,26 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 * `UsersManager.setUserAccess` now requires `passwordConfirmation` to grant the `admin` role, in either the string or the array form of `access`, on top of the existing check for granting the anonymous user `view` access. As before this applies only to session-authenticated requests, which includes any request sending `force_api_session=1`; plain `token_auth`, `Authorization: Bearer` and CLI calls are unaffected.
 
 ### New APIs
+* `Piwik\Plugins\AIProviders` now implements provider-side web search, also called grounding, so an AI
+  feature can ask the provider to search the web before answering and then read the sources it used.
+  `Piwik\Plugins\AIProviders\AIRequest::withWebSearchEnabled()` is no longer advisory: Anthropic,
+  Google and OpenAI honour it, and AWS Bedrock and the custom provider reject a grounded request with
+  an `AIProviderClientException` rather than silently answering ungrounded.
+  * `AIProviderService::canUseWebSearch($callerPluginName, $requestedProviderId = null)` reports
+    whether a grounded completion can run, answered for the provider `complete()` would actually
+    resolve to, so a feature can degrade before spending anything. The provider entries returned by
+    `getProviderStatusesForCaller()` gained a matching `supportsWebSearch` key.
+  * `AIProviderResponse::wasWebSearchUsed()` reports whether a search actually ran, which is not the
+    same as whether one was requested: given the tool, a model can decide the prompt needs none.
+    `getWebSearchCitations()` returns the deduplicated `url`, `title` and `domain` of each source,
+    `getWebSearchRequestCount()` the number of searches billed, and `getWebSearchQueries()` the
+    queries the model issued where the provider echoes them. The new `Piwik\Plugins\AIProviders\WebSearchUsage`
+    normalises the three providers' incompatible grounding shapes into that one shape.
+  * `AIRequest::withTimeoutSeconds()` overrides the provider HTTP timeout, which now defaults to 120s
+    for a grounded completion and stays at 30s otherwise. Grounded completions are intended for CLI
+    commands and scheduled tasks, because 120s exceeds PHP's default `max_execution_time`.
+  * Grounding is not a marginal cost: every provider charges per search and bills the retrieved page
+    content as input tokens on top.
 * The sparklines visualization has been redesigned as a responsive card grid of metric tiles. Plugin-facing additions that come with it:
   * The new `Piwik\Plugins\CoreVisualizations\Visualizations\Sparklines\Config::$use_metric_labels_as_titles` property lets a sparklines view use its own metric translations as the card titles instead of the generic metric names. Intended for views that relabel shared columns with section-specific names, e.g. the Ecommerce Overview.
   * The `sparkline(src, width, height)` Twig helper accepts optional `width`/`height` display-size parameters (in px, defaults `Piwik\Visualization\Sparkline::DEFAULT_WIDTH`/`DEFAULT_HEIGHT`); the sparkline PNG is rendered at twice the displayed size for hi-DPI screens.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,24 +21,18 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
   feature can ask the provider to search the web before answering and then read the sources it used.
   `Piwik\Plugins\AIProviders\AIRequest::withWebSearchEnabled()` is no longer advisory: Anthropic,
   Google and OpenAI honour it, while AWS Bedrock and the custom provider reject a grounded request with
-  an `AIProviderClientException` rather than silently answering ungrounded.
-  * `AIProviderService::canUseWebSearch($callerPluginName, $requestedProviderId = null)` reports whether
-    a grounded completion can run, answered for the provider `complete()` would actually resolve to, so
-    a feature can degrade before spending anything. The provider entries returned by
-    `getProviderStatusesForCaller()` gained a matching `supportsWebSearch` key.
-  * `AIProviderResponse::wasWebSearchUsed()` reports whether a search actually ran, which is not the
-    same as whether one was requested: given the tool, a model can decide the prompt needs none.
-    `getWebSearchCitations()` returns the deduplicated `url`, `title` and `domain` of each source,
-    `getWebSearchRequestCount()` the number of searches billed, and `getWebSearchQueries()` the queries
-    the model issued where the provider echoes them. Citation titles and queries are untrusted model
-    output, length-capped but otherwise verbatim, so escape them where they are rendered. The new
-    `Piwik\Plugins\AIProviders\WebSearchUsage` normalises the three providers' incompatible grounding
-    shapes into that one shape.
-  * `AIRequest::withTimeoutSeconds()` overrides the provider HTTP timeout, which now defaults to 120s
-    for a grounded completion and stays at 30s otherwise. Grounded completions are intended for CLI
-    commands and scheduled tasks, because 120s exceeds PHP's default `max_execution_time`.
-  * Grounding is not a marginal cost: every provider charges per search and bills the retrieved page
-    content as input tokens on top.
+  an `AIProviderClientException` rather than silently answering ungrounded. `AIProviderResponse` gained
+  `wasWebSearchUsed()`, `getWebSearchCitations()`, `getWebSearchRequestCount()` and
+  `getWebSearchQueries()`, backed by the new `Piwik\Plugins\AIProviders\WebSearchUsage`, which
+  normalises the three providers' incompatible grounding shapes; `AIProviderService::canUseWebSearch()`
+  and the new `supportsWebSearch` key of `getProviderStatusesForCaller()` let a feature check first.
+  Citation titles and queries are untrusted model output, length-capped but otherwise verbatim, so
+  escape them where they are rendered. Grounding is not a marginal cost: every provider charges per
+  search and bills the retrieved page content as input tokens on top. See `plugins/AIProviders/README.md`
+  for the per-provider caveats and the cost and timeout implications.
+* `AIRequest::withTimeoutSeconds()` overrides the provider HTTP timeout, which now defaults to 120s for
+  a grounded completion and stays at 30s otherwise. That outlasts the default read timeout of common
+  web servers and proxies, so grounded completions are intended for CLI commands and scheduled tasks.
 * `AIProviderResponse::getStopReason()` now reports a value for Google completions, which previously
   always returned `null`. Google's `finishReason` is mapped onto the same vocabulary the conversation
   API already uses (`STOP` becomes `end_turn`, `MAX_TOKENS` becomes `max_tokens`, `SAFETY` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,6 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 ## Matomo 5.14.0
 
 ### Breaking Changes
-* The placeholder `Piwik\Plugins\AIProviders\Provider\AIProvider::isWebSearchUsed()` has been removed
-  now that provider web search is implemented. Its base implementation always returned `false` and no
-  bundled provider overrode it, but the value it returned was passed into the response, so a
-  third-party provider that overrode it did control `AIProviderResponse::isWebSearchEnabled()`. Such a
-  provider must now override `supportsWebSearch()` to declare the capability and pass a
-  `Piwik\Plugins\AIProviders\WebSearchUsage` to `buildResponse()`, which reports the searches, queries
-  and citations the completion actually produced. Overriding the removed method has no effect and
-  raises no error, so check for it when upgrading a provider plugin.
 * The interface `Piwik\Settings\Interfaces\PolicyComparisonInterface` gained four methods used by the granular compliance dashboard: `getPolicySettingId()`, `isExternallyManagedByPolicyPage()`, `getWhatItDoes()` and `getImpact()`. Plugins that implement the interface directly must implement them. Plugins using `Piwik\Settings\Interfaces\Traits\PolicyComparisonTrait` (as all known implementers do) inherit default implementations and are not affected.
 * Exporting a report for a single goal (a goals table or a bar/pie/evolution chart showing one goal's
   conversions or revenue) now returns only the columns shown in the UI, by adding `showColumns` to the
@@ -58,10 +50,18 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
   the new `webSearchUsed` key. The name reads as request state, but both report what the provider
   actually did, while `AIRequest::isWebSearchEnabled()` keeps the request meaning. Both will be removed
   in Matomo 6.
-* The `$webSearchEnabled` parameter of the `AIProviderResponse` constructor is ignored. Pass a
-  `Piwik\Plugins\AIProviders\WebSearchUsage` as the new trailing `$webSearch` parameter instead. The
-  parameter is kept in place so positional callers written against Matomo 5.13.0 keep working, and will
-  be removed in Matomo 6.
+* The `$webSearchEnabled` parameter of the `AIProviderResponse` constructor is deprecated. Pass a
+  `Piwik\Plugins\AIProviders\WebSearchUsage` as the new trailing `$webSearch` parameter instead, which
+  reports the searches, queries and citations a completion actually produced rather than a bare flag.
+  The parameter keeps its position and its meaning, so positional callers written against Matomo 5.13.0
+  keep working and a `true` still makes `wasWebSearchUsed()` report a search. It will be removed in
+  Matomo 6.
+* `Piwik\Plugins\AIProviders\Provider\AIProvider::isWebSearchUsed()` is deprecated. It was a
+  placeholder whose base implementation always returned `false`, and no bundled provider overrode it,
+  but a third-party provider that did override it controlled `AIProviderResponse::isWebSearchEnabled()`.
+  Such a provider should now override `supportsWebSearch()` to declare the capability and pass a
+  `WebSearchUsage` to `buildResponse()`. An existing override is still honoured by
+  `wasWebSearchUsed()` for the transition, and will stop being consulted in Matomo 6.
 
 ### HTTP API
 * A new `keep_flattened_dimension_columns` parameter keeps the columns a flattened report adds for its

--- a/plugins/AIProviders/AIProviderResponse.php
+++ b/plugins/AIProviders/AIProviderResponse.php
@@ -82,7 +82,7 @@ class AIProviderResponse
     private $webSearch;
 
     /**
-     * @param bool $webSearchEnabled Deprecated since Matomo 5.14.0 and ignored; pass a
+     * @param bool $webSearchEnabled Deprecated since 5.14.0 and ignored; pass a
      *                               {@link WebSearchUsage} as $webSearch instead. Kept in place so
      *                               positional callers written against Matomo 5.13.0 keep working.
      *                               Will be removed in Matomo 6.
@@ -149,7 +149,7 @@ class AIProviderResponse
     }
 
     /**
-     * @deprecated since Matomo 5.14.0, use {@link wasWebSearchUsed()}. The name reads as
+     * @deprecated since 5.14.0, use {@link wasWebSearchUsed()} instead. The name reads as
      *             request state, but this reports what the provider actually did, and
      *             {@link AIRequest::isWebSearchEnabled()} keeps the request meaning.
      *             Will be removed in Matomo 6.
@@ -239,7 +239,7 @@ class AIProviderResponse
             'outputTokens' => $this->outputTokens,
             'reasoningLevel' => $this->reasoningLevel,
             'webSearchUsed' => $this->webSearch->wasUsed(),
-            // @deprecated since Matomo 5.14.0, use webSearchUsed.
+            // @deprecated since 5.14.0, use webSearchUsed instead.
             'webSearchEnabled' => $this->webSearch->wasUsed(),
             'webSearchRequestCount' => $this->webSearch->getRequestCount(),
             'webSearchQueries' => $this->webSearch->getQueries(),

--- a/plugins/AIProviders/AIProviderResponse.php
+++ b/plugins/AIProviders/AIProviderResponse.php
@@ -11,6 +11,9 @@ declare(strict_types=1);
 
 namespace Piwik\Plugins\AIProviders;
 
+/**
+ * @phpstan-import-type WebSearchCitationArray from WebSearchUsage
+ */
 class AIProviderResponse
 {
     /**
@@ -57,13 +60,6 @@ class AIProviderResponse
     private $reasoningLevel;
 
     /**
-     * Whether provider-side web search was actually applied.
-     *
-     * @var bool
-     */
-    private $webSearchEnabled;
-
-    /**
      * Total provider request time in milliseconds, including retries.
      *
      * @var int|null
@@ -77,6 +73,14 @@ class AIProviderResponse
      */
     private $stopReason;
 
+    /**
+     * What the provider's web search actually did, or {@link WebSearchUsage::none()}
+     * when it did not run.
+     *
+     * @var WebSearchUsage
+     */
+    private $webSearch;
+
     public function __construct(
         string $providerId,
         string $providerName,
@@ -85,9 +89,9 @@ class AIProviderResponse
         ?int $inputTokens = null,
         ?int $outputTokens = null,
         string $reasoningLevel = AIRequest::REASONING_NONE,
-        bool $webSearchEnabled = false,
         ?int $executionTimeMs = null,
-        ?string $stopReason = null
+        ?string $stopReason = null,
+        ?WebSearchUsage $webSearch = null
     ) {
         $this->providerId = $providerId;
         $this->providerName = $providerName;
@@ -96,9 +100,19 @@ class AIProviderResponse
         $this->inputTokens = $inputTokens;
         $this->outputTokens = $outputTokens;
         $this->reasoningLevel = $reasoningLevel;
-        $this->webSearchEnabled = $webSearchEnabled;
         $this->executionTimeMs = $executionTimeMs;
         $this->stopReason = $stopReason;
+        $this->webSearch = $webSearch ?? WebSearchUsage::none();
+    }
+
+    public function getProviderId(): string
+    {
+        return $this->providerId;
+    }
+
+    public function getProviderName(): string
+    {
+        return $this->providerName;
     }
 
     public function getText(): string
@@ -126,9 +140,46 @@ class AIProviderResponse
         return $this->reasoningLevel;
     }
 
+    /**
+     * Whether the provider's web search actually ran — not whether it was
+     * requested. A model given the tool can decide the prompt needs no search.
+     */
     public function isWebSearchEnabled(): bool
     {
-        return $this->webSearchEnabled;
+        return $this->webSearch->wasUsed();
+    }
+
+    /**
+     * Web sources attached to this answer, deduplicated, cited ones first where
+     * the provider distinguishes them. URLs are guaranteed http(s). For Google
+     * the `url` is its grounding redirect and only `domain` identifies the
+     * publisher — see {@link WebSearchUsage}.
+     *
+     * @return list<WebSearchCitationArray>
+     */
+    public function getWebSearchCitations(): array
+    {
+        return $this->webSearch->getCitations();
+    }
+
+    /**
+     * Number of searches the provider ran (what per-search fees are billed on),
+     * or null when it did not run or reports no count.
+     */
+    public function getWebSearchRequestCount(): ?int
+    {
+        return $this->webSearch->getRequestCount();
+    }
+
+    /**
+     * Search queries the model issued, when the provider echoes them. Can be
+     * empty even when searches ran.
+     *
+     * @return list<string>
+     */
+    public function getWebSearchQueries(): array
+    {
+        return $this->webSearch->getQueries();
     }
 
     public function getExecutionTimeMs(): ?int
@@ -178,7 +229,10 @@ class AIProviderResponse
             'inputTokens' => $this->inputTokens,
             'outputTokens' => $this->outputTokens,
             'reasoningLevel' => $this->reasoningLevel,
-            'webSearchEnabled' => $this->webSearchEnabled,
+            'webSearchEnabled' => $this->webSearch->wasUsed(),
+            'webSearchRequestCount' => $this->webSearch->getRequestCount(),
+            'webSearchQueries' => $this->webSearch->getQueries(),
+            'webSearchCitations' => $this->webSearch->getCitations(),
             'executionTimeMs' => $this->executionTimeMs,
             'stopReason' => $this->stopReason,
         ];

--- a/plugins/AIProviders/AIProviderResponse.php
+++ b/plugins/AIProviders/AIProviderResponse.php
@@ -82,12 +82,20 @@ class AIProviderResponse
     private $webSearch;
 
     /**
-     * @param bool $webSearchEnabled Deprecated since 5.14.0 and ignored; pass a
-     *                               {@link WebSearchUsage} as $webSearch instead. Kept in place so
-     *                               positional callers written against Matomo 5.13.0 keep working.
-     *                               Will be removed in Matomo 6.
+     * Legacy "web search was used" flag from the deprecated constructor parameter.
+     * Only ever true for a caller that predates {@link WebSearchUsage}.
+     *
+     * @var bool
      */
-    // @phpstan-ignore constructor.unusedParameter ($webSearchEnabled is deliberately ignored, see above)
+    private $legacyWebSearchEnabled;
+
+    /**
+     * @param bool $webSearchEnabled Deprecated since 5.14.0; pass a {@link WebSearchUsage} as
+     *                               $webSearch instead, which reports what the search actually
+     *                               did rather than a bare flag. Still honoured by
+     *                               {@link wasWebSearchUsed()} so callers and providers written
+     *                               against Matomo 5.13.0 keep working. Will be removed in Matomo 6.
+     */
     public function __construct(
         string $providerId,
         string $providerName,
@@ -111,6 +119,7 @@ class AIProviderResponse
         $this->executionTimeMs = $executionTimeMs;
         $this->stopReason = $stopReason;
         $this->webSearch = $webSearch ?? WebSearchUsage::none();
+        $this->legacyWebSearchEnabled = $webSearchEnabled;
     }
 
     public function getText(): string
@@ -145,7 +154,7 @@ class AIProviderResponse
      */
     public function wasWebSearchUsed(): bool
     {
-        return $this->webSearch->wasUsed();
+        return $this->webSearch->wasUsed() || $this->legacyWebSearchEnabled;
     }
 
     /**
@@ -238,9 +247,9 @@ class AIProviderResponse
             'inputTokens' => $this->inputTokens,
             'outputTokens' => $this->outputTokens,
             'reasoningLevel' => $this->reasoningLevel,
-            'webSearchUsed' => $this->webSearch->wasUsed(),
+            'webSearchUsed' => $this->wasWebSearchUsed(),
             // @deprecated since 5.14.0, use webSearchUsed instead.
-            'webSearchEnabled' => $this->webSearch->wasUsed(),
+            'webSearchEnabled' => $this->wasWebSearchUsed(),
             'webSearchRequestCount' => $this->webSearch->getRequestCount(),
             'webSearchQueries' => $this->webSearch->getQueries(),
             'webSearchCitations' => $this->webSearch->getCitations(),

--- a/plugins/AIProviders/AIProviderResponse.php
+++ b/plugins/AIProviders/AIProviderResponse.php
@@ -81,6 +81,13 @@ class AIProviderResponse
      */
     private $webSearch;
 
+    /**
+     * @param bool $webSearchEnabled Ignored.
+     * @deprecated since Matomo 5.14.0 the $webSearchEnabled parameter is ignored; pass a
+     *             {@link WebSearchUsage} as $webSearch instead. The parameter is kept so
+     *             positional callers written against Matomo 5.13.0 keep working, and will
+     *             be removed in Matomo 6.
+     */
     public function __construct(
         string $providerId,
         string $providerName,
@@ -89,6 +96,7 @@ class AIProviderResponse
         ?int $inputTokens = null,
         ?int $outputTokens = null,
         string $reasoningLevel = AIRequest::REASONING_NONE,
+        bool $webSearchEnabled = false,
         ?int $executionTimeMs = null,
         ?string $stopReason = null,
         ?WebSearchUsage $webSearch = null
@@ -100,19 +108,12 @@ class AIProviderResponse
         $this->inputTokens = $inputTokens;
         $this->outputTokens = $outputTokens;
         $this->reasoningLevel = $reasoningLevel;
+        // Deprecated and superseded by $webSearch; discarded so static analysis
+        // sees it consumed rather than forgotten.
+        unset($webSearchEnabled);
         $this->executionTimeMs = $executionTimeMs;
         $this->stopReason = $stopReason;
         $this->webSearch = $webSearch ?? WebSearchUsage::none();
-    }
-
-    public function getProviderId(): string
-    {
-        return $this->providerId;
-    }
-
-    public function getProviderName(): string
-    {
-        return $this->providerName;
     }
 
     public function getText(): string
@@ -141,19 +142,30 @@ class AIProviderResponse
     }
 
     /**
-     * Whether the provider's web search actually ran — not whether it was
-     * requested. A model given the tool can decide the prompt needs no search.
+     * Whether the provider's web search actually ran, which is not the same as
+     * whether it was requested: a model given the tool can decide the prompt
+     * needs no search.
      */
-    public function isWebSearchEnabled(): bool
+    public function wasWebSearchUsed(): bool
     {
         return $this->webSearch->wasUsed();
     }
 
     /**
+     * @deprecated since Matomo 5.14.0, use {@link wasWebSearchUsed()}. The name reads as
+     *             request state, but this reports what the provider actually did, and
+     *             {@link AIRequest::isWebSearchEnabled()} keeps the request meaning.
+     *             Will be removed in Matomo 6.
+     */
+    public function isWebSearchEnabled(): bool
+    {
+        return $this->wasWebSearchUsed();
+    }
+
+    /**
      * Web sources attached to this answer, deduplicated, cited ones first where
-     * the provider distinguishes them. URLs are guaranteed http(s). For Google
-     * the `url` is its grounding redirect and only `domain` identifies the
-     * publisher — see {@link WebSearchUsage}.
+     * the provider distinguishes them. Titles are untrusted model output; see
+     * {@link WebSearchUsage} for what is and is not guaranteed.
      *
      * @return list<WebSearchCitationArray>
      */
@@ -229,6 +241,8 @@ class AIProviderResponse
             'inputTokens' => $this->inputTokens,
             'outputTokens' => $this->outputTokens,
             'reasoningLevel' => $this->reasoningLevel,
+            'webSearchUsed' => $this->webSearch->wasUsed(),
+            // @deprecated since Matomo 5.14.0, use webSearchUsed.
             'webSearchEnabled' => $this->webSearch->wasUsed(),
             'webSearchRequestCount' => $this->webSearch->getRequestCount(),
             'webSearchQueries' => $this->webSearch->getQueries(),

--- a/plugins/AIProviders/AIProviderResponse.php
+++ b/plugins/AIProviders/AIProviderResponse.php
@@ -82,12 +82,12 @@ class AIProviderResponse
     private $webSearch;
 
     /**
-     * @param bool $webSearchEnabled Ignored.
-     * @deprecated since Matomo 5.14.0 the $webSearchEnabled parameter is ignored; pass a
-     *             {@link WebSearchUsage} as $webSearch instead. The parameter is kept so
-     *             positional callers written against Matomo 5.13.0 keep working, and will
-     *             be removed in Matomo 6.
+     * @param bool $webSearchEnabled Deprecated since Matomo 5.14.0 and ignored; pass a
+     *                               {@link WebSearchUsage} as $webSearch instead. Kept in place so
+     *                               positional callers written against Matomo 5.13.0 keep working.
+     *                               Will be removed in Matomo 6.
      */
+    // @phpstan-ignore constructor.unusedParameter ($webSearchEnabled is deliberately ignored, see above)
     public function __construct(
         string $providerId,
         string $providerName,
@@ -108,9 +108,6 @@ class AIProviderResponse
         $this->inputTokens = $inputTokens;
         $this->outputTokens = $outputTokens;
         $this->reasoningLevel = $reasoningLevel;
-        // Deprecated and superseded by $webSearch; discarded so static analysis
-        // sees it consumed rather than forgotten.
-        unset($webSearchEnabled);
         $this->executionTimeMs = $executionTimeMs;
         $this->stopReason = $stopReason;
         $this->webSearch = $webSearch ?? WebSearchUsage::none();

--- a/plugins/AIProviders/AIProviderService.php
+++ b/plugins/AIProviders/AIProviderService.php
@@ -222,6 +222,12 @@ class AIProviderService
      * wins unless the caller is allowlisted, and a forced provider without web
      * search makes every grounded request throw.
      *
+     * Answers for the provider only, not for a specific request: it takes no
+     * {@link AIRequest} and so cannot see request options that a provider
+     * refuses to combine with search. Google rejects grounding together with
+     * {@link AIRequest::withJsonResponse()}, and a `true` here does not warn
+     * about it.
+     *
      * @param string|null $requestedProviderId The same value the caller would pass to
      *                                         {@link AIRequest::withProviderId()}, if any.
      */

--- a/plugins/AIProviders/AIProviderService.php
+++ b/plugins/AIProviders/AIProviderService.php
@@ -87,8 +87,8 @@ class AIProviderService
         // sources would otherwise store answers it cannot tell apart from grounded ones.
         if ($request->isWebSearchEnabled() && !$provider->supportsWebSearch()) {
             throw new AIProviderClientException(sprintf(
-                'Provider "%s" does not support web search.',
-                $provider->getId()
+                '%s does not support web search.',
+                $provider->getName()
             ));
         }
 
@@ -211,6 +211,33 @@ class AIProviderService
         }
 
         return ['status' => self::CONVERSATION_READY] + $base;
+    }
+
+    /**
+     * Whether a grounded completion from this caller can run, so a feature that
+     * needs sources can degrade before spending anything.
+     *
+     * Answered for the provider {@link complete()} would actually resolve to,
+     * which is what makes it usable: on a managed instance the forced provider
+     * wins unless the caller is allowlisted, and a forced provider without web
+     * search makes every grounded request throw.
+     *
+     * @param string|null $requestedProviderId The same value the caller would pass to
+     *                                         {@link AIRequest::withProviderId()}, if any.
+     */
+    public function canUseWebSearch(string $callerPluginName, ?string $requestedProviderId = null): bool
+    {
+        $providers = AIProviders::getAvailableProviders();
+
+        try {
+            $resolution = $this->resolveProviderId($requestedProviderId, $callerPluginName, $providers);
+            $provider = $this->requireProvider($providers, $resolution['providerId']);
+        } catch (InvalidArgumentException $e) {
+            return false;
+        }
+
+        return $provider->supportsWebSearch()
+            && $provider->isConfigured($this->configuration->getProviderConfiguration($provider));
     }
 
     /**
@@ -418,6 +445,7 @@ class AIProviderService
                 'isConfigured' => $provider->isConfigured(
                     $this->configuration->getProviderConfiguration($provider)
                 ),
+                'supportsWebSearch' => $provider->supportsWebSearch(),
             ];
         }, $usableProviders);
     }

--- a/plugins/AIProviders/AIProviderService.php
+++ b/plugins/AIProviders/AIProviderService.php
@@ -82,6 +82,16 @@ class AIProviderService
         }
 
         $provider = $this->requireProvider($providers, $resolution['providerId']);
+
+        // Fail rather than silently answer ungrounded: a caller that asked for
+        // sources would otherwise store answers it cannot tell apart from grounded ones.
+        if ($request->isWebSearchEnabled() && !$provider->supportsWebSearch()) {
+            throw new AIProviderClientException(sprintf(
+                'Provider "%s" does not support web search.',
+                $provider->getId()
+            ));
+        }
+
         $configuration = $this->configuration->getProviderConfiguration($provider);
 
         $response = $this->runWithProvider($provider, $configuration, $request);

--- a/plugins/AIProviders/AIRequest.php
+++ b/plugins/AIProviders/AIRequest.php
@@ -134,7 +134,7 @@ class AIRequest
      * Whether the caller wants the provider's server-side web search (grounding).
      * Providers without one reject the request — see
      * {@link AIProviderService::complete()}. The model still decides whether a
-     * prompt needs a search, so read {@link AIProviderResponse::isWebSearchEnabled()}
+     * prompt needs a search, so read {@link AIProviderResponse::wasWebSearchUsed()}
      * for what actually happened.
      *
      * Never free: providers charge per search on top of the retrieved page

--- a/plugins/AIProviders/AIRequest.php
+++ b/plugins/AIProviders/AIRequest.php
@@ -131,12 +131,27 @@ class AIRequest
     private $reasoningLevel = self::REASONING_NONE;
 
     /**
-     * Whether the caller wants provider web search. Currently advisory only;
-     * providers do not enable provider-specific web search tools yet.
+     * Whether the caller wants the provider's server-side web search (grounding).
+     * Providers without one reject the request — see
+     * {@link AIProviderService::complete()}. The model still decides whether a
+     * prompt needs a search, so read {@link AIProviderResponse::isWebSearchEnabled()}
+     * for what actually happened.
+     *
+     * Never free: providers charge per search on top of the retrieved page
+     * content, which arrives as input tokens.
      *
      * @var bool
      */
     private $webSearchEnabled = false;
+
+    /**
+     * Provider HTTP timeout, or null for the provider's default: 30s, raised to
+     * 120s for grounded requests because server-side search runs several fetches
+     * inside the one HTTP request.
+     *
+     * @var int|null
+     */
+    private $timeoutSeconds = null;
 
     /**
      * Future provider-specific thinking budget. Not applied to requests yet.
@@ -247,6 +262,17 @@ class AIRequest
         return $request;
     }
 
+    /**
+     * Overrides the provider HTTP timeout; null restores the provider default.
+     */
+    public function withTimeoutSeconds(?int $timeoutSeconds): self
+    {
+        $request = clone $this;
+        $request->timeoutSeconds = $timeoutSeconds === null ? null : max(1, $timeoutSeconds);
+
+        return $request;
+    }
+
     public function withThinkingBudget(?int $thinkingBudget): self
     {
         $request = clone $this;
@@ -330,6 +356,11 @@ class AIRequest
     public function isWebSearchEnabled(): bool
     {
         return $this->webSearchEnabled;
+    }
+
+    public function getTimeoutSeconds(): ?int
+    {
+        return $this->timeoutSeconds;
     }
 
     public function getThinkingBudget(): ?int

--- a/plugins/AIProviders/Provider/AIProvider.php
+++ b/plugins/AIProviders/Provider/AIProvider.php
@@ -55,15 +55,26 @@ abstract class AIProvider
 
     /**
      * Default provider HTTP timeout for a single-shot completion, unless the
-     * request sets its own.
+     * request sets its own with {@link AIRequest::withTimeoutSeconds()}.
      */
     protected const COMPLETE_TIMEOUT_SECONDS = 30;
 
     /**
      * Default timeout for a grounded completion. Server-side search runs several
      * fetches inside the one HTTP request, so these routinely take 30-90s where
-     * an ungrounded completion takes 2-5s. Note it multiplies with the transient
-     * error retries in {@link sendRequest()}.
+     * an ungrounded completion takes 2-5s.
+     *
+     * This exceeds PHP's default 30s `max_execution_time`, so grounded
+     * completions are meant for CLI commands and scheduled tasks, where it is
+     * unlimited. A caller running one inside a web request must either raise
+     * that limit itself or lower this with
+     * {@link AIRequest::withTimeoutSeconds()}, or the request dies before the
+     * provider answers.
+     *
+     * A retryable HTTP status (see {@link TRANSIENT_ERROR_STATUS_CODES}) can
+     * multiply both the wall time and the per-search fees, because each attempt
+     * runs its own searches. A transport-level timeout does not: it throws on
+     * the first attempt.
      */
     protected const WEB_SEARCH_COMPLETE_TIMEOUT_SECONDS = 120;
 
@@ -371,6 +382,7 @@ abstract class AIProvider
             $inputTokens,
             $outputTokens,
             $this->getReasoningLevelUsed($request),
+            false, // deprecated $webSearchEnabled slot, superseded by $webSearch below
             $this->lastRequestExecutionTimeMs,
             $stopReason,
             $webSearch
@@ -962,16 +974,23 @@ abstract class AIProvider
     }
 
     /**
-     * Derives the OpenAI-compatible models-listing endpoint from a chat
-     * completions endpoint, e.g. `.../v1/chat/completions` or a bare `.../v1`
-     * base both become `.../v1/models` — the standard `GET {base}/models`
-     * probe used by the "test connection" flow.
+     * Derives a sibling OpenAI-compatible endpoint from a chat completions
+     * endpoint, e.g. `.../v1/chat/completions` or a bare `.../v1` base both
+     * become `.../v1/{$path}`.
      */
-    protected function openAiCompatibleModelsEndpoint(string $chatEndpointUrl): string
+    protected function openAiCompatibleEndpoint(string $chatEndpointUrl, string $path): string
     {
         $base = preg_replace('#/chat/completions/?$#', '', $chatEndpointUrl) ?? $chatEndpointUrl;
 
-        return rtrim($base, '/') . '/models';
+        return rtrim($base, '/') . '/' . $path;
+    }
+
+    /**
+     * The standard `GET {base}/models` probe used by the "test connection" flow.
+     */
+    protected function openAiCompatibleModelsEndpoint(string $chatEndpointUrl): string
+    {
+        return $this->openAiCompatibleEndpoint($chatEndpointUrl, 'models');
     }
 
     /**
@@ -987,8 +1006,12 @@ abstract class AIProvider
      * @param array<string, mixed> $payload
      * @return array<string, mixed>
      */
-    protected function sendJsonRequest(string $url, array $headers, array $payload, int $timeoutSeconds = 30): array
-    {
+    protected function sendJsonRequest(
+        string $url,
+        array $headers,
+        array $payload,
+        int $timeoutSeconds = self::COMPLETE_TIMEOUT_SECONDS
+    ): array {
         $requestBody = json_encode($payload);
 
         if (!is_string($requestBody)) {

--- a/plugins/AIProviders/Provider/AIProvider.php
+++ b/plugins/AIProviders/Provider/AIProvider.php
@@ -25,6 +25,7 @@ use Piwik\Plugins\AIProviders\Exception\AIProviderClientException;
 use Piwik\Plugins\AIProviders\Exception\AIProviderException;
 use Piwik\Plugins\AIProviders\Exception\AIProviderServerException;
 use Piwik\Plugins\AIProviders\Model\Configuration;
+use Piwik\Plugins\AIProviders\WebSearchUsage;
 
 /**
  * @phpstan-import-type CanonicalMessageArray from CanonicalMessage
@@ -51,6 +52,20 @@ abstract class AIProvider
      * above Anthropic's 1024-token minimum so it is valid for every provider.
      */
     protected const DEFAULT_THINKING_BUDGET = 2048;
+
+    /**
+     * Default provider HTTP timeout for a single-shot completion, unless the
+     * request sets its own.
+     */
+    protected const COMPLETE_TIMEOUT_SECONDS = 30;
+
+    /**
+     * Default timeout for a grounded completion. Server-side search runs several
+     * fetches inside the one HTTP request, so these routinely take 30-90s where
+     * an ungrounded completion takes 2-5s. Note it multiplies with the transient
+     * error retries in {@link sendRequest()}.
+     */
+    protected const WEB_SEARCH_COMPLETE_TIMEOUT_SECONDS = 120;
 
     /**
      * @var string
@@ -345,7 +360,8 @@ abstract class AIProvider
         string $text,
         ?int $inputTokens = null,
         ?int $outputTokens = null,
-        ?string $stopReason = null
+        ?string $stopReason = null,
+        ?WebSearchUsage $webSearch = null
     ): AIProviderResponse {
         return new AIProviderResponse(
             $this->getId(),
@@ -355,9 +371,9 @@ abstract class AIProvider
             $inputTokens,
             $outputTokens,
             $this->getReasoningLevelUsed($request),
-            $this->isWebSearchUsed($request),
             $this->lastRequestExecutionTimeMs,
-            $stopReason
+            $stopReason,
+            $webSearch
         );
     }
 
@@ -393,11 +409,33 @@ abstract class AIProvider
         return $this->wantsThinking($request) ? Configuration::CAPABILITY_THINKING : AIRequest::REASONING_NONE;
     }
 
-    protected function isWebSearchUsed(AIRequest $request): bool
+    /**
+     * Whether the provider has a server-side web search tool that
+     * {@link complete()} can switch on. {@link AIProviderService::complete()}
+     * rejects a grounded request for a provider that returns false.
+     */
+    public function supportsWebSearch(): bool
     {
-        // TODO: Implement provider-specific web search/tool configuration for
-        // OpenAI, Google, Anthropic, and managed providers separately.
         return false;
+    }
+
+    /**
+     * Whether this request runs grounded: the caller asked for search and this
+     * provider can do it.
+     */
+    protected function wantsWebSearch(AIRequest $request): bool
+    {
+        return $request->isWebSearchEnabled() && $this->supportsWebSearch();
+    }
+
+    /**
+     * The HTTP timeout for this completion: the request's own, else the default
+     * for grounded or ungrounded requests.
+     */
+    protected function completionTimeoutSeconds(AIRequest $request): int
+    {
+        return $request->getTimeoutSeconds()
+            ?? ($this->wantsWebSearch($request) ? static::WEB_SEARCH_COMPLETE_TIMEOUT_SECONDS : static::COMPLETE_TIMEOUT_SECONDS);
     }
 
     /**
@@ -437,7 +475,7 @@ abstract class AIProvider
             $payload['response_format'] = ['type' => 'json_object'];
         }
 
-        $response = $this->sendJsonRequest($endpointUrl, $headers, $payload);
+        $response = $this->sendJsonRequest($endpointUrl, $headers, $payload, $this->completionTimeoutSeconds($request));
 
         $text = $response['choices'][0]['message']['content'] ?? '';
         $finishReason = is_string($response['choices'][0]['finish_reason'] ?? null)

--- a/plugins/AIProviders/Provider/AIProvider.php
+++ b/plugins/AIProviders/Provider/AIProvider.php
@@ -382,7 +382,10 @@ abstract class AIProvider
             $inputTokens,
             $outputTokens,
             $this->getReasoningLevelUsed($request),
-            false, // deprecated $webSearchEnabled slot, superseded by $webSearch below
+            // Deprecated slot, superseded by $webSearch below. Still consulted so a
+            // provider written against Matomo 5.13.0, whose only way to report a
+            // search was overriding isWebSearchUsed(), keeps being believed.
+            $this->isWebSearchUsed($request),
             $this->lastRequestExecutionTimeMs,
             $stopReason,
             $webSearch
@@ -462,6 +465,19 @@ abstract class AIProvider
      * rejects a grounded request for a provider that returns false.
      */
     public function supportsWebSearch(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @deprecated since 5.14.0. Override {@link supportsWebSearch()} to declare the
+     *             capability and pass a {@link WebSearchUsage} to {@link buildResponse()},
+     *             which reports the searches, queries and citations a completion actually
+     *             produced instead of a bare flag. An override is still honoured by
+     *             {@link AIProviderResponse::wasWebSearchUsed()} for the transition.
+     *             Will be removed in Matomo 6.
+     */
+    protected function isWebSearchUsed(AIRequest $request): bool
     {
         return false;
     }

--- a/plugins/AIProviders/Provider/AIProvider.php
+++ b/plugins/AIProviders/Provider/AIProvider.php
@@ -422,6 +422,41 @@ abstract class AIProvider
     }
 
     /**
+     * Appends one fragment of answer text to the answer being assembled,
+     * inserting a single space only where a boundary needs one.
+     *
+     * Grounded answers arrive in pieces, and the two kinds of gap between them
+     * need opposite treatment:
+     *
+     * - Two *adjacent* text fragments are one sentence split at a citation
+     *   boundary, and each carries its own spacing, so nothing may be inserted.
+     *   Anthropic sends `"Matomo is "` then `"the leading option"`.
+     * - Fragments separated by something else, a tool-use block, a skipped
+     *   reasoning part or a separate output message, are separate sentences and
+     *   the provider does not pad them. Anthropic sends
+     *   `"I'll search for that."` then the search blocks then
+     *   `"Based on the search results, "`, which run together unjoined.
+     *
+     * A space rather than a newline, because a fragment boundary can fall inside
+     * a JSON string value, where a raw newline makes the response undecodable.
+     * Nothing is inserted when either side already carries boundary whitespace.
+     *
+     * @param bool $atBoundary Whether something other than answer text stood between the two.
+     */
+    protected function appendAnswerText(string $answer, string $fragment, bool $atBoundary): string
+    {
+        if ($answer === '' || $fragment === '') {
+            return $answer . $fragment;
+        }
+
+        $needsSpace = $atBoundary
+            && rtrim($answer) === $answer
+            && ltrim($fragment) === $fragment;
+
+        return $answer . ($needsSpace ? ' ' : '') . $fragment;
+    }
+
+    /**
      * Whether the provider has a server-side web search tool that
      * {@link complete()} can switch on. {@link AIProviderService::complete()}
      * rejects a grounded request for a provider that returns false.

--- a/plugins/AIProviders/Provider/AIProvider.php
+++ b/plugins/AIProviders/Provider/AIProvider.php
@@ -64,12 +64,18 @@ abstract class AIProvider
      * fetches inside the one HTTP request, so these routinely take 30-90s where
      * an ungrounded completion takes 2-5s.
      *
-     * This exceeds PHP's default 30s `max_execution_time`, so grounded
-     * completions are meant for CLI commands and scheduled tasks, where it is
-     * unlimited. A caller running one inside a web request must either raise
-     * that limit itself or lower this with
-     * {@link AIRequest::withTimeoutSeconds()}, or the request dies before the
+     * That outlasts the default read timeout of every common web server and
+     * proxy in front of PHP (nginx `fastcgi_read_timeout` and Apache `Timeout`
+     * are both 60s), which cut the connection whatever PHP is configured to
+     * allow. So grounded completions are meant for CLI commands and scheduled
+     * tasks, which have nothing in front of them. A caller running one inside a
+     * web request must either raise those limits itself or lower this with
+     * {@link AIRequest::withTimeoutSeconds()}, or the connection dies before the
      * provider answers.
+     *
+     * PHP's own `max_execution_time` is the lesser worry: on non-Windows SAPIs
+     * it does not advance while a cURL transfer is waiting, so a long provider
+     * call alone rarely trips it.
      *
      * A retryable HTTP status (see {@link TRANSIENT_ERROR_STATUS_CODES}) can
      * multiply both the wall time and the per-search fees, because each attempt

--- a/plugins/AIProviders/Provider/Anthropic.php
+++ b/plugins/AIProviders/Provider/Anthropic.php
@@ -162,6 +162,12 @@ class Anthropic extends AIProvider
             }
 
             if (($block['type'] ?? null) === 'text' && is_string($block['text'] ?? null)) {
+                // An empty block is neither text nor a boundary: leave a pending
+                // boundary pending, so the next real fragment still gets its space.
+                if ($block['text'] === '') {
+                    continue;
+                }
+
                 $answer = $this->appendAnswerText($answer, $block['text'], $atBoundary);
                 $atBoundary = false;
                 continue;

--- a/plugins/AIProviders/Provider/Anthropic.php
+++ b/plugins/AIProviders/Provider/Anthropic.php
@@ -144,6 +144,11 @@ class Anthropic extends AIProvider
      * block: extended thinking puts a `thinking` block first, and web search
      * splits the prose around `server_tool_use`/`web_search_tool_result` blocks.
      *
+     * Joined with nothing between them, because a grounded answer is split
+     * mid-sentence at a citation boundary and each fragment carries its own
+     * spacing. Inserting a separator would break the prose, and in JSON mode a
+     * newline landing inside a string value makes the response undecodable.
+     *
      * @param mixed $content
      */
     private function concatenateTextBlocks($content): string
@@ -163,7 +168,7 @@ class Anthropic extends AIProvider
             }
         }
 
-        return implode("\n", $texts);
+        return implode('', $texts);
     }
 
     /**
@@ -202,8 +207,13 @@ class Anthropic extends AIProvider
             }
 
             if ($type === 'web_search_tool_result') {
-                foreach ($this->webSearchResultRows($block['content'] ?? null) as $row) {
-                    $returned[] = ['url' => $row['url'] ?? null, 'title' => $row['title'] ?? null];
+                // A failed search (e.g. max_uses_exceeded) still returns HTTP 200 with
+                // `content` set to a single web_search_tool_result_error object rather
+                // than a list of rows; its scalar members fail the is_array() test below.
+                foreach ((is_array($block['content'] ?? null) ? $block['content'] : []) as $row) {
+                    if (is_array($row) && ($row['type'] ?? null) === 'web_search_result') {
+                        $returned[] = ['url' => $row['url'] ?? null, 'title' => $row['title'] ?? null];
+                    }
                 }
                 continue;
             }
@@ -222,33 +232,11 @@ class Anthropic extends AIProvider
 
         return WebSearchUsage::fromProviderData(
             array_merge($cited, $returned),
-            is_numeric($requestCount) ? (int) $requestCount : count($queries),
+            // Counted on the deduplicated queries so the fallback cannot exceed
+            // what getWebSearchQueries() reports.
+            is_numeric($requestCount) ? (int) $requestCount : count(array_unique($queries)),
             $queries
         );
-    }
-
-    /**
-     * The `web_search_result` rows of one result block. A failed search (for
-     * example `max_uses_exceeded`) still returns HTTP 200 with `content` set to a
-     * single `web_search_tool_result_error` object instead of a list of rows.
-     *
-     * @param mixed $content
-     * @return list<array<string, mixed>>
-     */
-    private function webSearchResultRows($content): array
-    {
-        if (!is_array($content) || ($content['type'] ?? null) === 'web_search_tool_result_error') {
-            return [];
-        }
-
-        $rows = [];
-        foreach ($content as $row) {
-            if (is_array($row) && ($row['type'] ?? null) === 'web_search_result') {
-                $rows[] = $row;
-            }
-        }
-
-        return $rows;
     }
 
     /**

--- a/plugins/AIProviders/Provider/Anthropic.php
+++ b/plugins/AIProviders/Provider/Anthropic.php
@@ -140,14 +140,10 @@ class Anthropic extends AIProvider
     }
 
     /**
-     * Concatenates every `text` block in order. The answer is not a single
+     * Assembles the answer from every `text` block in order. It is not a single
      * block: extended thinking puts a `thinking` block first, and web search
      * splits the prose around `server_tool_use`/`web_search_tool_result` blocks.
-     *
-     * Joined with nothing between them, because a grounded answer is split
-     * mid-sentence at a citation boundary and each fragment carries its own
-     * spacing. Inserting a separator would break the prose, and in JSON mode a
-     * newline landing inside a string value makes the response undecodable.
+     * Spacing across those gaps is handled by {@link appendAnswerText()}.
      *
      * @param mixed $content
      */
@@ -157,18 +153,26 @@ class Anthropic extends AIProvider
             return '';
         }
 
-        $texts = [];
+        $answer = '';
+        $atBoundary = false;
+
         foreach ($content as $block) {
             if (!is_array($block)) {
                 continue;
             }
 
             if (($block['type'] ?? null) === 'text' && is_string($block['text'] ?? null)) {
-                $texts[] = $block['text'];
+                $answer = $this->appendAnswerText($answer, $block['text'], $atBoundary);
+                $atBoundary = false;
+                continue;
             }
+
+            // A thinking, server_tool_use or web_search_tool_result block: the
+            // next text block starts a new sentence rather than continuing one.
+            $atBoundary = true;
         }
 
-        return implode('', $texts);
+        return $answer;
     }
 
     /**
@@ -229,12 +233,13 @@ class Anthropic extends AIProvider
         }
 
         $requestCount = $response['usage']['server_tool_use']['web_search_requests'] ?? null;
+        // Normalised first so the fallback count cannot exceed what
+        // getWebSearchQueries() lists back.
+        $queries = WebSearchUsage::normalizeQueries($queries);
 
         return WebSearchUsage::fromProviderData(
             array_merge($cited, $returned),
-            // Counted on the deduplicated queries so the fallback cannot exceed
-            // what getWebSearchQueries() reports.
-            is_numeric($requestCount) ? (int) $requestCount : count(array_unique($queries)),
+            is_numeric($requestCount) ? (int) $requestCount : count($queries),
             $queries
         );
     }

--- a/plugins/AIProviders/Provider/Anthropic.php
+++ b/plugins/AIProviders/Provider/Anthropic.php
@@ -16,6 +16,7 @@ use Piwik\Plugins\AIProviders\AIConversationResponse;
 use Piwik\Plugins\AIProviders\AIProviderResponse;
 use Piwik\Plugins\AIProviders\AIRequest;
 use Piwik\Plugins\AIProviders\CanonicalMessage;
+use Piwik\Plugins\AIProviders\WebSearchUsage;
 
 /**
  * @phpstan-import-type CanonicalMessageArray from CanonicalMessage
@@ -31,6 +32,19 @@ class Anthropic extends AIProvider
     // headroom keeps room for the visible answer on top of the thinking budget.
     private const THINKING_MIN_BUDGET = 1024;
     private const THINKING_OUTPUT_HEADROOM = 1024;
+
+    // Anthropic pins its server tools to a dated type. The basic version is used
+    // deliberately: later versions default `allowed_callers` to code execution,
+    // which turns one completion into a code-execution run.
+    private const WEB_SEARCH_TOOL_TYPE = 'web_search_20250305';
+    private const WEB_SEARCH_TOOL_NAME = 'web_search';
+
+    /**
+     * Searches allowed per grounded request. This is the cost cap: every search
+     * is billed as a server tool request on top of the retrieved page content,
+     * which lands in the prompt as input tokens.
+     */
+    private const WEB_SEARCH_MAX_USES = 5;
 
     public function __construct()
     {
@@ -54,6 +68,12 @@ class Anthropic extends AIProvider
 
     /**
      * Custom Anthropic chat completion method.
+     *
+     * With web search on, `stop_reason` can come back as `pause_turn`: Anthropic
+     * ended the turn mid-search and expects the message to be sent back to
+     * resume. This method is deliberately single-round-trip, so the reason is
+     * passed through unchanged and the partial answer is returned.
+     *
      * @see https://platform.claude.com/docs/en/api/messages/create
      * @param array<string, string> $configuration
      */
@@ -75,6 +95,16 @@ class Anthropic extends AIProvider
 
         $this->applyThinking($payload, $request);
 
+        if ($this->wantsWebSearch($request)) {
+            // No tool_choice: it defaults to "auto", so Claude decides whether the
+            // prompt needs fresh sources and an unnecessary search is not paid for.
+            $payload['tools'] = [[
+                'type' => self::WEB_SEARCH_TOOL_TYPE,
+                'name' => self::WEB_SEARCH_TOOL_NAME,
+                'max_uses' => self::WEB_SEARCH_MAX_USES,
+            ]];
+        }
+
         $systemPrompt = $this->getSystemPrompt($request);
         if ($systemPrompt !== null && $systemPrompt !== '') {
             $payload['system'] = $systemPrompt;
@@ -86,10 +116,11 @@ class Anthropic extends AIProvider
                 'anthropic-version' => self::ANTHROPIC_VERSION,
                 'x-api-key' => $this->getApiKey($configuration),
             ],
-            $payload
+            $payload,
+            $this->completionTimeoutSeconds($request)
         );
 
-        $text = $this->getFirstTextBlock($response['content'] ?? []);
+        $text = $this->concatenateTextBlocks($response['content'] ?? []);
         $stopReason = is_string($response['stop_reason'] ?? null) ? $response['stop_reason'] : null;
 
         return $this->buildResponse(
@@ -98,32 +129,126 @@ class Anthropic extends AIProvider
             $text,
             isset($response['usage']['input_tokens']) ? (int) $response['usage']['input_tokens'] : null,
             isset($response['usage']['output_tokens']) ? (int) $response['usage']['output_tokens'] : null,
-            $stopReason
+            $stopReason,
+            $this->parseWebSearchUsage($request, $response)
         );
     }
 
+    public function supportsWebSearch(): bool
+    {
+        return true;
+    }
+
     /**
-     * With thinking enabled, anthropic returns the text block at a different index.
+     * Concatenates every `text` block in order. The answer is not a single
+     * block: extended thinking puts a `thinking` block first, and web search
+     * splits the prose around `server_tool_use`/`web_search_tool_result` blocks.
      *
      * @param mixed $content
      */
-    private function getFirstTextBlock($content): string
+    private function concatenateTextBlocks($content): string
     {
         if (!is_array($content)) {
             return '';
         }
 
+        $texts = [];
         foreach ($content as $block) {
             if (!is_array($block)) {
                 continue;
             }
 
             if (($block['type'] ?? null) === 'text' && is_string($block['text'] ?? null)) {
-                return $block['text'];
+                $texts[] = $block['text'];
             }
         }
 
-        return '';
+        return implode("\n", $texts);
+    }
+
+    /**
+     * Reads the grounding trail out of the message: queries from
+     * `server_tool_use` blocks, sources from `web_search_tool_result` rows and
+     * from the `web_search_result_location` citations on text blocks (cited ones
+     * first), and the search count from `usage.server_tool_use.web_search_requests`.
+     *
+     * @param array<string, mixed> $response
+     */
+    private function parseWebSearchUsage(AIRequest $request, array $response): WebSearchUsage
+    {
+        if (!$this->wantsWebSearch($request)) {
+            return WebSearchUsage::none();
+        }
+
+        $content = is_array($response['content'] ?? null) ? $response['content'] : [];
+
+        $queries = [];
+        $cited = [];
+        $returned = [];
+
+        foreach ($content as $block) {
+            if (!is_array($block)) {
+                continue;
+            }
+
+            $type = $block['type'] ?? null;
+
+            if ($type === 'server_tool_use' && ($block['name'] ?? null) === self::WEB_SEARCH_TOOL_NAME) {
+                $query = $block['input']['query'] ?? null;
+                if (is_string($query)) {
+                    $queries[] = $query;
+                }
+                continue;
+            }
+
+            if ($type === 'web_search_tool_result') {
+                foreach ($this->webSearchResultRows($block['content'] ?? null) as $row) {
+                    $returned[] = ['url' => $row['url'] ?? null, 'title' => $row['title'] ?? null];
+                }
+                continue;
+            }
+
+            if ($type === 'text' && is_array($block['citations'] ?? null)) {
+                foreach ($block['citations'] as $citation) {
+                    if (!is_array($citation) || ($citation['type'] ?? null) !== 'web_search_result_location') {
+                        continue;
+                    }
+                    $cited[] = ['url' => $citation['url'] ?? null, 'title' => $citation['title'] ?? null];
+                }
+            }
+        }
+
+        $requestCount = $response['usage']['server_tool_use']['web_search_requests'] ?? null;
+
+        return WebSearchUsage::fromProviderData(
+            array_merge($cited, $returned),
+            is_numeric($requestCount) ? (int) $requestCount : count($queries),
+            $queries
+        );
+    }
+
+    /**
+     * The `web_search_result` rows of one result block. A failed search (for
+     * example `max_uses_exceeded`) still returns HTTP 200 with `content` set to a
+     * single `web_search_tool_result_error` object instead of a list of rows.
+     *
+     * @param mixed $content
+     * @return list<array<string, mixed>>
+     */
+    private function webSearchResultRows($content): array
+    {
+        if (!is_array($content) || ($content['type'] ?? null) === 'web_search_tool_result_error') {
+            return [];
+        }
+
+        $rows = [];
+        foreach ($content as $row) {
+            if (is_array($row) && ($row['type'] ?? null) === 'web_search_result') {
+                $rows[] = $row;
+            }
+        }
+
+        return $rows;
     }
 
     /**

--- a/plugins/AIProviders/Provider/Bedrock.php
+++ b/plugins/AIProviders/Provider/Bedrock.php
@@ -42,9 +42,6 @@ class Bedrock extends AIProvider
     private const DEFAULT_REGION = 'us-east-1';
     private const DEFAULT_MODEL = 'openai.gpt-oss-120b-1:0';
 
-    /** Timeout for single-shot completions; conversations use the request's own budget. */
-    private const COMPLETE_TIMEOUT_SECONDS = 30;
-
     /** Exact Bedrock model ID fragments that support the gpt-oss reasoning_effort field. */
     private const GPT_OSS_MODEL_PATTERN = '/(?:^|[.\/])openai\.gpt-oss-(?:20b|120b)-1:0$/';
 
@@ -193,7 +190,7 @@ class Bedrock extends AIProvider
             ];
         }
 
-        $response = $this->sendConverseRequest($model, $payload, self::COMPLETE_TIMEOUT_SECONDS, $configuration);
+        $response = $this->sendConverseRequest($model, $payload, $this->completionTimeoutSeconds($request), $configuration);
 
         $stopReason = is_string($response['stopReason'] ?? null) ? $response['stopReason'] : null;
 

--- a/plugins/AIProviders/Provider/Google.php
+++ b/plugins/AIProviders/Provider/Google.php
@@ -16,6 +16,8 @@ use Piwik\Plugins\AIProviders\AIConversationResponse;
 use Piwik\Plugins\AIProviders\AIProviderResponse;
 use Piwik\Plugins\AIProviders\AIRequest;
 use Piwik\Plugins\AIProviders\CanonicalMessage;
+use Piwik\Plugins\AIProviders\WebSearchUsage;
+use Piwik\UrlHelper;
 
 /**
  * @phpstan-import-type CanonicalMessageArray from CanonicalMessage
@@ -25,6 +27,12 @@ use Piwik\Plugins\AIProviders\CanonicalMessage;
 class Google extends AIProvider
 {
     private const DEFAULT_MODEL = 'gemini-3.1-flash-lite';
+
+    /**
+     * Grounding chunk URIs point at Google's redirect service rather than the
+     * publisher, so this host must never be reported as a citation domain.
+     */
+    private const GROUNDING_REDIRECT_HOST = 'vertexaisearch.cloud.google.com';
 
     public function __construct()
     {
@@ -78,6 +86,13 @@ class Google extends AIProvider
             $payload['generationConfig']['responseMimeType'] = 'application/json';
         }
 
+        if ($this->wantsWebSearch($request)) {
+            // Google exposes no cap on how many searches grounding may run and no
+            // tool_choice: the model always decides. stdClass so this encodes as
+            // `{}`; an empty PHP array encodes as `[]`, which Google rejects.
+            $payload['tools'] = [['google_search' => new \stdClass()]];
+        }
+
         $systemPrompt = $this->getSystemPrompt($request);
         if ($systemPrompt !== null && $systemPrompt !== '') {
             $payload['systemInstruction'] = [
@@ -94,18 +109,123 @@ class Google extends AIProvider
             [
                 'x-goog-api-key' => $this->getApiKey($configuration),
             ],
-            $payload
+            $payload,
+            $this->completionTimeoutSeconds($request)
         );
-
-        $text = $response['candidates'][0]['content']['parts'][0]['text'] ?? '';
 
         return $this->buildResponse(
             $request,
             $model,
-            is_string($text) ? $text : '',
+            $this->concatenateTextParts($response['candidates'][0]['content']['parts'] ?? null),
             isset($response['usageMetadata']['promptTokenCount']) ? (int) $response['usageMetadata']['promptTokenCount'] : null,
-            isset($response['usageMetadata']['candidatesTokenCount']) ? (int) $response['usageMetadata']['candidatesTokenCount'] : null
+            isset($response['usageMetadata']['candidatesTokenCount']) ? (int) $response['usageMetadata']['candidatesTokenCount'] : null,
+            null,
+            $this->parseWebSearchUsage($request, $response)
         );
+    }
+
+    public function supportsWebSearch(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Concatenates every text part in order: a grounded candidate returns
+     * several, so reading `parts[0]` truncated the answer. Parts flagged
+     * `thought` are the reasoning summary, not the answer, and are skipped.
+     *
+     * @param mixed $parts
+     */
+    private function concatenateTextParts($parts): string
+    {
+        if (!is_array($parts)) {
+            return '';
+        }
+
+        $texts = [];
+        foreach ($parts as $part) {
+            if (!is_array($part) || !empty($part['thought'])) {
+                continue;
+            }
+
+            if (is_string($part['text'] ?? null)) {
+                $texts[] = $part['text'];
+            }
+        }
+
+        return implode("\n", $texts);
+    }
+
+    /**
+     * Reads `candidates[0].groundingMetadata`: the queries Google ran and one
+     * citation per grounding chunk. Google reports no search counter, so the
+     * count is derived from the number of queries.
+     *
+     * @param array<string, mixed> $response
+     */
+    private function parseWebSearchUsage(AIRequest $request, array $response): WebSearchUsage
+    {
+        if (!$this->wantsWebSearch($request)) {
+            return WebSearchUsage::none();
+        }
+
+        $metadata = $response['candidates'][0]['groundingMetadata'] ?? null;
+        if (!is_array($metadata)) {
+            return WebSearchUsage::fromProviderData([], 0, []);
+        }
+
+        $queries = [];
+        foreach ((is_array($metadata['webSearchQueries'] ?? null) ? $metadata['webSearchQueries'] : []) as $query) {
+            if (is_string($query)) {
+                $queries[] = $query;
+            }
+        }
+
+        $citations = [];
+        foreach ((is_array($metadata['groundingChunks'] ?? null) ? $metadata['groundingChunks'] : []) as $chunk) {
+            if (!is_array($chunk) || !is_array($chunk['web'] ?? null)) {
+                continue;
+            }
+
+            $citations[] = [
+                'url' => $chunk['web']['uri'] ?? null,
+                'title' => $chunk['web']['title'] ?? null,
+                'domain' => $this->groundingDomain($chunk['web']),
+            ];
+        }
+
+        return WebSearchUsage::fromProviderData($citations, count($queries), $queries);
+    }
+
+    /**
+     * Publisher host of a grounding chunk. Google's `web.uri` is a redirect whose
+     * host is Google's own, and in practice no `web.domain` is returned; the
+     * publisher host arrives as the bare `web.title` ("matomo.org"). Order:
+     * `web.domain` when present, the URI host unless it is the redirect
+     * service, then the title when it is a hostname rather than prose. '' when
+     * none yields one: a visible gap beats a guess a caller cannot tell from a
+     * real value.
+     *
+     * @param array<string, mixed> $web
+     */
+    private function groundingDomain(array $web): string
+    {
+        $domain = is_string($web['domain'] ?? null) ? trim($web['domain']) : '';
+        if ($domain !== '') {
+            return $domain;
+        }
+
+        $host = is_string($web['uri'] ?? null) ? (string) UrlHelper::getHostFromUrl($web['uri']) : '';
+        $redirectSuffix = '.' . self::GROUNDING_REDIRECT_HOST;
+        $isRedirect = $host === self::GROUNDING_REDIRECT_HOST
+            || substr($host, -strlen($redirectSuffix)) === $redirectSuffix;
+        if ($host !== '' && !$isRedirect) {
+            return $host;
+        }
+
+        $title = is_string($web['title'] ?? null) ? strtolower(trim($web['title'])) : '';
+
+        return preg_match('~^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$~', $title) === 1 ? $title : '';
     }
 
     /**

--- a/plugins/AIProviders/Provider/Google.php
+++ b/plugins/AIProviders/Provider/Google.php
@@ -16,6 +16,7 @@ use Piwik\Plugins\AIProviders\AIConversationResponse;
 use Piwik\Plugins\AIProviders\AIProviderResponse;
 use Piwik\Plugins\AIProviders\AIRequest;
 use Piwik\Plugins\AIProviders\CanonicalMessage;
+use Piwik\Plugins\AIProviders\Exception\AIProviderClientException;
 use Piwik\Plugins\AIProviders\WebSearchUsage;
 use Piwik\UrlHelper;
 
@@ -73,11 +74,18 @@ class Google extends AIProvider
 
     /**
      * Custom Google chat completion method.
+     *
+     * Grounding and JSON mode cannot be combined here, so the request is
+     * rejected rather than answered ungrounded; see
+     * {@link checkWebSearchIsUsable()}.
+     *
      * @see https://ai.google.dev/gemini-api/docs/text-generation
      * @param array<string, string> $configuration
      */
     public function complete(AIRequest $request, array $configuration): AIProviderResponse
     {
+        $this->checkWebSearchIsUsable($request);
+
         $model = $this->resolveModel($request);
 
         $payload = [
@@ -146,6 +154,29 @@ class Google extends AIProvider
     public function supportsWebSearch(): bool
     {
         return true;
+    }
+
+    /**
+     * Rejects the one grounded request Gemini cannot serve: with JSON mode on it
+     * accepts the search tool and then never searches, so the answer comes back
+     * ungrounded. Asking for JSON suppresses grounding both through
+     * `responseMimeType` and through the instruction {@link getSystemPrompt()}
+     * appends, so dropping either would not restore it.
+     *
+     * Thrown rather than degraded for the same reason
+     * {@link \Piwik\Plugins\AIProviders\AIProviderService::complete()} rejects a
+     * provider with no web search at all: a caller that asked for sources should
+     * not have to discover after paying that it never got any.
+     */
+    private function checkWebSearchIsUsable(AIRequest $request): void
+    {
+        if ($this->wantsWebSearch($request) && $request->isJsonResponse()) {
+            throw new AIProviderClientException(sprintf(
+                '%s cannot combine web search with JSON mode. Drop withJsonResponse() to keep the sources, '
+                . 'or withWebSearchEnabled() to keep the native JSON format.',
+                $this->getName()
+            ));
+        }
     }
 
     /**

--- a/plugins/AIProviders/Provider/Google.php
+++ b/plugins/AIProviders/Provider/Google.php
@@ -172,6 +172,12 @@ class Google extends AIProvider
             }
 
             if (empty($part['thought']) && is_string($part['text'] ?? null)) {
+                // An empty part is neither text nor a boundary: leave a pending
+                // boundary pending, so the next real fragment still gets its space.
+                if ($part['text'] === '') {
+                    continue;
+                }
+
                 $answer = $this->appendAnswerText($answer, $part['text'], $atBoundary);
                 $atBoundary = false;
                 continue;

--- a/plugins/AIProviders/Provider/Google.php
+++ b/plugins/AIProviders/Provider/Google.php
@@ -138,7 +138,12 @@ class Google extends AIProvider
             $this->completionTimeoutSeconds($request)
         );
 
-        $finishReason = $response['candidates'][0]['finishReason'] ?? null;
+        // Mapped through the same canonical vocabulary the conversation path uses,
+        // so `end_turn`/`max_tokens` mean the same thing whichever provider ran.
+        $finishReason = is_string($response['candidates'][0]['finishReason'] ?? null)
+            ? $response['candidates'][0]['finishReason']
+            : '';
+        $stopReason = $this->resolveStopReason([], $finishReason);
 
         return $this->buildResponse(
             $request,
@@ -146,7 +151,7 @@ class Google extends AIProvider
             $this->concatenateTextParts($response['candidates'][0]['content']['parts'] ?? null),
             isset($response['usageMetadata']['promptTokenCount']) ? (int) $response['usageMetadata']['promptTokenCount'] : null,
             isset($response['usageMetadata']['candidatesTokenCount']) ? (int) $response['usageMetadata']['candidatesTokenCount'] : null,
-            is_string($finishReason) && $finishReason !== '' ? $finishReason : null,
+            $stopReason !== '' ? $stopReason : null,
             $this->parseWebSearchUsage($request, $response)
         );
     }

--- a/plugins/AIProviders/Provider/Google.php
+++ b/plugins/AIProviders/Provider/Google.php
@@ -34,6 +34,21 @@ class Google extends AIProvider
      */
     private const GROUNDING_REDIRECT_HOST = 'vertexaisearch.cloud.google.com';
 
+    /**
+     * Final labels that make a dotted title a filename rather than a hostname.
+     * A shape check alone cannot tell `report.pdf` from `example.pdf`, and no
+     * hostname worth crediting ends in one of these.
+     *
+     * Deliberately a fixed list rather than a public suffix list: this only has
+     * to reject the handful of titles Google returns as filenames, and a wrong
+     * answer costs one bogus entry in a domain count.
+     */
+    private const NON_HOSTNAME_SUFFIXES = [
+        'pdf', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'txt', 'csv', 'rtf',
+        'html', 'htm', 'php', 'aspx', 'json', 'xml', 'zip', 'gz',
+        'jpg', 'jpeg', 'png', 'gif', 'svg', 'webp', 'mp3', 'mp4', 'mov',
+    ];
+
     public function __construct()
     {
         parent::__construct(
@@ -113,13 +128,15 @@ class Google extends AIProvider
             $this->completionTimeoutSeconds($request)
         );
 
+        $finishReason = $response['candidates'][0]['finishReason'] ?? null;
+
         return $this->buildResponse(
             $request,
             $model,
             $this->concatenateTextParts($response['candidates'][0]['content']['parts'] ?? null),
             isset($response['usageMetadata']['promptTokenCount']) ? (int) $response['usageMetadata']['promptTokenCount'] : null,
             isset($response['usageMetadata']['candidatesTokenCount']) ? (int) $response['usageMetadata']['candidatesTokenCount'] : null,
-            null,
+            is_string($finishReason) && $finishReason !== '' ? $finishReason : null,
             $this->parseWebSearchUsage($request, $response)
         );
     }
@@ -133,6 +150,10 @@ class Google extends AIProvider
      * Concatenates every text part in order: a grounded candidate returns
      * several, so reading `parts[0]` truncated the answer. Parts flagged
      * `thought` are the reasoning summary, not the answer, and are skipped.
+     *
+     * Joined with nothing between them: the parts split mid-sentence and carry
+     * their own spacing, and in JSON mode a separator inside a string value
+     * makes the response undecodable.
      *
      * @param mixed $parts
      */
@@ -153,7 +174,7 @@ class Google extends AIProvider
             }
         }
 
-        return implode("\n", $texts);
+        return implode('', $texts);
     }
 
     /**
@@ -194,17 +215,18 @@ class Google extends AIProvider
             ];
         }
 
-        return WebSearchUsage::fromProviderData($citations, count($queries), $queries);
+        // Counted on the deduplicated queries so it cannot exceed what
+        // getWebSearchQueries() reports.
+        return WebSearchUsage::fromProviderData($citations, count(array_unique($queries)), $queries);
     }
 
     /**
-     * Publisher host of a grounding chunk. Google's `web.uri` is a redirect whose
-     * host is Google's own, and in practice no `web.domain` is returned; the
-     * publisher host arrives as the bare `web.title` ("matomo.org"). Order:
-     * `web.domain` when present, the URI host unless it is the redirect
-     * service, then the title when it is a hostname rather than prose. '' when
-     * none yields one: a visible gap beats a guess a caller cannot tell from a
-     * real value.
+     * Publisher host of a grounding chunk, or '' when nothing yields one, which
+     * a caller can see rather than mistake for a real value.
+     *
+     * `web.uri` is a redirect whose host is Google's own, and in practice no
+     * `web.domain` comes back: the publisher host arrives as the bare
+     * `web.title` ("matomo.org"), so the title is sniffed for a hostname shape.
      *
      * @param array<string, mixed> $web
      */
@@ -223,9 +245,22 @@ class Google extends AIProvider
             return $host;
         }
 
-        $title = is_string($web['title'] ?? null) ? strtolower(trim($web['title'])) : '';
+        // Requires an alphabetic final label, so a version ("1.2") is not
+        // mistaken for a hostname. Case and any `www.` are normalised by
+        // WebSearchUsage.
+        $title = is_string($web['title'] ?? null) ? trim($web['title']) : '';
+        $isHostname = preg_match(
+            '~^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*\.[a-z]{2,}$~i',
+            $title
+        ) === 1;
 
-        return preg_match('~^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$~', $title) === 1 ? $title : '';
+        if (!$isHostname) {
+            return '';
+        }
+
+        $suffix = strtolower(substr($title, (int) strrpos($title, '.') + 1));
+
+        return in_array($suffix, self::NON_HOSTNAME_SUFFIXES, true) ? '' : $title;
     }
 
     /**

--- a/plugins/AIProviders/Provider/Google.php
+++ b/plugins/AIProviders/Provider/Google.php
@@ -41,12 +41,14 @@ class Google extends AIProvider
      *
      * Deliberately a fixed list rather than a public suffix list: this only has
      * to reject the handful of titles Google returns as filenames, and a wrong
-     * answer costs one bogus entry in a domain count.
+     * answer costs one bogus entry in a domain count. Extensions that are also
+     * real top-level domains (`zip`, `mov`) are left out, so a genuine domain is
+     * never discarded.
      */
     private const NON_HOSTNAME_SUFFIXES = [
         'pdf', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'txt', 'csv', 'rtf',
-        'html', 'htm', 'php', 'aspx', 'json', 'xml', 'zip', 'gz',
-        'jpg', 'jpeg', 'png', 'gif', 'svg', 'webp', 'mp3', 'mp4', 'mov',
+        'html', 'htm', 'php', 'aspx', 'json', 'xml', 'gz',
+        'jpg', 'jpeg', 'png', 'gif', 'svg', 'webp', 'mp3', 'mp4',
     ];
 
     public function __construct()
@@ -147,13 +149,11 @@ class Google extends AIProvider
     }
 
     /**
-     * Concatenates every text part in order: a grounded candidate returns
-     * several, so reading `parts[0]` truncated the answer. Parts flagged
-     * `thought` are the reasoning summary, not the answer, and are skipped.
-     *
-     * Joined with nothing between them: the parts split mid-sentence and carry
-     * their own spacing, and in JSON mode a separator inside a string value
-     * makes the response undecodable.
+     * Assembles the answer from every text part in order: a grounded candidate
+     * returns several, so reading `parts[0]` truncated it. Parts flagged
+     * `thought` are the reasoning summary rather than the answer and are
+     * skipped, which is itself a boundary. Spacing across gaps is handled by
+     * {@link appendAnswerText()}.
      *
      * @param mixed $parts
      */
@@ -163,18 +163,24 @@ class Google extends AIProvider
             return '';
         }
 
-        $texts = [];
+        $answer = '';
+        $atBoundary = false;
+
         foreach ($parts as $part) {
-            if (!is_array($part) || !empty($part['thought'])) {
+            if (!is_array($part)) {
                 continue;
             }
 
-            if (is_string($part['text'] ?? null)) {
-                $texts[] = $part['text'];
+            if (empty($part['thought']) && is_string($part['text'] ?? null)) {
+                $answer = $this->appendAnswerText($answer, $part['text'], $atBoundary);
+                $atBoundary = false;
+                continue;
             }
+
+            $atBoundary = true;
         }
 
-        return implode('', $texts);
+        return $answer;
     }
 
     /**
@@ -215,9 +221,11 @@ class Google extends AIProvider
             ];
         }
 
-        // Counted on the deduplicated queries so it cannot exceed what
-        // getWebSearchQueries() reports.
-        return WebSearchUsage::fromProviderData($citations, count(array_unique($queries)), $queries);
+        // Google reports no search counter, so the count is the number of queries it
+        // ran. Normalised first so it cannot exceed what getWebSearchQueries() lists.
+        $queries = WebSearchUsage::normalizeQueries($queries);
+
+        return WebSearchUsage::fromProviderData($citations, count($queries), $queries);
     }
 
     /**

--- a/plugins/AIProviders/Provider/OpenAI.php
+++ b/plugins/AIProviders/Provider/OpenAI.php
@@ -26,6 +26,14 @@ class OpenAI extends AIProvider
     private const REASONING_EFFORT_THINKING = 'medium';
 
     /**
+     * Chat-completions `finish_reason` values. The grounded path runs against the
+     * Responses API, which names the same outcomes differently, and reports these
+     * so a caller reads one vocabulary per provider.
+     */
+    private const FINISH_REASON_STOP = 'stop';
+    private const FINISH_REASON_LENGTH = 'length';
+
+    /**
      * How much retrieved page content a search may pull into the prompt
      * (`low`/`medium`/`high`). OpenAI's own default; it is also the cost knob,
      * since search content is billed as input tokens on top of the per-call fee.
@@ -125,19 +133,45 @@ class OpenAI extends AIProvider
             }
         }
 
-        // `incomplete_details.reason` is the specific outcome (e.g. max_output_tokens);
-        // `status` the generic one.
-        $stopReason = $response['incomplete_details']['reason'] ?? $response['status'] ?? null;
-
         return $this->buildResponse(
             $request,
             $model,
             $this->extractResponsesText($outputItems),
             isset($response['usage']['input_tokens']) ? (int) $response['usage']['input_tokens'] : null,
             isset($response['usage']['output_tokens']) ? (int) $response['usage']['output_tokens'] : null,
-            is_string($stopReason) && $stopReason !== '' ? $stopReason : null,
+            $this->resolveResponsesStopReason($response),
             $this->parseWebSearchUsage($outputItems)
         );
+    }
+
+    /**
+     * Translates the Responses API outcome into the same stop reasons this
+     * provider's chat-completions path reports, so `getStopReason()` does not
+     * depend on whether the completion happened to be grounded.
+     *
+     * `incomplete_details.reason` is the specific outcome and wins over the
+     * generic `status`. Anything unrecognised (`failed`, `cancelled`) is passed
+     * through rather than flattened, since only the raw value says what went
+     * wrong.
+     *
+     * @param array<string, mixed> $response
+     */
+    private function resolveResponsesStopReason(array $response): ?string
+    {
+        $reason = $response['incomplete_details']['reason'] ?? $response['status'] ?? null;
+
+        if (!is_string($reason) || $reason === '') {
+            return null;
+        }
+
+        switch ($reason) {
+            case 'completed':
+                return self::FINISH_REASON_STOP;
+            case 'max_output_tokens':
+                return self::FINISH_REASON_LENGTH;
+            default:
+                return $reason;
+        }
     }
 
     /**

--- a/plugins/AIProviders/Provider/OpenAI.php
+++ b/plugins/AIProviders/Provider/OpenAI.php
@@ -164,10 +164,24 @@ class OpenAI extends AIProvider
             }
 
             foreach ($item['content'] as $part) {
-                if (is_array($part) && ($part['type'] ?? null) === 'output_text' && is_string($part['text'] ?? null)) {
-                    $answer = $this->appendAnswerText($answer, $part['text'], $atBoundary);
-                    $atBoundary = false;
+                $text = is_array($part) && ($part['type'] ?? null) === 'output_text' && is_string($part['text'] ?? null)
+                    ? $part['text']
+                    : null;
+
+                if ($text === null) {
+                    // A refusal or any other part type: what follows is not a
+                    // continuation of the sentence before it.
+                    $atBoundary = true;
+                    continue;
                 }
+
+                // An empty part is neither text nor a boundary.
+                if ($text === '') {
+                    continue;
+                }
+
+                $answer = $this->appendAnswerText($answer, $text, $atBoundary);
+                $atBoundary = false;
             }
 
             // The next message is separate prose, not a continuation.

--- a/plugins/AIProviders/Provider/OpenAI.php
+++ b/plugins/AIProviders/Provider/OpenAI.php
@@ -112,7 +112,7 @@ class OpenAI extends AIProvider
         ];
 
         $response = $this->sendJsonRequest(
-            $this->getResponsesEndpoint($this->getEndpointUrl($configuration)),
+            $this->openAiCompatibleEndpoint($this->getEndpointUrl($configuration), 'responses'),
             ['Authorization' => 'Bearer ' . $this->getApiKey($configuration)],
             $payload,
             $this->completionTimeoutSeconds($request)
@@ -141,39 +141,39 @@ class OpenAI extends AIProvider
     }
 
     /**
-     * Derives the Responses endpoint from the configured chat completions
-     * endpoint, so one configured URL serves both entry points.
-     */
-    private function getResponsesEndpoint(string $chatEndpointUrl): string
-    {
-        $base = preg_replace('#/chat/completions/?$#', '', $chatEndpointUrl) ?? $chatEndpointUrl;
-
-        return rtrim($base, '/') . '/responses';
-    }
-
-    /**
      * Concatenates the `output_text` parts of every `message` item. The output
      * is a typed item list (`reasoning`, `web_search_call`, `message`, …) and a
      * grounded answer can span several `message` items.
+     *
+     * Parts within one message are joined with nothing between them, because a
+     * grounded answer splits mid-sentence at a citation boundary and each part
+     * carries its own spacing; a separator there would break the prose, and in
+     * JSON mode a newline inside a string value makes the response undecodable.
+     * Separate messages are distinct blocks of prose and keep a newline.
      *
      * @param list<array<string, mixed>> $outputItems
      */
     private function extractResponsesText(array $outputItems): string
     {
-        $texts = [];
+        $messages = [];
         foreach ($outputItems as $item) {
             if (($item['type'] ?? null) !== 'message' || !is_array($item['content'] ?? null)) {
                 continue;
             }
 
+            $parts = [];
             foreach ($item['content'] as $part) {
                 if (is_array($part) && ($part['type'] ?? null) === 'output_text' && is_string($part['text'] ?? null)) {
-                    $texts[] = $part['text'];
+                    $parts[] = $part['text'];
                 }
+            }
+
+            if ($parts !== []) {
+                $messages[] = implode('', $parts);
             }
         }
 
-        return implode("\n", $texts);
+        return implode("\n", $messages);
     }
 
     /**
@@ -193,7 +193,13 @@ class OpenAI extends AIProvider
             $type = $item['type'] ?? null;
 
             if ($type === 'web_search_call') {
-                $searchCalls++;
+                // Reasoning models emit open_page and find_in_page actions on this
+                // same item type. Those are follow-ups within a search, not new
+                // billed searches, so counting them would overstate the fee.
+                $action = $item['action']['type'] ?? null;
+                if ($action === null || $action === 'search') {
+                    $searchCalls++;
+                }
                 if (is_string($item['action']['query'] ?? null)) {
                     $queries[] = $item['action']['query'];
                 }

--- a/plugins/AIProviders/Provider/OpenAI.php
+++ b/plugins/AIProviders/Provider/OpenAI.php
@@ -15,10 +15,22 @@ use Piwik\Plugins\AIProviders\AIConversationRequest;
 use Piwik\Plugins\AIProviders\AIConversationResponse;
 use Piwik\Plugins\AIProviders\AIProviderResponse;
 use Piwik\Plugins\AIProviders\AIRequest;
+use Piwik\Plugins\AIProviders\WebSearchUsage;
 
 class OpenAI extends AIProvider
 {
     private const DEFAULT_MODEL = 'gpt-5.4-mini';
+
+    /** gpt-5 reasoning levels: off for instant answers, medium for thinking. */
+    private const REASONING_EFFORT_NONE = 'none';
+    private const REASONING_EFFORT_THINKING = 'medium';
+
+    /**
+     * How much retrieved page content a search may pull into the prompt
+     * (`low`/`medium`/`high`). OpenAI's own default; it is also the cost knob,
+     * since search content is billed as input tokens on top of the per-call fee.
+     */
+    private const WEB_SEARCH_CONTEXT_SIZE = 'medium';
 
     public function __construct()
     {
@@ -36,15 +48,172 @@ class OpenAI extends AIProvider
     }
 
     /**
+     * Ungrounded completions use Chat Completions; grounded ones the Responses
+     * API, because the hosted `web_search` tool only exists there (on chat
+     * completions it requires the separate `gpt-5-search-api` model).
+     *
      * @param array<string, string> $configuration
      */
     public function complete(AIRequest $request, array $configuration): AIProviderResponse
     {
+        if ($this->wantsWebSearch($request)) {
+            return $this->completeGroundedResponse($request, $configuration);
+        }
+
         return $this->completeChatCompletion(
             $request,
             $this->getEndpointUrl($configuration),
             ['Authorization' => 'Bearer ' . $this->getApiKey($configuration)]
         );
+    }
+
+    public function supportsWebSearch(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Runs a grounded completion against `/v1/responses` with the `web_search`
+     * tool offered. No `tool_choice`: it defaults to auto, so the model decides
+     * whether the prompt needs fresh sources and an unnecessary search is not
+     * paid for.
+     *
+     * JSON mode is degraded here: OpenAI rejects `text.format` together with web
+     * search ("Web Search cannot be used with JSON mode"), so only the JSON
+     * instruction {@link getSystemPrompt()} adds to the prompt remains.
+     *
+     * @see https://platform.openai.com/docs/api-reference/responses
+     * @param array<string, string> $configuration
+     */
+    private function completeGroundedResponse(AIRequest $request, array $configuration): AIProviderResponse
+    {
+        $model = $this->resolveModel($request);
+
+        $input = [];
+        $systemPrompt = $this->getSystemPrompt($request);
+        if ($systemPrompt !== null && $systemPrompt !== '') {
+            // `developer` is the Responses-API role that replaces `system`.
+            $input[] = ['role' => 'developer', 'content' => $systemPrompt];
+        }
+        $input[] = ['role' => 'user', 'content' => $request->getUserPrompt()];
+
+        $payload = [
+            'model' => $model,
+            'input' => $input,
+            'max_output_tokens' => $request->getMaxTokens(),
+            'reasoning' => [
+                'effort' => $this->wantsThinking($request) ? self::REASONING_EFFORT_THINKING : self::REASONING_EFFORT_NONE,
+            ],
+            'tools' => [['type' => 'web_search', 'search_context_size' => self::WEB_SEARCH_CONTEXT_SIZE]],
+            // Unlike chat completions, the Responses API retains requests and
+            // output server-side (~30 days) by default. Matomo prompts carry site
+            // names, URLs and report data, so storage is switched off explicitly.
+            'store' => false,
+        ];
+
+        $response = $this->sendJsonRequest(
+            $this->getResponsesEndpoint($this->getEndpointUrl($configuration)),
+            ['Authorization' => 'Bearer ' . $this->getApiKey($configuration)],
+            $payload,
+            $this->completionTimeoutSeconds($request)
+        );
+
+        $outputItems = [];
+        foreach ((is_array($response['output'] ?? null) ? $response['output'] : []) as $item) {
+            if (is_array($item)) {
+                $outputItems[] = $item;
+            }
+        }
+
+        // `incomplete_details.reason` is the specific outcome (e.g. max_output_tokens);
+        // `status` the generic one.
+        $stopReason = $response['incomplete_details']['reason'] ?? $response['status'] ?? null;
+
+        return $this->buildResponse(
+            $request,
+            $model,
+            $this->extractResponsesText($outputItems),
+            isset($response['usage']['input_tokens']) ? (int) $response['usage']['input_tokens'] : null,
+            isset($response['usage']['output_tokens']) ? (int) $response['usage']['output_tokens'] : null,
+            is_string($stopReason) && $stopReason !== '' ? $stopReason : null,
+            $this->parseWebSearchUsage($outputItems)
+        );
+    }
+
+    /**
+     * Derives the Responses endpoint from the configured chat completions
+     * endpoint, so one configured URL serves both entry points.
+     */
+    private function getResponsesEndpoint(string $chatEndpointUrl): string
+    {
+        $base = preg_replace('#/chat/completions/?$#', '', $chatEndpointUrl) ?? $chatEndpointUrl;
+
+        return rtrim($base, '/') . '/responses';
+    }
+
+    /**
+     * Concatenates the `output_text` parts of every `message` item. The output
+     * is a typed item list (`reasoning`, `web_search_call`, `message`, …) and a
+     * grounded answer can span several `message` items.
+     *
+     * @param list<array<string, mixed>> $outputItems
+     */
+    private function extractResponsesText(array $outputItems): string
+    {
+        $texts = [];
+        foreach ($outputItems as $item) {
+            if (($item['type'] ?? null) !== 'message' || !is_array($item['content'] ?? null)) {
+                continue;
+            }
+
+            foreach ($item['content'] as $part) {
+                if (is_array($part) && ($part['type'] ?? null) === 'output_text' && is_string($part['text'] ?? null)) {
+                    $texts[] = $part['text'];
+                }
+            }
+        }
+
+        return implode("\n", $texts);
+    }
+
+    /**
+     * Counts `web_search_call` items and collects the `url_citation`
+     * annotations on the answer's `output_text` parts. OpenAI does not always
+     * echo the query it searched for, so queries can be empty when searches ran.
+     *
+     * @param list<array<string, mixed>> $outputItems
+     */
+    private function parseWebSearchUsage(array $outputItems): WebSearchUsage
+    {
+        $searchCalls = 0;
+        $queries = [];
+        $citations = [];
+
+        foreach ($outputItems as $item) {
+            $type = $item['type'] ?? null;
+
+            if ($type === 'web_search_call') {
+                $searchCalls++;
+                if (is_string($item['action']['query'] ?? null)) {
+                    $queries[] = $item['action']['query'];
+                }
+                continue;
+            }
+
+            if ($type !== 'message' || !is_array($item['content'] ?? null)) {
+                continue;
+            }
+
+            foreach ($item['content'] as $part) {
+                foreach ((is_array($part['annotations'] ?? null) ? $part['annotations'] : []) as $annotation) {
+                    if (is_array($annotation) && ($annotation['type'] ?? null) === 'url_citation') {
+                        $citations[] = ['url' => $annotation['url'] ?? null, 'title' => $annotation['title'] ?? null];
+                    }
+                }
+            }
+        }
+
+        return WebSearchUsage::fromProviderData($citations, $searchCalls, $queries);
     }
 
     /**
@@ -74,7 +243,7 @@ class OpenAI extends AIProvider
      */
     protected function getExtraChatCompletionPayload(AIRequest $request): array
     {
-        return ['reasoning_effort' => $this->wantsThinking($request) ? 'medium' : 'none'];
+        return ['reasoning_effort' => $this->wantsThinking($request) ? self::REASONING_EFFORT_THINKING : self::REASONING_EFFORT_NONE];
     }
 
     /**

--- a/plugins/AIProviders/Provider/OpenAI.php
+++ b/plugins/AIProviders/Provider/OpenAI.php
@@ -141,39 +141,40 @@ class OpenAI extends AIProvider
     }
 
     /**
-     * Concatenates the `output_text` parts of every `message` item. The output
-     * is a typed item list (`reasoning`, `web_search_call`, `message`, …) and a
-     * grounded answer can span several `message` items.
+     * Assembles the answer from the `output_text` parts of every `message` item.
+     * The output is a typed item list (`reasoning`, `web_search_call`,
+     * `message`, …) and a grounded answer can span several `message` items.
      *
-     * Parts within one message are joined with nothing between them, because a
-     * grounded answer splits mid-sentence at a citation boundary and each part
-     * carries its own spacing; a separator there would break the prose, and in
-     * JSON mode a newline inside a string value makes the response undecodable.
-     * Separate messages are distinct blocks of prose and keep a newline.
+     * Parts of one message continue a sentence; a new message, or any other item
+     * between them, starts one. Spacing across both is handled by
+     * {@link appendAnswerText()}, which never inserts a newline, so a boundary
+     * falling inside a JSON string value cannot make the answer undecodable.
      *
      * @param list<array<string, mixed>> $outputItems
      */
     private function extractResponsesText(array $outputItems): string
     {
-        $messages = [];
+        $answer = '';
+        $atBoundary = false;
+
         foreach ($outputItems as $item) {
             if (($item['type'] ?? null) !== 'message' || !is_array($item['content'] ?? null)) {
+                $atBoundary = true;
                 continue;
             }
 
-            $parts = [];
             foreach ($item['content'] as $part) {
                 if (is_array($part) && ($part['type'] ?? null) === 'output_text' && is_string($part['text'] ?? null)) {
-                    $parts[] = $part['text'];
+                    $answer = $this->appendAnswerText($answer, $part['text'], $atBoundary);
+                    $atBoundary = false;
                 }
             }
 
-            if ($parts !== []) {
-                $messages[] = implode('', $parts);
-            }
+            // The next message is separate prose, not a continuation.
+            $atBoundary = true;
         }
 
-        return implode("\n", $messages);
+        return $answer;
     }
 
     /**

--- a/plugins/AIProviders/README.md
+++ b/plugins/AIProviders/README.md
@@ -130,6 +130,11 @@ provider rather than the one you asked for.
 not override that. A grounded request can come back with no search at all, so read
 `wasWebSearchUsed()` and `getWebSearchRequestCount()` on the response for what actually happened.
 
+Grounded answers arrive in fragments, which AIProviders reassembles: adjacent fragments are one
+sentence split at a citation boundary and are joined as-is, while a fragment after a tool block or a
+separate output message starts a new sentence and gets a single space. Never a newline, so a boundary
+falling inside a JSON string value cannot break `getJsonData()`.
+
 **Citation titles and queries are untrusted model output.** They are length-capped but otherwise
 verbatim, so escape them where you render them. URLs are guaranteed to be `http(s)`.
 

--- a/plugins/AIProviders/README.md
+++ b/plugins/AIProviders/README.md
@@ -95,7 +95,7 @@ When a managed environment forces a provider from configuration, the service als
     'inputTokens' => 42,                   // input/prompt tokens reported by the provider, or null
     'outputTokens' => 12,                  // output/completion tokens reported by the provider, or null
     'reasoningLevel' => 'none',            // reasoning level used
-    'webSearchEnabled' => false,           // whether provider-side web search actually ran
+    'webSearchUsed' => false,              // whether provider-side web search actually ran
     'webSearchRequestCount' => null,       // searches performed, or null when none ran / not reported
     'webSearchQueries' => [],              // queries the model issued, when the provider echoes them
     'webSearchCitations' => [],            // ['url' => …, 'title' => …, 'domain' => …] per source
@@ -113,7 +113,7 @@ $response = $service->complete(
     (new AIRequest($prompt, 'YourPlugin'))->withWebSearchEnabled(true)
 );
 
-if ($response->isWebSearchEnabled()) {
+if ($response->wasWebSearchUsed()) {
     foreach ($response->getWebSearchCitations() as $citation) {
         // $citation['url'], $citation['title'], $citation['domain']
     }
@@ -122,25 +122,34 @@ if ($response->isWebSearchEnabled()) {
 
 Supported by Anthropic, Google and OpenAI. Providers without a web search tool (AWS Bedrock, custom
 provider) reject the request with an `AIProviderClientException` rather than silently answering
-ungrounded; check `supportsWebSearch()` on the provider up front if you need to fall back.
+ungrounded. Call `$service->canUseWebSearch('YourPlugin')` first if you need to fall back: it answers
+for the provider `complete()` would actually resolve to, which on a managed instance is the forced
+provider rather than the one you asked for.
 
 **The model decides whether to search.** All three providers let the model choose, and AIProviders does
 not override that. A grounded request can come back with no search at all, so read
-`isWebSearchEnabled()` and `getWebSearchRequestCount()` on the response for what actually happened.
+`wasWebSearchUsed()` and `getWebSearchRequestCount()` on the response for what actually happened.
+
+**Citation titles and queries are untrusted model output.** They are length-capped but otherwise
+verbatim, so escape them where you render them. URLs are guaranteed to be `http(s)`.
 
 **Grounding is not a marginal cost.** Every provider charges per search, and the retrieved page content
 is billed as input tokens on top. Expect roughly 10-30x the cost of the same request ungrounded. The
 number of searches is capped on Anthropic (`max_uses`: 5) and the retrieved context on OpenAI
 (`search_context_size`: medium); Google exposes no cap at all.
 
-Grounded requests are slow (30-90s). The provider timeout defaults to 120s for them (30s otherwise);
-override with `withTimeoutSeconds()`.
+Grounded requests are slow (30-90s). The provider timeout defaults to 120s for them (30s otherwise).
+That exceeds PHP's default 30s `max_execution_time`, so **grounded completions are meant for CLI
+commands and scheduled tasks**, where it is unlimited. From a web request, either raise that limit
+yourself or lower the timeout with `withTimeoutSeconds()`, or the request dies before the provider
+answers. A retryable HTTP status also re-runs the searches, so it multiplies both the wall time and the
+per-search fees.
 
 Two provider-specific caveats:
 
 - **Google's citation URLs are not publisher URLs.** It returns a grounding redirect, so `url` is a
-  `vertexaisearch.cloud.google.com` link and only `domain` (taken from the chunk title, which Google
-  sets to the publisher host) identifies the publisher. Two sources from the same page therefore do
+  `vertexaisearch.cloud.google.com` link and only `domain`, taken from the chunk title which Google
+  sets to the publisher host, identifies the publisher. Two sources from the same page therefore do
   not deduplicate for Google: count distinct `domain`, not distinct `url`. When the title is not a
   hostname, `domain` is an empty string rather than a guess.
 - **Combining web search with JSON mode is degraded, not native.** OpenAI rejects the two together, so

--- a/plugins/AIProviders/README.md
+++ b/plugins/AIProviders/README.md
@@ -95,11 +95,57 @@ When a managed environment forces a provider from configuration, the service als
     'inputTokens' => 42,                   // input/prompt tokens reported by the provider, or null
     'outputTokens' => 12,                  // output/completion tokens reported by the provider, or null
     'reasoningLevel' => 'none',            // reasoning level used
-    'webSearchEnabled' => false,           // whether provider-side web search was used
+    'webSearchEnabled' => false,           // whether provider-side web search actually ran
+    'webSearchRequestCount' => null,       // searches performed, or null when none ran / not reported
+    'webSearchQueries' => [],              // queries the model issued, when the provider echoes them
+    'webSearchCitations' => [],            // ['url' => …, 'title' => …, 'domain' => …] per source
     'executionTimeMs' => 1234,             // total request time in milliseconds, including retries, or null
     'stopReason' => 'stop',                // provider stop reason, if available, or null
 ]
 ```
+
+### Web search (grounding)
+
+Ask the provider to search the web before answering, and read the sources it used:
+
+```php
+$response = $service->complete(
+    (new AIRequest($prompt, 'YourPlugin'))->withWebSearchEnabled(true)
+);
+
+if ($response->isWebSearchEnabled()) {
+    foreach ($response->getWebSearchCitations() as $citation) {
+        // $citation['url'], $citation['title'], $citation['domain']
+    }
+}
+```
+
+Supported by Anthropic, Google and OpenAI. Providers without a web search tool (AWS Bedrock, custom
+provider) reject the request with an `AIProviderClientException` rather than silently answering
+ungrounded; check `supportsWebSearch()` on the provider up front if you need to fall back.
+
+**The model decides whether to search.** All three providers let the model choose, and AIProviders does
+not override that. A grounded request can come back with no search at all, so read
+`isWebSearchEnabled()` and `getWebSearchRequestCount()` on the response for what actually happened.
+
+**Grounding is not a marginal cost.** Every provider charges per search, and the retrieved page content
+is billed as input tokens on top. Expect roughly 10-30x the cost of the same request ungrounded. The
+number of searches is capped on Anthropic (`max_uses`: 5) and the retrieved context on OpenAI
+(`search_context_size`: medium); Google exposes no cap at all.
+
+Grounded requests are slow (30-90s). The provider timeout defaults to 120s for them (30s otherwise);
+override with `withTimeoutSeconds()`.
+
+Two provider-specific caveats:
+
+- **Google's citation URLs are not publisher URLs.** It returns a grounding redirect, so `url` is a
+  `vertexaisearch.cloud.google.com` link and only `domain` (taken from the chunk title, which Google
+  sets to the publisher host) identifies the publisher. Two sources from the same page therefore do
+  not deduplicate for Google: count distinct `domain`, not distinct `url`. When the title is not a
+  hostname, `domain` is an empty string rather than a guess.
+- **Combining web search with JSON mode is degraded, not native.** OpenAI rejects the two together, so
+  `withJsonResponse()` on a grounded request relies on the prompt instruction alone; handle a `null`
+  from `getJsonData()`. Google accepts the combination but may not search at all in JSON mode.
 
 ### JSON mode
 

--- a/plugins/AIProviders/README.md
+++ b/plugins/AIProviders/README.md
@@ -104,6 +104,12 @@ When a managed environment forces a provider from configuration, the service als
 ]
 ```
 
+`stopReason` is the provider's own vocabulary, not a normalised one. Anthropic, AWS Bedrock and Google
+report `end_turn` / `max_tokens` (Google's `STOP` / `MAX_TOKENS` are mapped onto those, and `SAFETY` /
+`RECITATION` onto `guardrail_intervened`); OpenAI reports `stop` / `length` on both its grounded and
+ungrounded paths. Match against the values of the provider you resolved to, and pass unrecognised ones
+through rather than treating them as failures.
+
 ### Web search (grounding)
 
 Ask the provider to search the web before answering, and read the sources it used:

--- a/plugins/AIProviders/README.md
+++ b/plugins/AIProviders/README.md
@@ -139,27 +139,40 @@ falling inside a JSON string value cannot break `getJsonData()`.
 verbatim, so escape them where you render them. URLs are guaranteed to be `http(s)`.
 
 **Grounding is not a marginal cost.** Every provider charges per search, and the retrieved page content
-is billed as input tokens on top. Expect roughly 10-30x the cost of the same request ungrounded. The
-number of searches is capped on Anthropic (`max_uses`: 5) and the retrieved context on OpenAI
-(`search_context_size`: medium); Google exposes no cap at all.
+is billed as input tokens on top, so a grounded request costs a multiple of the same request
+ungrounded rather than a little more. The number of searches is capped on Anthropic (`max_uses`: 5)
+and the retrieved context on OpenAI (`search_context_size`: medium); Google exposes no cap at all.
 
 Grounded requests are slow (30-90s). The provider timeout defaults to 120s for them (30s otherwise).
-That exceeds PHP's default 30s `max_execution_time`, so **grounded completions are meant for CLI
-commands and scheduled tasks**, where it is unlimited. From a web request, either raise that limit
-yourself or lower the timeout with `withTimeoutSeconds()`, or the request dies before the provider
-answers. A retryable HTTP status also re-runs the searches, so it multiplies both the wall time and the
-per-search fees.
+That outlasts the default read timeout of every common web server and proxy in front of PHP (nginx
+`fastcgi_read_timeout` and Apache `Timeout` are both 60s), which cut the connection whatever PHP is
+configured to allow. So **grounded completions are meant for CLI commands and scheduled tasks**, which
+have nothing in front of them. From a web request, either raise those limits yourself or lower the
+timeout with `withTimeoutSeconds()`, or the connection dies before the provider answers. (PHP's own
+`max_execution_time` is the lesser worry: on non-Windows SAPIs it does not advance while a cURL
+transfer is waiting.) A retryable HTTP status also re-runs the searches, so it multiplies both the wall
+time and the per-search fees.
 
-Two provider-specific caveats:
+Four provider-specific caveats:
 
 - **Google's citation URLs are not publisher URLs.** It returns a grounding redirect, so `url` is a
   `vertexaisearch.cloud.google.com` link and only `domain`, taken from the chunk title which Google
   sets to the publisher host, identifies the publisher. Two sources from the same page therefore do
   not deduplicate for Google: count distinct `domain`, not distinct `url`. When the title is not a
   hostname, `domain` is an empty string rather than a guess.
-- **Combining web search with JSON mode is degraded, not native.** OpenAI rejects the two together, so
-  `withJsonResponse()` on a grounded request relies on the prompt instruction alone; handle a `null`
-  from `getJsonData()`. Google accepts the combination but may not search at all in JSON mode.
+- **On OpenAI, combining web search with JSON mode is degraded, not native.** OpenAI rejects
+  `text.format` together with web search, so `withJsonResponse()` on a grounded request relies on the
+  prompt instruction alone; handle a `null` from `getJsonData()`. The search itself still runs.
+- **On Google, web search and JSON mode cannot combine at all, so the request is rejected** with an
+  `AIProviderClientException`. Gemini would accept it and then answer without searching. Verified
+  against `gemini-3.1-flash-lite`: asking for JSON suppresses grounding two independent ways, through
+  `responseMimeType: application/json` and through the JSON instruction `withJsonResponse()` adds to
+  the prompt, so dropping either one does not restore it. Drop one of the two calls; `canUseWebSearch()`
+  cannot warn you, because it does not see the request.
+- **Anthropic can pause mid-search.** With several searches to run it may end the turn early and expect
+  the message back to resume. AIProviders is deliberately single-round-trip, so the partial answer is
+  returned as-is with `getStopReason()` reporting `pause_turn`. Check it before treating a grounded
+  Anthropic answer as complete.
 
 ### JSON mode
 

--- a/plugins/AIProviders/WebSearchUsage.php
+++ b/plugins/AIProviders/WebSearchUsage.php
@@ -1,0 +1,227 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+declare(strict_types=1);
+
+namespace Piwik\Plugins\AIProviders;
+
+use Piwik\UrlHelper;
+
+/**
+ * Normalised record of what a provider's server-side web search actually did
+ * for one completion: the web sources attached to the answer, how many searches
+ * ran, and the queries the model issued.
+ *
+ * The providers report grounding in three incompatible shapes — Anthropic uses
+ * `server_tool_use`/`web_search_tool_result` blocks plus per-text-block
+ * citations, Google a `groundingMetadata` object, OpenAI typed output items
+ * carrying `url_citation` annotations. This plugin owns the translation so a
+ * caller reads one shape and can switch providers without changing its code.
+ *
+ * What that flattening hides, so callers know what they are reading:
+ *
+ * - Anthropic reports both cited sources and every returned search result, so
+ *   citations list the cited ones first. `requestCount` is Anthropic's own
+ *   counter.
+ * - Google reports every retrieved grounding chunk and draws no cited/uncited
+ *   distinction. Its `url` is the Vertex AI Search redirect Google returns,
+ *   *not* the publisher URL — the publisher host is in `domain`. Google has no
+ *   search counter, so `requestCount` is derived from the number of queries.
+ * - OpenAI reports cited sources only. `requestCount` counts its
+ *   `web_search_call` items, and `queries` can be empty even when searches ran,
+ *   because OpenAI does not always echo the query it used.
+ *
+ * A consequence worth knowing before computing shares: "citations" is not the
+ * same denominator on all three providers, and because Google's URLs are
+ * per-chunk redirects, two chunks from one publisher page do not collapse
+ * during deduplication. Count distinct `domain` rather than distinct `url` when
+ * the question is "how many sources".
+ *
+ * @phpstan-type WebSearchCitationArray array{url: string, title: string, domain: string}
+ */
+final class WebSearchUsage
+{
+    /**
+     * @var list<WebSearchCitationArray>
+     */
+    private $citations;
+
+    /**
+     * @var int|null
+     */
+    private $requestCount;
+
+    /**
+     * @var list<string>
+     */
+    private $queries;
+
+    /**
+     * @param list<WebSearchCitationArray> $citations
+     * @param list<string> $queries
+     */
+    private function __construct(array $citations, ?int $requestCount, array $queries)
+    {
+        $this->citations = $citations;
+        $this->requestCount = $requestCount;
+        $this->queries = $queries;
+    }
+
+    /**
+     * No search ran: it was not requested, or the provider has no web search to
+     * offer. This is what every ungrounded completion reports, so callers get a
+     * consistent object instead of a null check.
+     */
+    public static function none(): self
+    {
+        return new self([], null, []);
+    }
+
+    /**
+     * Normalises one provider's parsed grounding data.
+     *
+     * Citations are filtered to http(s) URLs and deduplicated by URL keeping the
+     * first occurrence (providers list the most relevant first).
+     *
+     * The `domain` key decides who owns domain resolution, and the distinction
+     * matters: when a citation omits the key entirely the domain is derived from
+     * the URL host, but when the key is present it is trusted verbatim — even
+     * when empty. Google needs that, because its URL is a redirect whose host is
+     * Google's own: deriving from the URL there would label every source
+     * `vertexaisearch.cloud.google.com`, and an empty string is Google's honest
+     * "no trustworthy publisher domain for this chunk". Anthropic and OpenAI omit
+     * the key and get the derived host.
+     *
+     * @param list<array{url?: mixed, title?: mixed, domain?: mixed}> $citations
+     * @param int|null $requestCount Provider-reported search count, or null when it reports none.
+     * @param list<string> $queries
+     */
+    public static function fromProviderData(array $citations, ?int $requestCount, array $queries): self
+    {
+        $normalized = [];
+        $seenUrls = [];
+
+        foreach ($citations as $citation) {
+            $url = is_string($citation['url'] ?? null) ? trim($citation['url']) : '';
+            if (!self::isUsableUrl($url) || isset($seenUrls[$url])) {
+                continue;
+            }
+            $seenUrls[$url] = true;
+
+            if (array_key_exists('domain', $citation)) {
+                $domain = is_string($citation['domain']) ? self::normalizeHost($citation['domain']) : '';
+            } else {
+                $domain = self::hostFromUrl($url);
+            }
+
+            $normalized[] = [
+                'url' => $url,
+                'title' => is_string($citation['title'] ?? null) ? trim($citation['title']) : '',
+                'domain' => $domain,
+            ];
+        }
+
+        $normalizedQueries = [];
+        foreach ($queries as $query) {
+            $query = trim($query);
+            if ($query !== '' && !in_array($query, $normalizedQueries, true)) {
+                $normalizedQueries[] = $query;
+            }
+        }
+
+        return new self($normalized, $requestCount, $normalizedQueries);
+    }
+
+    /**
+     * @return list<WebSearchCitationArray>
+     */
+    public function getCitations(): array
+    {
+        return $this->citations;
+    }
+
+    /**
+     * Number of searches the provider ran, or null when it reports none. Google
+     * has no counter, so its value is derived from the query count.
+     */
+    public function getRequestCount(): ?int
+    {
+        return $this->requestCount;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getQueries(): array
+    {
+        return $this->queries;
+    }
+
+    /**
+     * Whether search demonstrably ran. Any positive evidence counts, because the
+     * providers disagree on what they report: a model can search and cite
+     * nothing (Anthropic still counts the request), cite without echoing a query
+     * (OpenAI), or report a query whose chunk yielded no usable URL (Google).
+     * Reporting false in those cases would hide spend that actually happened.
+     */
+    public function wasUsed(): bool
+    {
+        return $this->citations !== []
+            || $this->queries !== []
+            || ($this->requestCount !== null && $this->requestCount > 0);
+    }
+
+    /**
+     * @return array{citations: list<WebSearchCitationArray>, requestCount: int|null, queries: list<string>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'citations' => $this->citations,
+            'requestCount' => $this->requestCount,
+            'queries' => $this->queries,
+        ];
+    }
+
+    /**
+     * Rejects anything that is not an http(s) URL. Citation URLs are
+     * model-controlled data that callers will render as links, so a
+     * `javascript:` or `data:` scheme must never leave this plugin.
+     */
+    private static function isUsableUrl(string $url): bool
+    {
+        return preg_match('~^https?://~i', $url) === 1 && self::hostFromUrl($url) !== '';
+    }
+
+    /**
+     * Publisher host of a URL, or '' when it carries none.
+     */
+    private static function hostFromUrl(string $url): string
+    {
+        $host = UrlHelper::getHostFromUrl($url);
+
+        return is_string($host) ? self::normalizeHost($host) : '';
+    }
+
+    /**
+     * Normalises a hostname for grouping and display: lowercased, trailing dot
+     * and leading `www.` stripped, matching how callers normalise their own
+     * configured domains so both sides compare equal.
+     */
+    private static function normalizeHost(string $host): string
+    {
+        $host = strtolower(rtrim(trim($host), '.'));
+
+        if (strpos($host, 'www.') === 0) {
+            $host = substr($host, 4);
+        }
+
+        return $host;
+    }
+}

--- a/plugins/AIProviders/WebSearchUsage.php
+++ b/plugins/AIProviders/WebSearchUsage.php
@@ -126,15 +126,31 @@ final class WebSearchUsage
             ];
         }
 
-        $normalizedQueries = [];
+        return new self($normalized, $requestCount, self::normalizeQueries($queries));
+    }
+
+    /**
+     * Trims, drops empties and deduplicates a provider's reported queries.
+     *
+     * Public because Google and Anthropic derive their search count from the
+     * number of queries, and counting the raw list would report more searches
+     * than {@link getQueries()} lists back.
+     *
+     * @param list<string> $queries
+     * @return list<string>
+     */
+    public static function normalizeQueries(array $queries): array
+    {
+        $normalized = [];
+
         foreach ($queries as $query) {
             $query = self::cap(trim($query), self::MAX_QUERY_LENGTH);
-            if ($query !== '' && !in_array($query, $normalizedQueries, true)) {
-                $normalizedQueries[] = $query;
+            if ($query !== '' && !in_array($query, $normalized, true)) {
+                $normalized[] = $query;
             }
         }
 
-        return new self($normalized, $requestCount, $normalizedQueries);
+        return $normalized;
     }
 
     /**

--- a/plugins/AIProviders/WebSearchUsage.php
+++ b/plugins/AIProviders/WebSearchUsage.php
@@ -18,35 +18,37 @@ use Piwik\UrlHelper;
  * for one completion: the web sources attached to the answer, how many searches
  * ran, and the queries the model issued.
  *
- * The providers report grounding in three incompatible shapes — Anthropic uses
- * `server_tool_use`/`web_search_tool_result` blocks plus per-text-block
- * citations, Google a `groundingMetadata` object, OpenAI typed output items
- * carrying `url_citation` annotations. This plugin owns the translation so a
- * caller reads one shape and can switch providers without changing its code.
- *
- * What that flattening hides, so callers know what they are reading:
+ * Providers report grounding in three incompatible shapes, so this class owns
+ * the translation and a caller reads one shape whichever provider ran. What the
+ * flattening hides:
  *
  * - Anthropic reports both cited sources and every returned search result, so
- *   citations list the cited ones first. `requestCount` is Anthropic's own
- *   counter.
+ *   citations list the cited ones first. `requestCount` is its own counter.
  * - Google reports every retrieved grounding chunk and draws no cited/uncited
- *   distinction. Its `url` is the Vertex AI Search redirect Google returns,
- *   *not* the publisher URL — the publisher host is in `domain`. Google has no
- *   search counter, so `requestCount` is derived from the number of queries.
- * - OpenAI reports cited sources only. `requestCount` counts its
- *   `web_search_call` items, and `queries` can be empty even when searches ran,
- *   because OpenAI does not always echo the query it used.
+ *   distinction. Its `url` is the redirect Google returns, *not* the publisher
+ *   URL, and the publisher host is in `domain`. It has no search counter, so
+ *   `requestCount` is derived from the deduplicated query count. Two chunks from
+ *   one page therefore do not collapse: count distinct `domain`, not `url`.
+ * - OpenAI reports cited sources only. `requestCount` counts its `search`
+ *   actions, and `queries` can be empty even when searches ran.
  *
- * A consequence worth knowing before computing shares: "citations" is not the
- * same denominator on all three providers, and because Google's URLs are
- * per-chunk redirects, two chunks from one publisher page do not collapse
- * during deduplication. Count distinct `domain` rather than distinct `url` when
- * the question is "how many sources".
+ * URLs are guaranteed to be http(s) and are length-capped. Titles and queries
+ * are untrusted model output, capped in length but otherwise verbatim: escape
+ * them at the point of rendering.
  *
  * @phpstan-type WebSearchCitationArray array{url: string, title: string, domain: string}
  */
 final class WebSearchUsage
 {
+    /**
+     * Length caps for model-controlled strings. Providers have no documented
+     * limit, and these values are stored and rendered by callers, so a runaway
+     * title cannot bloat a row or a page.
+     */
+    private const MAX_URL_LENGTH = 2048;
+    private const MAX_TITLE_LENGTH = 300;
+    private const MAX_QUERY_LENGTH = 300;
+
     /**
      * @var list<WebSearchCitationArray>
      */
@@ -87,16 +89,13 @@ final class WebSearchUsage
      * Normalises one provider's parsed grounding data.
      *
      * Citations are filtered to http(s) URLs and deduplicated by URL keeping the
-     * first occurrence (providers list the most relevant first).
+     * first occurrence, since providers list the most relevant first.
      *
-     * The `domain` key decides who owns domain resolution, and the distinction
-     * matters: when a citation omits the key entirely the domain is derived from
-     * the URL host, but when the key is present it is trusted verbatim — even
-     * when empty. Google needs that, because its URL is a redirect whose host is
-     * Google's own: deriving from the URL there would label every source
-     * `vertexaisearch.cloud.google.com`, and an empty string is Google's honest
-     * "no trustworthy publisher domain for this chunk". Anthropic and OpenAI omit
-     * the key and get the derived host.
+     * A `domain` key that is present is trusted verbatim, even when empty, and
+     * an absent one is derived from the URL host. Google needs that: its URL is
+     * its own redirect, so deriving there would label every source
+     * `vertexaisearch.cloud.google.com`, and an empty string is its honest "no
+     * publisher domain for this chunk".
      *
      * @param list<array{url?: mixed, title?: mixed, domain?: mixed}> $citations
      * @param int|null $requestCount Provider-reported search count, or null when it reports none.
@@ -122,14 +121,14 @@ final class WebSearchUsage
 
             $normalized[] = [
                 'url' => $url,
-                'title' => is_string($citation['title'] ?? null) ? trim($citation['title']) : '',
+                'title' => self::cap(is_string($citation['title'] ?? null) ? trim($citation['title']) : '', self::MAX_TITLE_LENGTH),
                 'domain' => $domain,
             ];
         }
 
         $normalizedQueries = [];
         foreach ($queries as $query) {
-            $query = trim($query);
+            $query = self::cap(trim($query), self::MAX_QUERY_LENGTH);
             if ($query !== '' && !in_array($query, $normalizedQueries, true)) {
                 $normalizedQueries[] = $query;
             }
@@ -178,30 +177,22 @@ final class WebSearchUsage
     }
 
     /**
-     * @return array{citations: list<WebSearchCitationArray>, requestCount: int|null, queries: list<string>}
-     */
-    public function toArray(): array
-    {
-        return [
-            'citations' => $this->citations,
-            'requestCount' => $this->requestCount,
-            'queries' => $this->queries,
-        ];
-    }
-
-    /**
-     * Rejects anything that is not an http(s) URL. Citation URLs are
-     * model-controlled data that callers will render as links, so a
+     * Rejects anything that is not an http(s) URL of sane length. Citation URLs
+     * are model-controlled data that callers will render as links, so a
      * `javascript:` or `data:` scheme must never leave this plugin.
      */
     private static function isUsableUrl(string $url): bool
     {
-        return preg_match('~^https?://~i', $url) === 1 && self::hostFromUrl($url) !== '';
+        return strlen($url) <= self::MAX_URL_LENGTH
+            && preg_match('~^https?://~i', $url) === 1
+            && self::hostFromUrl($url) !== '';
     }
 
-    /**
-     * Publisher host of a URL, or '' when it carries none.
-     */
+    private static function cap(string $value, int $maxLength): string
+    {
+        return mb_strlen($value) > $maxLength ? mb_substr($value, 0, $maxLength) : $value;
+    }
+
     private static function hostFromUrl(string $url): string
     {
         $host = UrlHelper::getHostFromUrl($url);
@@ -211,14 +202,15 @@ final class WebSearchUsage
 
     /**
      * Normalises a hostname for grouping and display: lowercased, trailing dot
-     * and leading `www.` stripped, matching how callers normalise their own
-     * configured domains so both sides compare equal.
+     * and leading `www.` stripped.
      */
     private static function normalizeHost(string $host): string
     {
         $host = strtolower(rtrim(trim($host), '.'));
 
-        if (strpos($host, 'www.') === 0) {
+        // Only when a dotted name remains, so the registered domain `www.com`
+        // does not collapse to the meaningless `com`.
+        if (strpos($host, 'www.') === 0 && substr_count($host, '.') > 1) {
             $host = substr($host, 4);
         }
 

--- a/plugins/AIProviders/WebSearchUsage.php
+++ b/plugins/AIProviders/WebSearchUsage.php
@@ -99,7 +99,7 @@ final class WebSearchUsage
      *
      * @param list<array{url?: mixed, title?: mixed, domain?: mixed}> $citations
      * @param int|null $requestCount Provider-reported search count, or null when it reports none.
-     * @param list<string> $queries
+     * @param list<mixed> $queries Raw provider queries; normalised by {@link normalizeQueries()}.
      */
     public static function fromProviderData(array $citations, ?int $requestCount, array $queries): self
     {
@@ -136,7 +136,11 @@ final class WebSearchUsage
      * number of queries, and counting the raw list would report more searches
      * than {@link getQueries()} lists back.
      *
-     * @param list<string> $queries
+     * Non-string entries are dropped rather than coerced, for the same reason
+     * {@link fromProviderData()} guards every citation field: this takes raw
+     * provider JSON, where a documented string can arrive as anything.
+     *
+     * @param list<mixed> $queries
      * @return list<string>
      */
     public static function normalizeQueries(array $queries): array
@@ -144,7 +148,7 @@ final class WebSearchUsage
         $normalized = [];
 
         foreach ($queries as $query) {
-            $query = self::cap(trim($query), self::MAX_QUERY_LENGTH);
+            $query = self::cap(is_string($query) ? trim($query) : '', self::MAX_QUERY_LENGTH);
             if ($query !== '' && !in_array($query, $normalized, true)) {
                 $normalized[] = $query;
             }

--- a/plugins/AIProviders/tests/Integration/ConfigurationTest.php
+++ b/plugins/AIProviders/tests/Integration/ConfigurationTest.php
@@ -274,8 +274,7 @@ class ConfigurationTest extends IntegrationTestCase
             ->withModel('gpt-4o-mini')
             ->withMaxTokens(64)
             ->withTemperature(0.5)
-            ->withReasoningLevel('low')
-            ->withWebSearchEnabled(true);
+            ->withReasoningLevel('low');
 
         $response = StaticContainer::get(AIProviderService::class)->complete($request);
 
@@ -287,6 +286,7 @@ class ConfigurationTest extends IntegrationTestCase
         $this->assertSame(64, $capturedBody['max_completion_tokens']);
         $this->assertArrayNotHasKey('max_tokens', $capturedBody);
         $this->assertArrayNotHasKey('temperature', $capturedBody);
+        $this->assertArrayNotHasKey('tools', $capturedBody);
         $this->assertSame('none', $capturedBody['reasoning_effort']);
         $this->assertSame(
             [
@@ -294,6 +294,104 @@ class ConfigurationTest extends IntegrationTestCase
                 ['role' => 'user', 'content' => 'why is the sky blue'],
             ],
             $capturedBody['messages']
+        );
+    }
+
+    public function testWebSearchRequestRunsGroundedAndReportsWhatTheProviderSearched(): void
+    {
+        $this->api->saveSettings(
+            'openai',
+            Configuration::CAPABILITY_INSTANT,
+            (string) json_encode([
+                'openai' => [
+                    'apiKey' => 'secret-openai-key',
+                    'endpointUrl' => '',
+                ],
+            ])
+        );
+
+        $capturedUrl = null;
+        $capturedBody = null;
+        Piwik::addAction('Http.sendHttpRequest', function (
+            string $url,
+            array $httpEventParams,
+            ?string &$response,
+            ?int &$status,
+            array &$headers
+        ) use (
+            &$capturedUrl,
+            &$capturedBody
+): void {
+            $capturedUrl = $url;
+            $capturedBody = json_decode((string) $httpEventParams['body'], true);
+            $response = (string) json_encode([
+                'output' => [
+                    ['type' => 'web_search_call', 'status' => 'completed', 'action' => ['type' => 'search', 'query' => 'sky colour']],
+                    [
+                        'type' => 'message',
+                        'content' => [[
+                            'type' => 'output_text',
+                            'text' => 'Blue light scatters most.',
+                            'annotations' => [
+                                ['type' => 'url_citation', 'url' => 'https://www.example.org/sky', 'title' => 'Why the sky is blue'],
+                            ],
+                        ]],
+                    ],
+                ],
+                'usage' => ['input_tokens' => 900, 'output_tokens' => 20],
+                'status' => 'completed',
+            ]);
+            $status = 200;
+            $headers = ['Content-Type' => 'application/json'];
+        });
+
+        $request = (new AIRequest('why is the sky blue', 'Test'))
+            ->withSystemPrompt('You are concise.')
+            ->withWebSearchEnabled(true);
+
+        $response = StaticContainer::get(AIProviderService::class)->complete($request);
+
+        $this->assertSame('https://api.openai.com/v1/responses', $capturedUrl);
+        $this->assertSame([['type' => 'web_search', 'search_context_size' => 'medium']], $capturedBody['tools']);
+        $this->assertFalse($capturedBody['store']);
+        $this->assertSame(
+            [
+                ['role' => 'developer', 'content' => 'You are concise.'],
+                ['role' => 'user', 'content' => 'why is the sky blue'],
+            ],
+            $capturedBody['input']
+        );
+
+        $this->assertSame('Blue light scatters most.', $response->getText());
+        $this->assertTrue($response->isWebSearchEnabled());
+        $this->assertSame(1, $response->getWebSearchRequestCount());
+        $this->assertSame(['sky colour'], $response->getWebSearchQueries());
+        $this->assertSame(
+            [['url' => 'https://www.example.org/sky', 'title' => 'Why the sky is blue', 'domain' => 'example.org']],
+            $response->getWebSearchCitations()
+        );
+        $this->assertSame(900, $response->getInputTokens());
+    }
+
+    public function testWebSearchRequestIsRejectedForAProviderWithoutWebSearch(): void
+    {
+        $this->api->saveSettings(
+            'custom-provider',
+            Configuration::CAPABILITY_INSTANT,
+            (string) json_encode([
+                'custom-provider' => [
+                    'apiKey' => '',
+                    'endpointUrl' => 'http://localhost:1234/v1',
+                    'model' => 'local-model',
+                ],
+            ])
+        );
+
+        $this->expectException(AIProviderClientException::class);
+        $this->expectExceptionMessage('does not support web search');
+
+        StaticContainer::get(AIProviderService::class)->complete(
+            (new AIRequest('why is the sky blue', 'Test'))->withWebSearchEnabled(true)
         );
     }
 

--- a/plugins/AIProviders/tests/Integration/ConfigurationTest.php
+++ b/plugins/AIProviders/tests/Integration/ConfigurationTest.php
@@ -391,6 +391,52 @@ class ConfigurationTest extends IntegrationTestCase
         $this->assertFalse($service->canUseWebSearch('Test', 'custom-provider'));
     }
 
+    /**
+     * The reason canUseWebSearch() exists rather than callers reading
+     * supportsWebSearch() themselves: on a managed instance the forced provider
+     * wins, so a locked caller must be told about that provider's capability and
+     * not the one it would have asked for.
+     */
+    public function testCanUseWebSearchAnswersForTheForcedProviderOnAManagedInstance(): void
+    {
+        $this->api->saveSettings(
+            'bedrock',
+            Configuration::CAPABILITY_INSTANT,
+            (string) json_encode([
+                'bedrock' => ['apiKey' => 'ak:sk', 'endpointUrl' => 'us-east-1'],
+                'openai' => ['apiKey' => 'secret-openai-key', 'endpointUrl' => ''],
+            ])
+        );
+        Config::getInstance()->AIProviders = [
+            'defaultProvider' => 'bedrock',
+            'providerSelectionAllowlist' => ['ExamplePlugin'],
+        ];
+
+        $service = StaticContainer::get(AIProviderService::class);
+
+        // Locked to Bedrock, which has no web search, even though OpenAI is
+        // configured and is what the caller asked for.
+        $this->assertFalse($service->canUseWebSearch('OtherPlugin'));
+        $this->assertFalse($service->canUseWebSearch('OtherPlugin', 'openai'));
+        // An allowlisted caller keeps its requested provider, so it can ground.
+        $this->assertTrue($service->canUseWebSearch('ExamplePlugin', 'openai'));
+    }
+
+    public function testCanUseWebSearchIsFalseForAnUnknownRequestedProvider(): void
+    {
+        $this->api->saveSettings(
+            'openai',
+            Configuration::CAPABILITY_INSTANT,
+            (string) json_encode([
+                'openai' => ['apiKey' => 'secret-openai-key', 'endpointUrl' => ''],
+            ])
+        );
+
+        $this->assertFalse(
+            StaticContainer::get(AIProviderService::class)->canUseWebSearch('Test', 'not-a-provider')
+        );
+    }
+
     public function testWebSearchRequestIsRejectedForAProviderWithoutWebSearch(): void
     {
         $this->api->saveSettings(

--- a/plugins/AIProviders/tests/Integration/ConfigurationTest.php
+++ b/plugins/AIProviders/tests/Integration/ConfigurationTest.php
@@ -373,6 +373,24 @@ class ConfigurationTest extends IntegrationTestCase
         $this->assertSame(900, $response->getInputTokens());
     }
 
+    public function testCanUseWebSearchAnswersForTheProviderThatWouldActuallyRun(): void
+    {
+        $this->api->saveSettings(
+            'openai',
+            Configuration::CAPABILITY_INSTANT,
+            (string) json_encode([
+                'openai' => ['apiKey' => 'secret-openai-key', 'endpointUrl' => ''],
+            ])
+        );
+
+        $service = StaticContainer::get(AIProviderService::class);
+
+        $this->assertTrue($service->canUseWebSearch('Test'));
+        // A provider the caller asks for by name is answered for too, so a
+        // feature can degrade before spending anything.
+        $this->assertFalse($service->canUseWebSearch('Test', 'custom-provider'));
+    }
+
     public function testWebSearchRequestIsRejectedForAProviderWithoutWebSearch(): void
     {
         $this->api->saveSettings(
@@ -739,9 +757,11 @@ class ConfigurationTest extends IntegrationTestCase
         $this->assertTrue($statusesById['anthropic']['isConfigured']);
         $this->assertFalse($statusesById['google']['isConfigured']);
         $this->assertSame(
-            ['id', 'name', 'isConfigured'],
+            ['id', 'name', 'isConfigured', 'supportsWebSearch'],
             array_keys($statusesById['anthropic'])
         );
+        $this->assertTrue($statusesById['anthropic']['supportsWebSearch']);
+        $this->assertFalse($statusesById['bedrock']['supportsWebSearch']);
     }
 
     public function testNonAllowlistedCallerOnlySeesTheForcedProvider(): void

--- a/plugins/AIProviders/tests/Integration/ConfigurationTest.php
+++ b/plugins/AIProviders/tests/Integration/ConfigurationTest.php
@@ -236,7 +236,7 @@ class ConfigurationTest extends IntegrationTestCase
         $this->assertSame(12, $response->getInputTokens());
         $this->assertSame(7, $response->getOutputTokens());
         $this->assertSame(AIRequest::REASONING_NONE, $response->getReasoningLevel());
-        $this->assertFalse($response->isWebSearchEnabled());
+        $this->assertFalse($response->wasWebSearchUsed());
         $this->assertIsInt($response->getExecutionTimeMs());
     }
 
@@ -280,7 +280,7 @@ class ConfigurationTest extends IntegrationTestCase
 
         $this->assertSame('Blue light scatters most.', $response->getText());
         $this->assertSame(AIRequest::REASONING_NONE, $response->getReasoningLevel());
-        $this->assertFalse($response->isWebSearchEnabled());
+        $this->assertFalse($response->wasWebSearchUsed());
         $this->assertIsArray($capturedBody);
         $this->assertSame('gpt-4o-mini', $capturedBody['model']);
         $this->assertSame(64, $capturedBody['max_completion_tokens']);
@@ -363,7 +363,7 @@ class ConfigurationTest extends IntegrationTestCase
         );
 
         $this->assertSame('Blue light scatters most.', $response->getText());
-        $this->assertTrue($response->isWebSearchEnabled());
+        $this->assertTrue($response->wasWebSearchUsed());
         $this->assertSame(1, $response->getWebSearchRequestCount());
         $this->assertSame(['sky colour'], $response->getWebSearchQueries());
         $this->assertSame(

--- a/plugins/AIProviders/tests/Unit/AIProviderResponseTest.php
+++ b/plugins/AIProviders/tests/Unit/AIProviderResponseTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+// No declare(strict_types=1) on purpose: the compatibility test below mimics a caller
+// written against Matomo 5.13.0, and coercion of its positional arguments is the
+// behaviour under test.
+
+namespace Piwik\Plugins\AIProviders\tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Piwik\Plugins\AIProviders\AIProviderResponse;
+use Piwik\Plugins\AIProviders\AIRequest;
+use Piwik\Plugins\AIProviders\WebSearchUsage;
+
+/**
+ * @group AIProviders
+ * @group Plugins
+ */
+class AIProviderResponseTest extends TestCase
+{
+    /**
+     * The positional shape Matomo 5.13.0 shipped, argument for argument. The
+     * $webSearchEnabled slot is kept and ignored precisely so this keeps binding
+     * the execution time and stop reason to the right parameters; without it
+     * `true` coerced into $executionTimeMs and reported a 1ms provider round trip.
+     */
+    public function testTheMatomo5130PositionalConstructorStillBindsCorrectly(): void
+    {
+        $response = new AIProviderResponse(
+            'openai',
+            'OpenAI',
+            'gpt-5.4-mini',
+            'Blue light scatters most.',
+            12,
+            7,
+            AIRequest::REASONING_NONE,
+            true,
+            1234,
+            'stop'
+        );
+
+        $this->assertSame(1234, $response->getExecutionTimeMs());
+        $this->assertSame('stop', $response->getStopReason());
+        // The deprecated flag is ignored: only a WebSearchUsage reports a search.
+        $this->assertFalse($response->wasWebSearchUsed());
+        $this->assertNull($response->getWebSearchRequestCount());
+        $this->assertSame([], $response->getWebSearchCitations());
+    }
+
+    public function testTheDeprecatedReaderAgreesWithTheCurrentOne(): void
+    {
+        $grounded = $this->groundedResponse();
+
+        $this->assertTrue($grounded->wasWebSearchUsed());
+        $this->assertTrue($grounded->isWebSearchEnabled());
+
+        $ungrounded = new AIProviderResponse('openai', 'OpenAI', 'm', 'hi');
+
+        $this->assertFalse($ungrounded->wasWebSearchUsed());
+        $this->assertFalse($ungrounded->isWebSearchEnabled());
+    }
+
+    /**
+     * Pins the array the README documents, including the deprecated
+     * `webSearchEnabled` key kept alongside `webSearchUsed`.
+     */
+    public function testToArrayExposesTheDocumentedShape(): void
+    {
+        $this->assertSame([
+            'providerId' => 'openai',
+            'providerName' => 'OpenAI',
+            'model' => 'gpt-5.4-mini',
+            'text' => 'Matomo is open source.',
+            'inputTokens' => 900,
+            'outputTokens' => 20,
+            'reasoningLevel' => AIRequest::REASONING_NONE,
+            'webSearchUsed' => true,
+            'webSearchEnabled' => true,
+            'webSearchRequestCount' => 2,
+            'webSearchQueries' => ['best analytics'],
+            'webSearchCitations' => [
+                ['url' => 'https://matomo.org/a', 'title' => 'Matomo', 'domain' => 'matomo.org'],
+            ],
+            'executionTimeMs' => 5,
+            'stopReason' => 'stop',
+        ], $this->groundedResponse()->toArray());
+    }
+
+    private function groundedResponse(): AIProviderResponse
+    {
+        return new AIProviderResponse(
+            'openai',
+            'OpenAI',
+            'gpt-5.4-mini',
+            'Matomo is open source.',
+            900,
+            20,
+            AIRequest::REASONING_NONE,
+            false,
+            5,
+            'stop',
+            WebSearchUsage::fromProviderData(
+                [['url' => 'https://matomo.org/a', 'title' => 'Matomo']],
+                2,
+                ['best analytics']
+            )
+        );
+    }
+}

--- a/plugins/AIProviders/tests/Unit/AIProviderResponseTest.php
+++ b/plugins/AIProviders/tests/Unit/AIProviderResponseTest.php
@@ -7,9 +7,7 @@
  * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-// No declare(strict_types=1) on purpose: the compatibility test below mimics a caller
-// written against Matomo 5.13.0, and coercion of its positional arguments is the
-// behaviour under test.
+declare(strict_types=1);
 
 namespace Piwik\Plugins\AIProviders\tests\Unit;
 
@@ -26,9 +24,10 @@ class AIProviderResponseTest extends TestCase
 {
     /**
      * The positional shape Matomo 5.13.0 shipped, argument for argument. The
-     * $webSearchEnabled slot is kept and ignored precisely so this keeps binding
-     * the execution time and stop reason to the right parameters; without it
-     * `true` coerced into $executionTimeMs and reported a 1ms provider round trip.
+     * deprecated $webSearchEnabled slot is kept so this keeps binding the execution
+     * time and stop reason to the right parameters — removing it would have bound
+     * `true` to $executionTimeMs — and it keeps its meaning, so a 5.13.0 caller that
+     * reported a search still has that search reported back.
      */
     public function testTheMatomo5130PositionalConstructorStillBindsCorrectly(): void
     {
@@ -47,10 +46,22 @@ class AIProviderResponseTest extends TestCase
 
         $this->assertSame(1234, $response->getExecutionTimeMs());
         $this->assertSame('stop', $response->getStopReason());
-        // The deprecated flag is ignored: only a WebSearchUsage reports a search.
-        $this->assertFalse($response->wasWebSearchUsed());
+        // The deprecated flag is still honoured, so the caller's report survives.
+        $this->assertTrue($response->wasWebSearchUsed());
+        $this->assertTrue($response->isWebSearchEnabled());
+        // It carries no detail, though: only a WebSearchUsage has queries or sources.
         $this->assertNull($response->getWebSearchRequestCount());
         $this->assertSame([], $response->getWebSearchCitations());
+        $this->assertSame([], $response->getWebSearchQueries());
+    }
+
+    /**
+     * The deprecated flag reports a search, it does not veto one: a provider that
+     * has migrated to WebSearchUsage passes `false` in the old slot.
+     */
+    public function testTheDeprecatedFlagDoesNotOverrideAWebSearchUsage(): void
+    {
+        $this->assertTrue($this->groundedResponse()->wasWebSearchUsed());
     }
 
     public function testTheDeprecatedReaderAgreesWithTheCurrentOne(): void

--- a/plugins/AIProviders/tests/Unit/AIRequestTest.php
+++ b/plugins/AIProviders/tests/Unit/AIRequestTest.php
@@ -76,4 +76,16 @@ class AIRequestTest extends TestCase
         $this->assertSame(90, $modified->getTimeoutSeconds());
         $this->assertSame(128, $modified->getThinkingBudget());
     }
+
+    public function testTimeoutSecondsIsClampedToAtLeastOneSecondAndNullRestoresTheDefault(): void
+    {
+        $request = new AIRequest('Prompt', 'Goals');
+
+        $this->assertSame(1, $request->withTimeoutSeconds(0)->getTimeoutSeconds());
+        $this->assertSame(1, $request->withTimeoutSeconds(-5)->getTimeoutSeconds());
+        $this->assertSame(90, $request->withTimeoutSeconds(90)->getTimeoutSeconds());
+        // null is not a value but the absence of one: the provider picks its own
+        // default, which differs for a grounded request.
+        $this->assertNull($request->withTimeoutSeconds(45)->withTimeoutSeconds(null)->getTimeoutSeconds());
+    }
 }

--- a/plugins/AIProviders/tests/Unit/AIRequestTest.php
+++ b/plugins/AIProviders/tests/Unit/AIRequestTest.php
@@ -35,6 +35,7 @@ class AIRequestTest extends TestCase
         $this->assertSame(AIRequest::DEFAULT_TEMPERATURE, $request->getTemperature());
         $this->assertSame(AIRequest::REASONING_NONE, $request->getReasoningLevel());
         $this->assertFalse($request->isWebSearchEnabled());
+        $this->assertNull($request->getTimeoutSeconds());
         $this->assertNull($request->getThinkingBudget());
     }
 
@@ -53,6 +54,7 @@ class AIRequestTest extends TestCase
             ->withTemperature(0.7)
             ->withReasoningLevel('low')
             ->withWebSearchEnabled(true)
+            ->withTimeoutSeconds(90)
             ->withThinkingBudget(128);
 
         // The original request is unchanged.
@@ -71,6 +73,7 @@ class AIRequestTest extends TestCase
         $this->assertSame(0.7, $modified->getTemperature());
         $this->assertSame('low', $modified->getReasoningLevel());
         $this->assertTrue($modified->isWebSearchEnabled());
+        $this->assertSame(90, $modified->getTimeoutSeconds());
         $this->assertSame(128, $modified->getThinkingBudget());
     }
 }

--- a/plugins/AIProviders/tests/Unit/WebSearchTest.php
+++ b/plugins/AIProviders/tests/Unit/WebSearchTest.php
@@ -105,7 +105,7 @@ class WebSearchTest extends TestCase
         $claude = new WebSearchRecordingAnthropic();
         $claude->mockResponse = [
             'content' => [
-                ['type' => 'text', 'text' => "I'll search for that. "],
+                ['type' => 'text', 'text' => "I'll search for that."],
                 [
                     'type' => 'server_tool_use',
                     'id' => 'srvtoolu_1',
@@ -126,6 +126,8 @@ class WebSearchTest extends TestCase
 
         $response = $claude->complete($this->groundedRequest(), self::CLAUDE_CONFIG);
 
+        // A space is inserted because the search blocks stood between the two, and
+        // Anthropic pads neither side. Without it the sentences ran together.
         $this->assertSame("I'll search for that. Matomo is a leading open source option.", $response->getText());
     }
 
@@ -179,6 +181,62 @@ class WebSearchTest extends TestCase
         $this->assertFalse($response->wasWebSearchUsed());
     }
 
+    /**
+     * Anthropic's own documented grounded shape: the preamble ends with a full
+     * stop and no trailing space, and the post-search block does not start with
+     * one. Joining these with nothing produced "born.Based on the search".
+     */
+    public function testAnthropicSpacesSentencesSeparatedByTheSearchBlocks(): void
+    {
+        $claude = new WebSearchRecordingAnthropic();
+        $claude->mockResponse = [
+            'content' => [
+                ['type' => 'text', 'text' => "I'll search for when Claude Shannon was born."],
+                [
+                    'type' => 'server_tool_use',
+                    'id' => 'srvtoolu_1',
+                    'name' => 'web_search',
+                    'input' => ['query' => 'Claude Shannon birth date'],
+                ],
+                [
+                    'type' => 'web_search_tool_result',
+                    'tool_use_id' => 'srvtoolu_1',
+                    'content' => [
+                        ['type' => 'web_search_result', 'url' => 'https://example.org/s', 'title' => 'Shannon'],
+                    ],
+                ],
+                ['type' => 'text', 'text' => 'Based on the search results, '],
+                ['type' => 'text', 'text' => 'he was born on April 30, 1916.'],
+            ],
+            'stop_reason' => 'end_turn',
+        ];
+
+        $response = $claude->complete($this->groundedRequest(), self::CLAUDE_CONFIG);
+
+        $this->assertSame(
+            "I'll search for when Claude Shannon was born. Based on the search results, he was born on April 30, 1916.",
+            $response->getText()
+        );
+    }
+
+    /**
+     * A thinking block is a boundary too, but it precedes the whole answer, so
+     * nothing may be prepended to it.
+     */
+    public function testAnthropicDoesNotPrependASpaceAfterAThinkingBlock(): void
+    {
+        $claude = new WebSearchRecordingAnthropic();
+        $claude->mockResponse = [
+            'content' => [
+                ['type' => 'thinking', 'thinking' => 'Considering the options.'],
+                ['type' => 'text', 'text' => 'Matomo.'],
+            ],
+            'stop_reason' => 'end_turn',
+        ];
+
+        $this->assertSame('Matomo.', $claude->complete($this->plainRequest(), self::CLAUDE_CONFIG)->getText());
+    }
+
     public function testAnthropicParsesCitationsQueriesAndRequestCount(): void
     {
         $claude = new WebSearchRecordingAnthropic();
@@ -220,7 +278,7 @@ class WebSearchTest extends TestCase
 
         $response = $claude->complete($this->groundedRequest(), self::CLAUDE_CONFIG);
 
-        $this->assertTrue($response->isWebSearchEnabled());
+        $this->assertTrue($response->wasWebSearchUsed());
         $this->assertSame(3, $response->getWebSearchRequestCount());
         $this->assertSame(['best web analytics'], $response->getWebSearchQueries());
         // Cited sources come before merely returned ones.
@@ -261,7 +319,7 @@ class WebSearchTest extends TestCase
 
         $this->assertSame([], $response->getWebSearchCitations());
         $this->assertSame(1, $response->getWebSearchRequestCount());
-        $this->assertTrue($response->isWebSearchEnabled(), 'the search was billed even though it failed');
+        $this->assertTrue($response->wasWebSearchUsed(), 'the search was billed even though it failed');
     }
 
     public function testAnthropicReportsSearchUnusedWhenTheModelChoseNotToSearch(): void
@@ -275,7 +333,7 @@ class WebSearchTest extends TestCase
 
         $response = $claude->complete($this->groundedRequest(), self::CLAUDE_CONFIG);
 
-        $this->assertFalse($response->isWebSearchEnabled());
+        $this->assertFalse($response->wasWebSearchUsed());
         $this->assertSame(0, $response->getWebSearchRequestCount());
         $this->assertSame([], $response->getWebSearchCitations());
     }
@@ -438,7 +496,7 @@ class WebSearchTest extends TestCase
 
         $response = $gemini->complete($this->groundedRequest(), self::GEMINI_CONFIG);
 
-        $this->assertFalse($response->isWebSearchEnabled());
+        $this->assertFalse($response->wasWebSearchUsed());
         $this->assertSame(0, $response->getWebSearchRequestCount());
     }
 
@@ -537,7 +595,7 @@ class WebSearchTest extends TestCase
 
         $response = $openAI->complete($this->groundedRequest(), self::OPENAI_CONFIG);
 
-        $this->assertSame("First part.\nSecond part.", $response->getText());
+        $this->assertSame('First part. Second part.', $response->getText());
     }
 
     public function testOpenAiParsesUrlCitationAnnotationsAndCountsSearchCalls(): void
@@ -571,7 +629,7 @@ class WebSearchTest extends TestCase
 
         $response = $openAI->complete($this->groundedRequest(), self::OPENAI_CONFIG);
 
-        $this->assertTrue($response->isWebSearchEnabled());
+        $this->assertTrue($response->wasWebSearchUsed());
         $this->assertSame(2, $response->getWebSearchRequestCount());
         $this->assertSame(['best web analytics'], $response->getWebSearchQueries());
         $this->assertSame([
@@ -606,10 +664,12 @@ class WebSearchTest extends TestCase
     }
 
     /**
-     * Parts of one message join with nothing between them, separate messages
-     * with a newline: the first is a citation split, the second distinct prose.
+     * Parts of one message are a sentence split at a citation boundary and carry
+     * their own spacing, so nothing is inserted. A separate message starts new
+     * prose and OpenAI pads neither side, so one space is inserted. Never a
+     * newline: a boundary can fall inside a JSON string value.
      */
-    public function testOpenAiJoinsPartsWithinAMessageButNewlinesBetweenMessages(): void
+    public function testOpenAiJoinsPartsWithinAMessageAndSpacesBetweenMessages(): void
     {
         $openAI = new WebSearchRecordingOpenAI();
         $openAI->mockResponse = [
@@ -625,7 +685,29 @@ class WebSearchTest extends TestCase
 
         $response = $openAI->complete($this->groundedRequest(), self::OPENAI_CONFIG);
 
-        $this->assertSame("Matomo is open source.\nIt self-hosts.", $response->getText());
+        $this->assertSame('Matomo is open source. It self-hosts.', $response->getText());
+    }
+
+    /**
+     * The boundary between two output messages must not be a newline: a grounded
+     * JSON answer can be split across them, and a raw newline inside a string
+     * value makes the response undecodable.
+     */
+    public function testOpenAiGroundedJsonSurvivesAMessageBoundary(): void
+    {
+        $openAI = new WebSearchRecordingOpenAI();
+        $openAI->mockResponse = [
+            'output' => [
+                ['type' => 'web_search_call', 'action' => ['type' => 'search', 'query' => 'analytics']],
+                ['type' => 'message', 'content' => [['type' => 'output_text', 'text' => '{"verdict": "Matomo is ']]],
+                ['type' => 'message', 'content' => [['type' => 'output_text', 'text' => 'open source"}']]],
+            ],
+            'status' => 'completed',
+        ];
+
+        $response = $openAI->complete($this->groundedRequest()->withJsonResponse(), self::OPENAI_CONFIG);
+
+        $this->assertSame(['verdict' => 'Matomo is open source'], $response->getJsonData());
     }
 
     public function testOpenAiIncompleteDetailsReasonWinsOverStatusAsStopReason(): void
@@ -680,7 +762,7 @@ class WebSearchTest extends TestCase
 
         $this->assertArrayNotHasKey('tools', $custom->sentPayload);
         $this->assertSame(30, $custom->sentTimeout, 'no grounded timeout for a provider that cannot ground');
-        $this->assertFalse($response->isWebSearchEnabled());
+        $this->assertFalse($response->wasWebSearchUsed());
         $this->assertSame([], $response->getWebSearchCitations());
         $this->assertNull(
             $response->getWebSearchRequestCount(),

--- a/plugins/AIProviders/tests/Unit/WebSearchTest.php
+++ b/plugins/AIProviders/tests/Unit/WebSearchTest.php
@@ -13,6 +13,7 @@ namespace Piwik\Plugins\AIProviders\tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Piwik\Plugins\AIProviders\AIConversationRequest;
+use Piwik\Plugins\AIProviders\AIConversationResponse;
 use Piwik\Plugins\AIProviders\AIProviderResponse;
 use Piwik\Plugins\AIProviders\AIRequest;
 use Piwik\Plugins\AIProviders\Exception\AIProviderClientException;
@@ -447,6 +448,42 @@ class WebSearchTest extends TestCase
         );
     }
 
+    /**
+     * Google's finishReason is mapped onto the same canonical vocabulary the
+     * conversation path uses, so `end_turn` means the same thing whichever
+     * provider ran instead of Google alone shouting `STOP`.
+     *
+     * @dataProvider getGoogleFinishReasons
+     */
+    public function testGoogleMapsTheFinishReasonOntoTheCanonicalStopReason(
+        ?string $finishReason,
+        ?string $expected
+    ): void {
+        $gemini = new WebSearchRecordingGoogle();
+        $candidate = ['content' => ['parts' => [['text' => 'Answer.']]]];
+        if ($finishReason !== null) {
+            $candidate['finishReason'] = $finishReason;
+        }
+        $gemini->mockResponse = ['candidates' => [$candidate]];
+
+        $response = $gemini->complete($this->plainRequest(), self::GEMINI_CONFIG);
+
+        $this->assertSame($expected, $response->getStopReason());
+    }
+
+    /**
+     * @return iterable<string, array{string|null, string|null}>
+     */
+    public function getGoogleFinishReasons(): iterable
+    {
+        yield 'end of turn' => ['STOP', AIConversationResponse::STOP_END_TURN];
+        yield 'truncated' => ['MAX_TOKENS', AIConversationResponse::STOP_MAX_TOKENS];
+        yield 'safety' => ['SAFETY', AIConversationResponse::STOP_GUARDRAIL_INTERVENED];
+        yield 'recitation' => ['RECITATION', AIConversationResponse::STOP_GUARDRAIL_INTERVENED];
+        yield 'unrecognised passes through' => ['OTHER', 'OTHER'];
+        yield 'absent stays null' => [null, null];
+    }
+
     // -- Google: parsing ------------------------------------------------------
 
     /**
@@ -778,7 +815,13 @@ class WebSearchTest extends TestCase
         $this->assertSame(['verdict' => 'Matomo is open source'], $response->getJsonData());
     }
 
-    public function testOpenAiIncompleteDetailsReasonWinsOverStatusAsStopReason(): void
+    /**
+     * `incomplete_details.reason` is the specific outcome and wins over the
+     * generic `status`, and both are reported in the same vocabulary the
+     * ungrounded chat-completions path uses, so getStopReason() does not depend
+     * on whether the completion happened to be grounded.
+     */
+    public function testOpenAiReportsGroundedStopReasonsInTheChatCompletionsVocabulary(): void
     {
         $truncated = new WebSearchRecordingOpenAI();
         $truncated->mockResponse = [
@@ -789,13 +832,29 @@ class WebSearchTest extends TestCase
 
         $completed = new WebSearchRecordingOpenAI();
 
+        // Same values the ungrounded path reports as `finish_reason`.
         $this->assertSame(
-            'max_output_tokens',
+            'length',
             $truncated->complete($this->groundedRequest(), self::OPENAI_CONFIG)->getStopReason()
         );
         $this->assertSame(
-            'completed',
+            'stop',
             $completed->complete($this->groundedRequest(), self::OPENAI_CONFIG)->getStopReason()
+        );
+    }
+
+    /**
+     * An outcome with no chat-completions equivalent is passed through, because
+     * only the raw value says what went wrong.
+     */
+    public function testOpenAiPassesThroughAnUnrecognisedResponsesStatus(): void
+    {
+        $failed = new WebSearchRecordingOpenAI();
+        $failed->mockResponse = ['output' => [], 'status' => 'failed'];
+
+        $this->assertSame(
+            'failed',
+            $failed->complete($this->groundedRequest(), self::OPENAI_CONFIG)->getStopReason()
         );
     }
 

--- a/plugins/AIProviders/tests/Unit/WebSearchTest.php
+++ b/plugins/AIProviders/tests/Unit/WebSearchTest.php
@@ -77,7 +77,6 @@ class WebSearchTest extends TestCase
         $this->assertArrayNotHasKey('tool_choice', $claude->sentPayload);
     }
 
-
     public function testAnthropicUsesTheLongerTimeoutOnlyForGroundedRequests(): void
     {
         $claude = new WebSearchRecordingAnthropic();
@@ -961,7 +960,7 @@ class WebSearchRecordingAnthropic extends Anthropic
     /** @var array<string, mixed> */
     public $mockResponse = ['content' => [['type' => 'text', 'text' => 'ok']], 'stop_reason' => 'end_turn'];
 
-    protected function sendJsonRequest(string $url, array $headers, array $payload, int $timeoutSeconds = 30): array
+    protected function sendJsonRequest(string $url, array $headers, array $payload, int $timeoutSeconds = self::COMPLETE_TIMEOUT_SECONDS): array
     {
         $this->sentPayload = $payload;
         $this->sentTimeout = $timeoutSeconds;
@@ -981,7 +980,7 @@ class WebSearchRecordingGoogle extends Google
     /** @var array<string, mixed> */
     public $mockResponse = ['candidates' => [['content' => ['parts' => [['text' => 'ok']]]]]];
 
-    protected function sendJsonRequest(string $url, array $headers, array $payload, int $timeoutSeconds = 30): array
+    protected function sendJsonRequest(string $url, array $headers, array $payload, int $timeoutSeconds = self::COMPLETE_TIMEOUT_SECONDS): array
     {
         $this->sentPayload = $payload;
         $this->sentTimeout = $timeoutSeconds;
@@ -1007,7 +1006,7 @@ class WebSearchRecordingOpenAI extends OpenAI
         'status' => 'completed',
     ];
 
-    protected function sendJsonRequest(string $url, array $headers, array $payload, int $timeoutSeconds = 30): array
+    protected function sendJsonRequest(string $url, array $headers, array $payload, int $timeoutSeconds = self::COMPLETE_TIMEOUT_SECONDS): array
     {
         $this->sentUrl = $url;
         $this->sentPayload = $payload;
@@ -1030,7 +1029,7 @@ class WebSearchRecordingCustomProvider extends CustomProvider
     /** @var int|null */
     public $sentTimeout = null;
 
-    protected function sendJsonRequest(string $url, array $headers, array $payload, int $timeoutSeconds = 30): array
+    protected function sendJsonRequest(string $url, array $headers, array $payload, int $timeoutSeconds = self::COMPLETE_TIMEOUT_SECONDS): array
     {
         $this->sentPayload = $payload;
         $this->sentTimeout = $timeoutSeconds;

--- a/plugins/AIProviders/tests/Unit/WebSearchTest.php
+++ b/plugins/AIProviders/tests/Unit/WebSearchTest.php
@@ -792,6 +792,26 @@ class WebSearchTest extends TestCase
         );
     }
 
+    // -- deprecated provider surface -----------------------------------------
+
+    /**
+     * A provider written against Matomo 5.13.0 could only report a search by
+     * overriding the now-deprecated isWebSearchUsed(). Dropping that override on
+     * the floor would silently downgrade its answers to "ungrounded", so it is
+     * still consulted until Matomo 6.
+     */
+    public function testALegacyProviderOverridingIsWebSearchUsedIsStillBelieved(): void
+    {
+        $legacy = new WebSearchLegacyOverrideProvider();
+
+        $response = $legacy->complete($this->groundedRequest(), self::CUSTOM_CONFIG);
+
+        $this->assertTrue($response->wasWebSearchUsed());
+        $this->assertTrue($response->isWebSearchEnabled());
+        // The flag carries no detail; only a WebSearchUsage does.
+        $this->assertSame([], $response->getWebSearchCitations());
+        $this->assertNull($response->getWebSearchRequestCount());
+    }
 
     // -- helpers --------------------------------------------------------------
 
@@ -910,6 +930,23 @@ class WebSearchRecordingCustomProvider extends CustomProvider
         $this->sentPayload = $payload;
         $this->sentTimeout = $timeoutSeconds;
 
+        return ['choices' => [['message' => ['content' => 'ok'], 'finish_reason' => 'stop']]];
+    }
+}
+
+/**
+ * Mimics a third-party provider written against Matomo 5.13.0: it reports a search
+ * through the deprecated override and never passes a WebSearchUsage.
+ */
+class WebSearchLegacyOverrideProvider extends CustomProvider
+{
+    protected function isWebSearchUsed(AIRequest $request): bool
+    {
+        return $request->isWebSearchEnabled();
+    }
+
+    protected function sendJsonRequest(string $url, array $headers, array $payload, int $timeoutSeconds = self::COMPLETE_TIMEOUT_SECONDS): array
+    {
         return ['choices' => [['message' => ['content' => 'ok'], 'finish_reason' => 'stop']]];
     }
 }

--- a/plugins/AIProviders/tests/Unit/WebSearchTest.php
+++ b/plugins/AIProviders/tests/Unit/WebSearchTest.php
@@ -39,12 +39,6 @@ class WebSearchTest extends TestCase
         'endpointUrl' => 'http://localhost:1234/v1',
         'model' => 'local-model',
     ];
-    private const BEDROCK_CONFIG = [
-        'apiKey' => 'k',
-        'endpointUrl' => '',
-        'region' => 'us-east-1',
-        'model' => 'openai.gpt-oss-120b-1:0',
-    ];
 
     public function testSupportsWebSearchFlags(): void
     {
@@ -76,21 +70,11 @@ class WebSearchTest extends TestCase
         $this->assertSame([
             ['type' => 'web_search_20250305', 'name' => 'web_search', 'max_uses' => 5],
         ], $claude->sentPayload['tools']);
-    }
-
-    /**
-     * No tool_choice is sent: Anthropic defaults it to "auto" when tools are
-     * present, which is the behaviour we want (the model decides whether the
-     * prompt needs fresh sources) and an explicit auto would invalidate caching.
-     */
-    public function testAnthropicSendsNoToolChoiceSoTheModelDecides(): void
-    {
-        $claude = new WebSearchRecordingAnthropic();
-
-        $claude->complete($this->groundedRequest(), self::CLAUDE_CONFIG);
-
+        // No tool_choice: Anthropic defaults it to "auto" when tools are present,
+        // so Claude decides whether the prompt needs fresh sources.
         $this->assertArrayNotHasKey('tool_choice', $claude->sentPayload);
     }
+
 
     public function testAnthropicUsesTheLongerTimeoutOnlyForGroundedRequests(): void
     {
@@ -121,7 +105,7 @@ class WebSearchTest extends TestCase
         $claude = new WebSearchRecordingAnthropic();
         $claude->mockResponse = [
             'content' => [
-                ['type' => 'text', 'text' => "I'll search for that."],
+                ['type' => 'text', 'text' => "I'll search for that. "],
                 [
                     'type' => 'server_tool_use',
                     'id' => 'srvtoolu_1',
@@ -142,7 +126,57 @@ class WebSearchTest extends TestCase
 
         $response = $claude->complete($this->groundedRequest(), self::CLAUDE_CONFIG);
 
-        $this->assertSame("I'll search for that.\nMatomo is a leading open source option.", $response->getText());
+        $this->assertSame("I'll search for that. Matomo is a leading open source option.", $response->getText());
+    }
+
+    /**
+     * Regression guard for the real defect a separator caused: a grounded answer
+     * splits mid-sentence, so any character inserted between the fragments lands
+     * inside the JSON string value and makes the response undecodable.
+     */
+    public function testGroundedJsonModeSurvivesACitationSplitInsideAStringValue(): void
+    {
+        $claude = new WebSearchRecordingAnthropic();
+        $claude->mockResponse = [
+            'content' => [
+                ['type' => 'text', 'text' => '{"verdict": "Matomo is '],
+                [
+                    'type' => 'text',
+                    'text' => 'the leading option"}',
+                    'citations' => [[
+                        'type' => 'web_search_result_location',
+                        'url' => 'https://matomo.org/',
+                        'title' => 'Matomo',
+                    ]],
+                ],
+            ],
+            'stop_reason' => 'end_turn',
+        ];
+
+        $response = $claude->complete($this->groundedRequest()->withJsonResponse(), self::CLAUDE_CONFIG);
+
+        $this->assertSame(['verdict' => 'Matomo is the leading option'], $response->getJsonData());
+    }
+
+    /**
+     * The multi-block read also changed the ungrounded path, where extended
+     * thinking puts a thinking block before the answer.
+     */
+    public function testAnthropicUngroundedThinkingResponseReturnsOnlyTheAnswer(): void
+    {
+        $claude = new WebSearchRecordingAnthropic();
+        $claude->mockResponse = [
+            'content' => [
+                ['type' => 'thinking', 'thinking' => 'Let me consider the options.'],
+                ['type' => 'text', 'text' => 'Matomo.'],
+            ],
+            'stop_reason' => 'end_turn',
+        ];
+
+        $response = $claude->complete($this->plainRequest(), self::CLAUDE_CONFIG);
+
+        $this->assertSame('Matomo.', $response->getText());
+        $this->assertFalse($response->wasWebSearchUsed());
     }
 
     public function testAnthropicParsesCitationsQueriesAndRequestCount(): void
@@ -299,7 +333,7 @@ class WebSearchTest extends TestCase
         $gemini->mockResponse = [
             'candidates' => [[
                 'content' => ['parts' => [
-                    ['text' => 'First fragment.'],
+                    ['text' => 'First fragment. '],
                     ['text' => 'Second fragment.'],
                 ]],
             ]],
@@ -307,7 +341,7 @@ class WebSearchTest extends TestCase
 
         $response = $gemini->complete($this->groundedRequest(), self::GEMINI_CONFIG);
 
-        $this->assertSame("First fragment.\nSecond fragment.", $response->getText());
+        $this->assertSame('First fragment. Second fragment.', $response->getText());
     }
 
     public function testGoogleSkipsThoughtParts(): void
@@ -327,61 +361,56 @@ class WebSearchTest extends TestCase
         $this->assertSame('The answer.', $response->getText());
     }
 
-    public function testGooglePrefersAnExplicitWebDomain(): void
+    /**
+     * `web.domain` wins, then the URI host unless it is Google's redirect, then
+     * the title when it looks like a hostname. Google in practice sends only the
+     * redirect plus a bare-host title, and a prose title yields '' rather than a
+     * guess a caller could not tell from a real value.
+     *
+     * @dataProvider getGroundingChunkDomains
+     * @param array<string, mixed> $web
+     */
+    public function testGoogleResolvesTheCitationDomain(array $web, string $expected): void
     {
-        $response = $this->completeGoogleWithChunks([
-            ['web' => [
-                'uri' => 'https://vertexaisearch.cloud.google.com/grounding-api-redirect/abc',
-                'title' => 'Some Page Title',
-                'domain' => 'uefa.com',
-            ]],
-        ]);
+        $response = $this->completeGoogleWithChunks([['web' => $web]]);
 
-        $this->assertSame('uefa.com', $response->getWebSearchCitations()[0]['domain']);
+        $this->assertSame($expected, $response->getWebSearchCitations()[0]['domain']);
     }
 
     /**
-     * The shape Google actually returns: a redirect URI whose host is Google's,
-     * no `web.domain`, and the publisher host as the title.
+     * @return iterable<string, array{array<string, mixed>, string}>
      */
-    public function testGoogleFallsBackToTheTitleWhenTheUriIsAGroundingRedirect(): void
+    public function getGroundingChunkDomains(): iterable
     {
-        $response = $this->completeGoogleWithChunks([
-            ['web' => [
-                'uri' => 'https://vertexaisearch.cloud.google.com/grounding-api-redirect/abc',
-                'title' => 'Matomo.org',
-            ]],
-        ]);
-
-        $citation = $response->getWebSearchCitations()[0];
-
-        $this->assertSame('matomo.org', $citation['domain']);
-        $this->assertSame('https://vertexaisearch.cloud.google.com/grounding-api-redirect/abc', $citation['url']);
+        yield 'explicit web.domain wins over redirect uri and title' => [
+            ['uri' => 'https://vertexaisearch.cloud.google.com/grounding-api-redirect/abc', 'title' => 'Some Page Title', 'domain' => 'uefa.com'],
+            'uefa.com',
+        ];
+        yield 'bare-host title behind a redirect uri' => [
+            ['uri' => 'https://vertexaisearch.cloud.google.com/grounding-api-redirect/abc', 'title' => 'Matomo.org'],
+            'matomo.org',
+        ];
+        yield 'prose title behind a redirect uri yields nothing' => [
+            ['uri' => 'https://vertexaisearch.cloud.google.com/grounding-api-redirect/abc', 'title' => 'Who won Euro 2024 - full report'],
+            '',
+        ];
+        yield 'filename title is not a hostname' => [
+            ['uri' => 'https://vertexaisearch.cloud.google.com/grounding-api-redirect/abc', 'title' => 'report.pdf'],
+            '',
+        ];
+        yield 'host derived from a non-redirect uri' => [
+            ['uri' => 'https://www.example.org/a', 'title' => 'Example'],
+            'example.org',
+        ];
     }
 
-    /**
-     * A prose title is not a domain: an empty string is reported rather than a
-     * guess a caller could not distinguish from a real value.
-     */
-    public function testGoogleReportsNoDomainWhenNeitherUriNorTitleYieldsOne(): void
+    public function testGoogleKeepsTheRedirectUrlAsTheCitationUrl(): void
     {
         $response = $this->completeGoogleWithChunks([
-            ['web' => [
-                'uri' => 'https://vertexaisearch.cloud.google.com/grounding-api-redirect/abc',
-                'title' => 'Who won Euro 2024 - full report',
-            ]],
+            ['web' => ['uri' => 'https://vertexaisearch.cloud.google.com/grounding-api-redirect/abc', 'title' => 'Matomo.org']],
         ]);
 
-        $this->assertSame('', $response->getWebSearchCitations()[0]['domain']);
-    }
-
-    public function testGoogleDerivesTheDomainFromANonRedirectUri(): void
-    {
-        $response = $this->completeGoogleWithChunks([
-            ['web' => ['uri' => 'https://www.example.org/a', 'title' => 'Example']],
-        ]);
-
-        $this->assertSame('example.org', $response->getWebSearchCitations()[0]['domain']);
+        $this->assertSame('https://vertexaisearch.cloud.google.com/grounding-api-redirect/abc', $response->getWebSearchCitations()[0]['url']);
     }
 
     public function testGoogleDerivesTheRequestCountFromItsSearchQueries(): void
@@ -415,14 +444,35 @@ class WebSearchTest extends TestCase
 
     // -- OpenAI: payload ------------------------------------------------------
 
-    public function testOpenAiGroundedCompleteTargetsTheResponsesEndpoint(): void
+    /**
+     * The grounded request switches API, offers the tool without forcing it, and
+     * disables the Responses API's server-side prompt storage, which chat
+     * completions does not do and which Matomo prompts must not be subject to.
+     */
+    public function testOpenAiGroundedCompleteSendsTheResponsesRequest(): void
     {
         $openAI = new WebSearchRecordingOpenAI();
 
-        $openAI->complete($this->groundedRequest(), self::OPENAI_CONFIG);
+        $openAI->complete($this->groundedRequest()->withMaxTokens(64), self::OPENAI_CONFIG);
 
         $this->assertSame('https://api.openai.com/v1/responses', $openAI->sentUrl);
         $this->assertSame(120, $openAI->sentTimeout);
+        $this->assertSame(
+            [['type' => 'web_search', 'search_context_size' => 'medium']],
+            $openAI->sentPayload['tools']
+        );
+        $this->assertArrayNotHasKey('tool_choice', $openAI->sentPayload);
+        $this->assertFalse($openAI->sentPayload['store'], 'prompts must not be retained by OpenAI');
+        $this->assertSame(
+            [['role' => 'user', 'content' => 'best web analytics tools']],
+            $openAI->sentPayload['input']
+        );
+        $this->assertSame('none', $openAI->sentPayload['reasoning']['effort']);
+        $this->assertSame(64, $openAI->sentPayload['max_output_tokens']);
+        $this->assertArrayNotHasKey('messages', $openAI->sentPayload);
+        $this->assertArrayNotHasKey('max_completion_tokens', $openAI->sentPayload);
+        $this->assertArrayNotHasKey('max_tokens', $openAI->sentPayload);
+        $this->assertArrayNotHasKey('temperature', $openAI->sentPayload);
     }
 
     public function testOpenAiUngroundedCompleteStaysOnChatCompletions(): void
@@ -436,51 +486,12 @@ class WebSearchTest extends TestCase
         $this->assertSame(30, $openAI->sentTimeout);
     }
 
-    public function testOpenAiOffersTheWebSearchToolAndLetsTheModelDecide(): void
-    {
-        $openAI = new WebSearchRecordingOpenAI();
-
-        $openAI->complete($this->groundedRequest(), self::OPENAI_CONFIG);
-
-        $this->assertSame(
-            [['type' => 'web_search', 'search_context_size' => 'medium']],
-            $openAI->sentPayload['tools']
-        );
-        $this->assertArrayNotHasKey('tool_choice', $openAI->sentPayload);
-    }
-
-    public function testOpenAiCompleteSendsTheResponsesPayloadShape(): void
-    {
-        $openAI = new WebSearchRecordingOpenAI();
-
-        $openAI->complete($this->groundedRequest()->withMaxTokens(64), self::OPENAI_CONFIG);
-
-        $this->assertSame(
-            [['role' => 'user', 'content' => 'best web analytics tools']],
-            $openAI->sentPayload['input']
-        );
-        $this->assertSame('none', $openAI->sentPayload['reasoning']['effort']);
-        $this->assertSame(64, $openAI->sentPayload['max_output_tokens']);
-        $this->assertArrayNotHasKey('messages', $openAI->sentPayload);
-        $this->assertArrayNotHasKey('max_completion_tokens', $openAI->sentPayload);
-        $this->assertArrayNotHasKey('max_tokens', $openAI->sentPayload);
-        $this->assertArrayNotHasKey('temperature', $openAI->sentPayload);
-    }
-
     /**
-     * The Responses API stores prompts and output server-side by default, which
-     * chat completions does not. Matomo prompts carry customer data, so storage
-     * must be switched off on every request.
+     * The system prompt is an input message with the `developer` role, not the
+     * top-level `instructions` field, because OpenAI does not count
+     * `instructions` when it looks for the word "json" that native JSON mode
+     * requires.
      */
-    public function testOpenAiCompleteDisablesServerSideStorage(): void
-    {
-        $openAI = new WebSearchRecordingOpenAI();
-
-        $openAI->complete($this->groundedRequest(), self::OPENAI_CONFIG);
-
-        $this->assertFalse($openAI->sentPayload['store']);
-    }
-
     public function testOpenAiCompleteSendsTheSystemPromptAsADeveloperInputMessage(): void
     {
         $openAI = new WebSearchRecordingOpenAI();
@@ -570,6 +581,53 @@ class WebSearchTest extends TestCase
         $this->assertSame(800, $response->getOutputTokens());
     }
 
+    /**
+     * Reasoning models emit open_page and find_in_page actions on the same
+     * web_search_call item type. Counting those as searches would overstate the
+     * per-search fee a caller is billed for.
+     */
+    public function testOpenAiCountsOnlySearchActionsNotPageFollowUps(): void
+    {
+        $openAI = new WebSearchRecordingOpenAI();
+        $openAI->mockResponse = [
+            'output' => [
+                ['type' => 'web_search_call', 'action' => ['type' => 'search', 'query' => 'best analytics']],
+                ['type' => 'web_search_call', 'action' => ['type' => 'open_page', 'url' => 'https://matomo.org/']],
+                ['type' => 'web_search_call', 'action' => ['type' => 'find_in_page', 'pattern' => 'privacy']],
+                ['type' => 'message', 'content' => [['type' => 'output_text', 'text' => 'Matomo.']]],
+            ],
+            'status' => 'completed',
+        ];
+
+        $response = $openAI->complete($this->groundedRequest(), self::OPENAI_CONFIG);
+
+        $this->assertSame(1, $response->getWebSearchRequestCount());
+        $this->assertSame(['best analytics'], $response->getWebSearchQueries());
+    }
+
+    /**
+     * Parts of one message join with nothing between them, separate messages
+     * with a newline: the first is a citation split, the second distinct prose.
+     */
+    public function testOpenAiJoinsPartsWithinAMessageButNewlinesBetweenMessages(): void
+    {
+        $openAI = new WebSearchRecordingOpenAI();
+        $openAI->mockResponse = [
+            'output' => [
+                ['type' => 'message', 'content' => [
+                    ['type' => 'output_text', 'text' => 'Matomo is '],
+                    ['type' => 'output_text', 'text' => 'open source.'],
+                ]],
+                ['type' => 'message', 'content' => [['type' => 'output_text', 'text' => 'It self-hosts.']]],
+            ],
+            'status' => 'completed',
+        ];
+
+        $response = $openAI->complete($this->groundedRequest(), self::OPENAI_CONFIG);
+
+        $this->assertSame("Matomo is open source.\nIt self-hosts.", $response->getText());
+    }
+
     public function testOpenAiIncompleteDetailsReasonWinsOverStatusAsStopReason(): void
     {
         $truncated = new WebSearchRecordingOpenAI();
@@ -630,17 +688,6 @@ class WebSearchTest extends TestCase
         );
     }
 
-    public function testBedrockIgnoresAWebSearchRequest(): void
-    {
-        $bedrock = new WebSearchRecordingBedrock();
-
-        $response = $bedrock->complete($this->groundedRequest(), self::BEDROCK_CONFIG);
-
-        $this->assertArrayNotHasKey('tools', $bedrock->sentPayload);
-        $this->assertArrayNotHasKey('toolConfig', $bedrock->sentPayload);
-        $this->assertFalse($response->isWebSearchEnabled());
-        $this->assertNull($response->getWebSearchRequestCount());
-    }
 
     // -- helpers --------------------------------------------------------------
 
@@ -760,31 +807,5 @@ class WebSearchRecordingCustomProvider extends CustomProvider
         $this->sentTimeout = $timeoutSeconds;
 
         return ['choices' => [['message' => ['content' => 'ok'], 'finish_reason' => 'stop']]];
-    }
-}
-
-class WebSearchRecordingBedrock extends Bedrock
-{
-    /** @var array<string, mixed> */
-    public $sentPayload = [];
-
-    /** @var int|null */
-    public $sentTimeout = null;
-
-    // Intercepted at sendConverseRequest() rather than sendJsonRequest() so the
-    // test does not depend on Bedrock's region/endpoint derivation.
-    protected function sendConverseRequest(
-        string $model,
-        array $payload,
-        int $timeoutSeconds,
-        array $configuration
-    ): array {
-        $this->sentPayload = $payload;
-        $this->sentTimeout = $timeoutSeconds;
-
-        return [
-            'output' => ['message' => ['content' => [['text' => 'ok']]]],
-            'stopReason' => 'end_turn',
-        ];
     }
 }

--- a/plugins/AIProviders/tests/Unit/WebSearchTest.php
+++ b/plugins/AIProviders/tests/Unit/WebSearchTest.php
@@ -1,0 +1,790 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+declare(strict_types=1);
+
+namespace Piwik\Plugins\AIProviders\tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Piwik\Plugins\AIProviders\AIConversationRequest;
+use Piwik\Plugins\AIProviders\AIProviderResponse;
+use Piwik\Plugins\AIProviders\AIRequest;
+use Piwik\Plugins\AIProviders\Provider\Anthropic;
+use Piwik\Plugins\AIProviders\Provider\Bedrock;
+use Piwik\Plugins\AIProviders\Provider\CustomProvider;
+use Piwik\Plugins\AIProviders\Provider\Google;
+use Piwik\Plugins\AIProviders\Provider\OpenAI;
+
+/**
+ * Verifies how a web search request maps onto each provider's complete() wire
+ * format, and how each provider's grounding data is parsed back into the shared
+ * citation shape.
+ *
+ * @group AIProviders
+ * @group Plugins
+ */
+class WebSearchTest extends TestCase
+{
+    private const OPENAI_CONFIG = ['apiKey' => 'k', 'endpointUrl' => ''];
+    private const CLAUDE_CONFIG = ['apiKey' => 'k', 'endpointUrl' => ''];
+    private const GEMINI_CONFIG = ['apiKey' => 'k', 'endpointUrl' => ''];
+    private const CUSTOM_CONFIG = [
+        'apiKey' => '',
+        'endpointUrl' => 'http://localhost:1234/v1',
+        'model' => 'local-model',
+    ];
+    private const BEDROCK_CONFIG = [
+        'apiKey' => 'k',
+        'endpointUrl' => '',
+        'region' => 'us-east-1',
+        'model' => 'openai.gpt-oss-120b-1:0',
+    ];
+
+    public function testSupportsWebSearchFlags(): void
+    {
+        $this->assertTrue((new Anthropic())->supportsWebSearch());
+        $this->assertTrue((new Google())->supportsWebSearch());
+        $this->assertTrue((new OpenAI())->supportsWebSearch());
+        $this->assertFalse((new Bedrock())->supportsWebSearch());
+        $this->assertFalse((new CustomProvider())->supportsWebSearch());
+    }
+
+    // -- Anthropic: payload ---------------------------------------------------
+
+    public function testAnthropicSendsNoToolsWhenWebSearchNotRequested(): void
+    {
+        $claude = new WebSearchRecordingAnthropic();
+
+        $claude->complete($this->plainRequest(), self::CLAUDE_CONFIG);
+
+        $this->assertArrayNotHasKey('tools', $claude->sentPayload);
+        $this->assertSame(30, $claude->sentTimeout);
+    }
+
+    public function testAnthropicSendsWebSearchToolWithACappedNumberOfSearches(): void
+    {
+        $claude = new WebSearchRecordingAnthropic();
+
+        $claude->complete($this->groundedRequest(), self::CLAUDE_CONFIG);
+
+        $this->assertSame([
+            ['type' => 'web_search_20250305', 'name' => 'web_search', 'max_uses' => 5],
+        ], $claude->sentPayload['tools']);
+    }
+
+    /**
+     * No tool_choice is sent: Anthropic defaults it to "auto" when tools are
+     * present, which is the behaviour we want (the model decides whether the
+     * prompt needs fresh sources) and an explicit auto would invalidate caching.
+     */
+    public function testAnthropicSendsNoToolChoiceSoTheModelDecides(): void
+    {
+        $claude = new WebSearchRecordingAnthropic();
+
+        $claude->complete($this->groundedRequest(), self::CLAUDE_CONFIG);
+
+        $this->assertArrayNotHasKey('tool_choice', $claude->sentPayload);
+    }
+
+    public function testAnthropicUsesTheLongerTimeoutOnlyForGroundedRequests(): void
+    {
+        $claude = new WebSearchRecordingAnthropic();
+
+        $claude->complete($this->groundedRequest(), self::CLAUDE_CONFIG);
+
+        $this->assertSame(120, $claude->sentTimeout);
+    }
+
+    public function testARequestTimeoutOverridesTheGroundedDefault(): void
+    {
+        $claude = new WebSearchRecordingAnthropic();
+
+        $claude->complete($this->groundedRequest()->withTimeoutSeconds(45), self::CLAUDE_CONFIG);
+
+        $this->assertSame(45, $claude->sentTimeout);
+    }
+
+    // -- Anthropic: parsing ---------------------------------------------------
+
+    /**
+     * Regression guard: with search on, the first text block is only the model's
+     * "I'll look that up" preamble, so returning it alone lost the answer.
+     */
+    public function testAnthropicConcatenatesAllTextBlocksAroundASearch(): void
+    {
+        $claude = new WebSearchRecordingAnthropic();
+        $claude->mockResponse = [
+            'content' => [
+                ['type' => 'text', 'text' => "I'll search for that."],
+                [
+                    'type' => 'server_tool_use',
+                    'id' => 'srvtoolu_1',
+                    'name' => 'web_search',
+                    'input' => ['query' => 'best web analytics'],
+                ],
+                [
+                    'type' => 'web_search_tool_result',
+                    'tool_use_id' => 'srvtoolu_1',
+                    'content' => [
+                        ['type' => 'web_search_result', 'url' => 'https://matomo.org/', 'title' => 'Matomo'],
+                    ],
+                ],
+                ['type' => 'text', 'text' => 'Matomo is a leading open source option.'],
+            ],
+            'stop_reason' => 'end_turn',
+        ];
+
+        $response = $claude->complete($this->groundedRequest(), self::CLAUDE_CONFIG);
+
+        $this->assertSame("I'll search for that.\nMatomo is a leading open source option.", $response->getText());
+    }
+
+    public function testAnthropicParsesCitationsQueriesAndRequestCount(): void
+    {
+        $claude = new WebSearchRecordingAnthropic();
+        $claude->mockResponse = [
+            'content' => [
+                [
+                    'type' => 'server_tool_use',
+                    'id' => 'srvtoolu_1',
+                    'name' => 'web_search',
+                    'input' => ['query' => 'best web analytics'],
+                ],
+                [
+                    'type' => 'web_search_tool_result',
+                    'tool_use_id' => 'srvtoolu_1',
+                    'content' => [
+                        ['type' => 'web_search_result', 'url' => 'https://g2.com/analytics', 'title' => 'G2'],
+                    ],
+                ],
+                [
+                    'type' => 'text',
+                    'text' => 'Matomo is a leading option.',
+                    'citations' => [
+                        [
+                            'type' => 'web_search_result_location',
+                            'url' => 'https://matomo.org/blog/x',
+                            'title' => 'Matomo Blog',
+                            'cited_text' => 'Matomo is…',
+                        ],
+                    ],
+                ],
+            ],
+            'usage' => [
+                'input_tokens' => 8412,
+                'output_tokens' => 431,
+                'server_tool_use' => ['web_search_requests' => 3],
+            ],
+            'stop_reason' => 'end_turn',
+        ];
+
+        $response = $claude->complete($this->groundedRequest(), self::CLAUDE_CONFIG);
+
+        $this->assertTrue($response->isWebSearchEnabled());
+        $this->assertSame(3, $response->getWebSearchRequestCount());
+        $this->assertSame(['best web analytics'], $response->getWebSearchQueries());
+        // Cited sources come before merely returned ones.
+        $this->assertSame([
+            ['url' => 'https://matomo.org/blog/x', 'title' => 'Matomo Blog', 'domain' => 'matomo.org'],
+            ['url' => 'https://g2.com/analytics', 'title' => 'G2', 'domain' => 'g2.com'],
+        ], $response->getWebSearchCitations());
+    }
+
+    /**
+     * A failed search still returns HTTP 200 with `content` as a single error
+     * object instead of a list of rows, which must not break parsing — and the
+     * attempt still counted, so the search is reported as having run.
+     */
+    public function testAnthropicSearchToolResultErrorYieldsNoCitationsWithoutThrowing(): void
+    {
+        $claude = new WebSearchRecordingAnthropic();
+        $claude->mockResponse = [
+            'content' => [
+                [
+                    'type' => 'server_tool_use',
+                    'id' => 'srvtoolu_1',
+                    'name' => 'web_search',
+                    'input' => ['query' => 'best web analytics'],
+                ],
+                [
+                    'type' => 'web_search_tool_result',
+                    'tool_use_id' => 'srvtoolu_1',
+                    'content' => ['type' => 'web_search_tool_result_error', 'error_code' => 'max_uses_exceeded'],
+                ],
+                ['type' => 'text', 'text' => 'I could not search.'],
+            ],
+            'usage' => ['server_tool_use' => ['web_search_requests' => 1]],
+            'stop_reason' => 'end_turn',
+        ];
+
+        $response = $claude->complete($this->groundedRequest(), self::CLAUDE_CONFIG);
+
+        $this->assertSame([], $response->getWebSearchCitations());
+        $this->assertSame(1, $response->getWebSearchRequestCount());
+        $this->assertTrue($response->isWebSearchEnabled(), 'the search was billed even though it failed');
+    }
+
+    public function testAnthropicReportsSearchUnusedWhenTheModelChoseNotToSearch(): void
+    {
+        $claude = new WebSearchRecordingAnthropic();
+        $claude->mockResponse = [
+            'content' => [['type' => 'text', 'text' => 'Two plus two is four.']],
+            'usage' => ['input_tokens' => 12, 'output_tokens' => 7, 'server_tool_use' => ['web_search_requests' => 0]],
+            'stop_reason' => 'end_turn',
+        ];
+
+        $response = $claude->complete($this->groundedRequest(), self::CLAUDE_CONFIG);
+
+        $this->assertFalse($response->isWebSearchEnabled());
+        $this->assertSame(0, $response->getWebSearchRequestCount());
+        $this->assertSame([], $response->getWebSearchCitations());
+    }
+
+    public function testAnthropicPauseTurnIsSurfacedAsTheStopReason(): void
+    {
+        $claude = new WebSearchRecordingAnthropic();
+        $claude->mockResponse = [
+            'content' => [['type' => 'text', 'text' => 'Partial answer so far.']],
+            'stop_reason' => 'pause_turn',
+        ];
+
+        $response = $claude->complete($this->groundedRequest(), self::CLAUDE_CONFIG);
+
+        $this->assertSame('pause_turn', $response->getStopReason());
+    }
+
+    // -- Google: payload ------------------------------------------------------
+
+    public function testGoogleSendsNoToolsWhenWebSearchNotRequested(): void
+    {
+        $gemini = new WebSearchRecordingGoogle();
+
+        $gemini->complete($this->plainRequest(), self::GEMINI_CONFIG);
+
+        $this->assertArrayNotHasKey('tools', $gemini->sentPayload);
+    }
+
+    /**
+     * Asserted on the encoded JSON rather than the PHP array: an empty array
+     * would satisfy an array comparison but encodes as `[]`, which Google rejects
+     * for this object slot.
+     */
+    public function testGoogleSendsGoogleSearchToolAsAJsonObject(): void
+    {
+        $gemini = new WebSearchRecordingGoogle();
+
+        $gemini->complete($this->groundedRequest(), self::GEMINI_CONFIG);
+
+        $this->assertStringContainsString(
+            '"tools":[{"google_search":{}}]',
+            (string) json_encode($gemini->sentPayload)
+        );
+    }
+
+    // -- Google: parsing ------------------------------------------------------
+
+    /**
+     * Regression guard: a grounded candidate returns several text parts, so
+     * reading parts[0] truncated the answer to its first fragment.
+     */
+    public function testGoogleConcatenatesAllTextParts(): void
+    {
+        $gemini = new WebSearchRecordingGoogle();
+        $gemini->mockResponse = [
+            'candidates' => [[
+                'content' => ['parts' => [
+                    ['text' => 'First fragment.'],
+                    ['text' => 'Second fragment.'],
+                ]],
+            ]],
+        ];
+
+        $response = $gemini->complete($this->groundedRequest(), self::GEMINI_CONFIG);
+
+        $this->assertSame("First fragment.\nSecond fragment.", $response->getText());
+    }
+
+    public function testGoogleSkipsThoughtParts(): void
+    {
+        $gemini = new WebSearchRecordingGoogle();
+        $gemini->mockResponse = [
+            'candidates' => [[
+                'content' => ['parts' => [
+                    ['text' => 'Internal reasoning.', 'thought' => true],
+                    ['text' => 'The answer.'],
+                ]],
+            ]],
+        ];
+
+        $response = $gemini->complete($this->groundedRequest(), self::GEMINI_CONFIG);
+
+        $this->assertSame('The answer.', $response->getText());
+    }
+
+    public function testGooglePrefersAnExplicitWebDomain(): void
+    {
+        $response = $this->completeGoogleWithChunks([
+            ['web' => [
+                'uri' => 'https://vertexaisearch.cloud.google.com/grounding-api-redirect/abc',
+                'title' => 'Some Page Title',
+                'domain' => 'uefa.com',
+            ]],
+        ]);
+
+        $this->assertSame('uefa.com', $response->getWebSearchCitations()[0]['domain']);
+    }
+
+    /**
+     * The shape Google actually returns: a redirect URI whose host is Google's,
+     * no `web.domain`, and the publisher host as the title.
+     */
+    public function testGoogleFallsBackToTheTitleWhenTheUriIsAGroundingRedirect(): void
+    {
+        $response = $this->completeGoogleWithChunks([
+            ['web' => [
+                'uri' => 'https://vertexaisearch.cloud.google.com/grounding-api-redirect/abc',
+                'title' => 'Matomo.org',
+            ]],
+        ]);
+
+        $citation = $response->getWebSearchCitations()[0];
+
+        $this->assertSame('matomo.org', $citation['domain']);
+        $this->assertSame('https://vertexaisearch.cloud.google.com/grounding-api-redirect/abc', $citation['url']);
+    }
+
+    /**
+     * A prose title is not a domain: an empty string is reported rather than a
+     * guess a caller could not distinguish from a real value.
+     */
+    public function testGoogleReportsNoDomainWhenNeitherUriNorTitleYieldsOne(): void
+    {
+        $response = $this->completeGoogleWithChunks([
+            ['web' => [
+                'uri' => 'https://vertexaisearch.cloud.google.com/grounding-api-redirect/abc',
+                'title' => 'Who won Euro 2024 - full report',
+            ]],
+        ]);
+
+        $this->assertSame('', $response->getWebSearchCitations()[0]['domain']);
+    }
+
+    public function testGoogleDerivesTheDomainFromANonRedirectUri(): void
+    {
+        $response = $this->completeGoogleWithChunks([
+            ['web' => ['uri' => 'https://www.example.org/a', 'title' => 'Example']],
+        ]);
+
+        $this->assertSame('example.org', $response->getWebSearchCitations()[0]['domain']);
+    }
+
+    public function testGoogleDerivesTheRequestCountFromItsSearchQueries(): void
+    {
+        $gemini = new WebSearchRecordingGoogle();
+        $gemini->mockResponse = [
+            'candidates' => [[
+                'content' => ['parts' => [['text' => 'Spain won.']]],
+                'groundingMetadata' => [
+                    'webSearchQueries' => ['UEFA Euro 2024 winner', 'who won euro 2024'],
+                    'groundingChunks' => [],
+                ],
+            ]],
+        ];
+
+        $response = $gemini->complete($this->groundedRequest(), self::GEMINI_CONFIG);
+
+        $this->assertSame(2, $response->getWebSearchRequestCount());
+        $this->assertSame(['UEFA Euro 2024 winner', 'who won euro 2024'], $response->getWebSearchQueries());
+    }
+
+    public function testGoogleReportsSearchUnusedWhenNoGroundingMetadataCameBack(): void
+    {
+        $gemini = new WebSearchRecordingGoogle();
+
+        $response = $gemini->complete($this->groundedRequest(), self::GEMINI_CONFIG);
+
+        $this->assertFalse($response->isWebSearchEnabled());
+        $this->assertSame(0, $response->getWebSearchRequestCount());
+    }
+
+    // -- OpenAI: payload ------------------------------------------------------
+
+    public function testOpenAiGroundedCompleteTargetsTheResponsesEndpoint(): void
+    {
+        $openAI = new WebSearchRecordingOpenAI();
+
+        $openAI->complete($this->groundedRequest(), self::OPENAI_CONFIG);
+
+        $this->assertSame('https://api.openai.com/v1/responses', $openAI->sentUrl);
+        $this->assertSame(120, $openAI->sentTimeout);
+    }
+
+    public function testOpenAiUngroundedCompleteStaysOnChatCompletions(): void
+    {
+        $openAI = new WebSearchRecordingOpenAI();
+
+        $openAI->complete($this->plainRequest(), self::OPENAI_CONFIG);
+
+        $this->assertSame('https://api.openai.com/v1/chat/completions', $openAI->sentUrl);
+        $this->assertArrayNotHasKey('tools', $openAI->sentPayload);
+        $this->assertSame(30, $openAI->sentTimeout);
+    }
+
+    public function testOpenAiOffersTheWebSearchToolAndLetsTheModelDecide(): void
+    {
+        $openAI = new WebSearchRecordingOpenAI();
+
+        $openAI->complete($this->groundedRequest(), self::OPENAI_CONFIG);
+
+        $this->assertSame(
+            [['type' => 'web_search', 'search_context_size' => 'medium']],
+            $openAI->sentPayload['tools']
+        );
+        $this->assertArrayNotHasKey('tool_choice', $openAI->sentPayload);
+    }
+
+    public function testOpenAiCompleteSendsTheResponsesPayloadShape(): void
+    {
+        $openAI = new WebSearchRecordingOpenAI();
+
+        $openAI->complete($this->groundedRequest()->withMaxTokens(64), self::OPENAI_CONFIG);
+
+        $this->assertSame(
+            [['role' => 'user', 'content' => 'best web analytics tools']],
+            $openAI->sentPayload['input']
+        );
+        $this->assertSame('none', $openAI->sentPayload['reasoning']['effort']);
+        $this->assertSame(64, $openAI->sentPayload['max_output_tokens']);
+        $this->assertArrayNotHasKey('messages', $openAI->sentPayload);
+        $this->assertArrayNotHasKey('max_completion_tokens', $openAI->sentPayload);
+        $this->assertArrayNotHasKey('max_tokens', $openAI->sentPayload);
+        $this->assertArrayNotHasKey('temperature', $openAI->sentPayload);
+    }
+
+    /**
+     * The Responses API stores prompts and output server-side by default, which
+     * chat completions does not. Matomo prompts carry customer data, so storage
+     * must be switched off on every request.
+     */
+    public function testOpenAiCompleteDisablesServerSideStorage(): void
+    {
+        $openAI = new WebSearchRecordingOpenAI();
+
+        $openAI->complete($this->groundedRequest(), self::OPENAI_CONFIG);
+
+        $this->assertFalse($openAI->sentPayload['store']);
+    }
+
+    public function testOpenAiCompleteSendsTheSystemPromptAsADeveloperInputMessage(): void
+    {
+        $openAI = new WebSearchRecordingOpenAI();
+
+        $openAI->complete($this->groundedRequest()->withSystemPrompt('You are concise.'), self::OPENAI_CONFIG);
+
+        $this->assertSame([
+            ['role' => 'developer', 'content' => 'You are concise.'],
+            ['role' => 'user', 'content' => 'best web analytics tools'],
+        ], $openAI->sentPayload['input']);
+        $this->assertArrayNotHasKey('instructions', $openAI->sentPayload);
+    }
+
+    /**
+     * OpenAI rejects the combination outright, so the native format is dropped and
+     * JSON is requested through the prompt instruction instead of failing.
+     */
+    public function testOpenAiDropsNativeJsonFormatWhenGroundingIsOn(): void
+    {
+        $openAI = new WebSearchRecordingOpenAI();
+
+        $openAI->complete($this->groundedRequest()->withJsonResponse(), self::OPENAI_CONFIG);
+
+        $this->assertArrayNotHasKey('text', $openAI->sentPayload);
+        $this->assertArrayHasKey('tools', $openAI->sentPayload);
+        $this->assertStringContainsString('JSON', $openAI->sentPayload['input'][0]['content']);
+    }
+
+    // -- OpenAI: parsing ------------------------------------------------------
+
+    public function testOpenAiConcatenatesOutputTextAcrossMessageItems(): void
+    {
+        $openAI = new WebSearchRecordingOpenAI();
+        $openAI->mockResponse = [
+            'output' => [
+                ['type' => 'reasoning', 'summary' => []],
+                ['type' => 'web_search_call', 'action' => ['type' => 'search', 'query' => 'best web analytics']],
+                ['type' => 'message', 'content' => [['type' => 'output_text', 'text' => 'First part.']]],
+                ['type' => 'message', 'content' => [['type' => 'output_text', 'text' => 'Second part.']]],
+            ],
+            'status' => 'completed',
+        ];
+
+        $response = $openAI->complete($this->groundedRequest(), self::OPENAI_CONFIG);
+
+        $this->assertSame("First part.\nSecond part.", $response->getText());
+    }
+
+    public function testOpenAiParsesUrlCitationAnnotationsAndCountsSearchCalls(): void
+    {
+        $openAI = new WebSearchRecordingOpenAI();
+        $openAI->mockResponse = [
+            'output' => [
+                ['type' => 'web_search_call', 'action' => ['type' => 'search', 'query' => 'best web analytics']],
+                ['type' => 'web_search_call', 'action' => ['type' => 'search']],
+                [
+                    'type' => 'message',
+                    'content' => [[
+                        'type' => 'output_text',
+                        'text' => 'Matomo is a leading option.',
+                        'annotations' => [
+                            [
+                                'type' => 'url_citation',
+                                'url' => 'https://matomo.org/blog/x',
+                                'title' => 'Matomo Blog',
+                                'start_index' => 0,
+                                'end_index' => 10,
+                            ],
+                            ['type' => 'file_citation', 'file_id' => 'ignored'],
+                        ],
+                    ]],
+                ],
+            ],
+            'usage' => ['input_tokens' => 4050, 'output_tokens' => 800],
+            'status' => 'completed',
+        ];
+
+        $response = $openAI->complete($this->groundedRequest(), self::OPENAI_CONFIG);
+
+        $this->assertTrue($response->isWebSearchEnabled());
+        $this->assertSame(2, $response->getWebSearchRequestCount());
+        $this->assertSame(['best web analytics'], $response->getWebSearchQueries());
+        $this->assertSame([
+            ['url' => 'https://matomo.org/blog/x', 'title' => 'Matomo Blog', 'domain' => 'matomo.org'],
+        ], $response->getWebSearchCitations());
+        $this->assertSame(4050, $response->getInputTokens());
+        $this->assertSame(800, $response->getOutputTokens());
+    }
+
+    public function testOpenAiIncompleteDetailsReasonWinsOverStatusAsStopReason(): void
+    {
+        $truncated = new WebSearchRecordingOpenAI();
+        $truncated->mockResponse = [
+            'output' => [['type' => 'message', 'content' => [['type' => 'output_text', 'text' => 'Cut short']]]],
+            'status' => 'incomplete',
+            'incomplete_details' => ['reason' => 'max_output_tokens'],
+        ];
+
+        $completed = new WebSearchRecordingOpenAI();
+
+        $this->assertSame(
+            'max_output_tokens',
+            $truncated->complete($this->groundedRequest(), self::OPENAI_CONFIG)->getStopReason()
+        );
+        $this->assertSame(
+            'completed',
+            $completed->complete($this->groundedRequest(), self::OPENAI_CONFIG)->getStopReason()
+        );
+    }
+
+    /**
+     * Regression guard for the migration: converse() must stay on chat
+     * completions, where the canonical tool-calling translation lives.
+     */
+    public function testOpenAiConverseStillUsesChatCompletions(): void
+    {
+        $openAI = new WebSearchRecordingOpenAI();
+
+        $openAI->converse(
+            new AIConversationRequest(
+                [['role' => 'user', 'content' => [['type' => 'text', 'text' => 'Hello']]]],
+                'Test'
+            ),
+            self::OPENAI_CONFIG
+        );
+
+        $this->assertSame('https://api.openai.com/v1/chat/completions', $openAI->sentUrl);
+        $this->assertArrayHasKey('max_completion_tokens', $openAI->sentPayload);
+        $this->assertArrayNotHasKey('reasoning', $openAI->sentPayload);
+    }
+
+    // -- Providers without web search ----------------------------------------
+
+    public function testCustomProviderIgnoresAWebSearchRequest(): void
+    {
+        $custom = new WebSearchRecordingCustomProvider();
+
+        $response = $custom->complete($this->groundedRequest(), self::CUSTOM_CONFIG);
+
+        $this->assertArrayNotHasKey('tools', $custom->sentPayload);
+        $this->assertSame(30, $custom->sentTimeout, 'no grounded timeout for a provider that cannot ground');
+        $this->assertFalse($response->isWebSearchEnabled());
+        $this->assertSame([], $response->getWebSearchCitations());
+        $this->assertNull(
+            $response->getWebSearchRequestCount(),
+            'null means "cannot report", which is different from a reported zero'
+        );
+    }
+
+    public function testBedrockIgnoresAWebSearchRequest(): void
+    {
+        $bedrock = new WebSearchRecordingBedrock();
+
+        $response = $bedrock->complete($this->groundedRequest(), self::BEDROCK_CONFIG);
+
+        $this->assertArrayNotHasKey('tools', $bedrock->sentPayload);
+        $this->assertArrayNotHasKey('toolConfig', $bedrock->sentPayload);
+        $this->assertFalse($response->isWebSearchEnabled());
+        $this->assertNull($response->getWebSearchRequestCount());
+    }
+
+    // -- helpers --------------------------------------------------------------
+
+    private function plainRequest(): AIRequest
+    {
+        return new AIRequest('why is the sky blue', 'Test');
+    }
+
+    private function groundedRequest(): AIRequest
+    {
+        return (new AIRequest('best web analytics tools', 'Test'))->withWebSearchEnabled(true);
+    }
+
+    /**
+     * @param list<array<string, mixed>> $chunks
+     */
+    private function completeGoogleWithChunks(array $chunks): AIProviderResponse
+    {
+        $gemini = new WebSearchRecordingGoogle();
+        $gemini->mockResponse = [
+            'candidates' => [[
+                'content' => ['parts' => [['text' => 'Answer.']]],
+                'groundingMetadata' => [
+                    'webSearchQueries' => ['a query'],
+                    'groundingChunks' => $chunks,
+                ],
+            ]],
+        ];
+
+        return $gemini->complete($this->groundedRequest(), self::GEMINI_CONFIG);
+    }
+}
+
+class WebSearchRecordingAnthropic extends Anthropic
+{
+    /** @var array<string, mixed> */
+    public $sentPayload = [];
+
+    /** @var int|null */
+    public $sentTimeout = null;
+
+    /** @var array<string, mixed> */
+    public $mockResponse = ['content' => [['type' => 'text', 'text' => 'ok']], 'stop_reason' => 'end_turn'];
+
+    protected function sendJsonRequest(string $url, array $headers, array $payload, int $timeoutSeconds = 30): array
+    {
+        $this->sentPayload = $payload;
+        $this->sentTimeout = $timeoutSeconds;
+
+        return $this->mockResponse;
+    }
+}
+
+class WebSearchRecordingGoogle extends Google
+{
+    /** @var array<string, mixed> */
+    public $sentPayload = [];
+
+    /** @var int|null */
+    public $sentTimeout = null;
+
+    /** @var array<string, mixed> */
+    public $mockResponse = ['candidates' => [['content' => ['parts' => [['text' => 'ok']]]]]];
+
+    protected function sendJsonRequest(string $url, array $headers, array $payload, int $timeoutSeconds = 30): array
+    {
+        $this->sentPayload = $payload;
+        $this->sentTimeout = $timeoutSeconds;
+
+        return $this->mockResponse;
+    }
+}
+
+class WebSearchRecordingOpenAI extends OpenAI
+{
+    /** @var string */
+    public $sentUrl = '';
+
+    /** @var array<string, mixed> */
+    public $sentPayload = [];
+
+    /** @var int|null */
+    public $sentTimeout = null;
+
+    /** @var array<string, mixed> */
+    public $mockResponse = [
+        'output' => [['type' => 'message', 'content' => [['type' => 'output_text', 'text' => 'ok']]]],
+        'status' => 'completed',
+    ];
+
+    protected function sendJsonRequest(string $url, array $headers, array $payload, int $timeoutSeconds = 30): array
+    {
+        $this->sentUrl = $url;
+        $this->sentPayload = $payload;
+        $this->sentTimeout = $timeoutSeconds;
+
+        // converse() speaks chat completions, so it needs a choices[] body.
+        if (strpos($url, '/chat/completions') !== false) {
+            return ['choices' => [['message' => ['content' => 'ok'], 'finish_reason' => 'stop']]];
+        }
+
+        return $this->mockResponse;
+    }
+}
+
+class WebSearchRecordingCustomProvider extends CustomProvider
+{
+    /** @var array<string, mixed> */
+    public $sentPayload = [];
+
+    /** @var int|null */
+    public $sentTimeout = null;
+
+    protected function sendJsonRequest(string $url, array $headers, array $payload, int $timeoutSeconds = 30): array
+    {
+        $this->sentPayload = $payload;
+        $this->sentTimeout = $timeoutSeconds;
+
+        return ['choices' => [['message' => ['content' => 'ok'], 'finish_reason' => 'stop']]];
+    }
+}
+
+class WebSearchRecordingBedrock extends Bedrock
+{
+    /** @var array<string, mixed> */
+    public $sentPayload = [];
+
+    /** @var int|null */
+    public $sentTimeout = null;
+
+    // Intercepted at sendConverseRequest() rather than sendJsonRequest() so the
+    // test does not depend on Bedrock's region/endpoint derivation.
+    protected function sendConverseRequest(
+        string $model,
+        array $payload,
+        int $timeoutSeconds,
+        array $configuration
+    ): array {
+        $this->sentPayload = $payload;
+        $this->sentTimeout = $timeoutSeconds;
+
+        return [
+            'output' => ['message' => ['content' => [['text' => 'ok']]]],
+            'stopReason' => 'end_turn',
+        ];
+    }
+}

--- a/plugins/AIProviders/tests/Unit/WebSearchTest.php
+++ b/plugins/AIProviders/tests/Unit/WebSearchTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Piwik\Plugins\AIProviders\AIConversationRequest;
 use Piwik\Plugins\AIProviders\AIProviderResponse;
 use Piwik\Plugins\AIProviders\AIRequest;
+use Piwik\Plugins\AIProviders\Exception\AIProviderClientException;
 use Piwik\Plugins\AIProviders\Provider\Anthropic;
 use Piwik\Plugins\AIProviders\Provider\Bedrock;
 use Piwik\Plugins\AIProviders\Provider\CustomProvider;
@@ -398,6 +399,51 @@ class WebSearchTest extends TestCase
         $this->assertStringContainsString(
             '"tools":[{"google_search":{}}]',
             (string) json_encode($gemini->sentPayload)
+        );
+    }
+
+    /**
+     * Verified against gemini-3.1-flash-lite: Gemini accepts the tool alongside a
+     * JSON request (HTTP 200) but then answers without searching, and asking for
+     * JSON suppresses grounding through the prompt instruction too — so dropping
+     * responseMimeType would not restore the search and would only lose the native
+     * format as well. The combination is therefore refused before anything is
+     * spent, for the same reason a provider with no web search at all is refused.
+     */
+    public function testGoogleRejectsWebSearchCombinedWithJsonMode(): void
+    {
+        $gemini = new WebSearchRecordingGoogle();
+
+        $this->expectException(AIProviderClientException::class);
+        $this->expectExceptionMessage('cannot combine web search with JSON mode');
+
+        $gemini->complete($this->groundedRequest()->withJsonResponse(), self::GEMINI_CONFIG);
+    }
+
+    /**
+     * Only the combination is refused: either option on its own is untouched.
+     */
+    public function testGoogleAcceptsJsonModeAndWebSearchSeparately(): void
+    {
+        $json = new WebSearchRecordingGoogle();
+        $json->mockResponse = [
+            'candidates' => [[
+                'content' => ['parts' => [['text' => '{"winner": "Spain"}']]],
+                'finishReason' => 'STOP',
+            ]],
+        ];
+        $jsonResponse = $json->complete($this->plainRequest()->withJsonResponse(), self::GEMINI_CONFIG);
+
+        $this->assertSame(['winner' => 'Spain'], $jsonResponse->getJsonData());
+        $this->assertArrayNotHasKey('tools', $json->sentPayload);
+
+        $grounded = new WebSearchRecordingGoogle();
+        $grounded->complete($this->groundedRequest(), self::GEMINI_CONFIG);
+
+        $this->assertArrayNotHasKey('responseMimeType', $grounded->sentPayload['generationConfig']);
+        $this->assertStringContainsString(
+            '"tools":[{"google_search":{}}]',
+            (string) json_encode($grounded->sentPayload)
         );
     }
 

--- a/plugins/AIProviders/tests/Unit/WebSearchTest.php
+++ b/plugins/AIProviders/tests/Unit/WebSearchTest.php
@@ -237,6 +237,28 @@ class WebSearchTest extends TestCase
         $this->assertSame('Matomo.', $claude->complete($this->plainRequest(), self::CLAUDE_CONFIG)->getText());
     }
 
+    /**
+     * An empty text block must not swallow the boundary the search blocks
+     * created, or the sentences either side of it run together again.
+     */
+    public function testAnthropicKeepsAPendingBoundaryAcrossAnEmptyTextBlock(): void
+    {
+        $claude = new WebSearchRecordingAnthropic();
+        $claude->mockResponse = [
+            'content' => [
+                ['type' => 'text', 'text' => 'Let me check.'],
+                ['type' => 'server_tool_use', 'id' => 's1', 'name' => 'web_search', 'input' => ['query' => 'q']],
+                ['type' => 'text', 'text' => ''],
+                ['type' => 'text', 'text' => 'Matomo leads.'],
+            ],
+            'stop_reason' => 'end_turn',
+        ];
+
+        $response = $claude->complete($this->groundedRequest(), self::CLAUDE_CONFIG);
+
+        $this->assertSame('Let me check. Matomo leads.', $response->getText());
+    }
+
     public function testAnthropicParsesCitationsQueriesAndRequestCount(): void
     {
         $claude = new WebSearchRecordingAnthropic();

--- a/plugins/AIProviders/tests/Unit/WebSearchUsageTest.php
+++ b/plugins/AIProviders/tests/Unit/WebSearchUsageTest.php
@@ -183,6 +183,18 @@ class WebSearchUsageTest extends TestCase
     }
 
     /**
+     * fromProviderData() takes raw provider JSON, so a query that is documented as
+     * a string can arrive as anything. Dropped rather than coerced, matching how
+     * every citation field is guarded.
+     */
+    public function testDropsQueriesThatAreNotStrings(): void
+    {
+        $usage = WebSearchUsage::fromProviderData([], 2, ['best analytics', 42, null, ['nested'], true]);
+
+        $this->assertSame(['best analytics'], $usage->getQueries());
+    }
+
+    /**
      * The providers disagree on what they report, so any positive evidence has to
      * count — otherwise spend that really happened would be reported as no search.
      *

--- a/plugins/AIProviders/tests/Unit/WebSearchUsageTest.php
+++ b/plugins/AIProviders/tests/Unit/WebSearchUsageTest.php
@@ -1,0 +1,201 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+declare(strict_types=1);
+
+namespace Piwik\Plugins\AIProviders\tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Piwik\Plugins\AIProviders\WebSearchUsage;
+
+/**
+ * Verifies the provider-agnostic normalisation of web search results: which
+ * citation URLs are accepted, how domains are derived, and when a search counts
+ * as having run.
+ *
+ * @group AIProviders
+ * @group Plugins
+ */
+class WebSearchUsageTest extends TestCase
+{
+    public function testNoneReportsUnusedWithEmptyData(): void
+    {
+        $usage = WebSearchUsage::none();
+
+        $this->assertFalse($usage->wasUsed());
+        $this->assertSame([], $usage->getCitations());
+        $this->assertSame([], $usage->getQueries());
+        $this->assertNull($usage->getRequestCount());
+    }
+
+    /**
+     * Citation URLs are model-controlled and callers render them as links, so
+     * anything that is not http(s) must be dropped rather than passed on.
+     */
+    public function testDropsCitationsThatAreNotHttpUrls(): void
+    {
+        $usage = WebSearchUsage::fromProviderData([
+            ['url' => 'javascript:alert(1)', 'title' => 'xss'],
+            ['url' => 'data:text/html;base64,PHNjcmlwdD4=', 'title' => 'data uri'],
+            ['url' => '/relative/path', 'title' => 'relative'],
+            ['url' => '', 'title' => 'empty'],
+            ['url' => 'https://matomo.org/blog', 'title' => 'kept'],
+        ], 1, []);
+
+        $citations = $usage->getCitations();
+
+        $this->assertCount(1, $citations);
+        $this->assertSame('https://matomo.org/blog', $citations[0]['url']);
+    }
+
+    public function testDeduplicatesCitationsByUrlKeepingTheFirst(): void
+    {
+        $usage = WebSearchUsage::fromProviderData([
+            ['url' => 'https://matomo.org/blog', 'title' => 'cited'],
+            ['url' => 'https://matomo.org/blog', 'title' => 'returned again'],
+        ], 1, []);
+
+        $citations = $usage->getCitations();
+
+        $this->assertCount(1, $citations);
+        $this->assertSame('cited', $citations[0]['title']);
+    }
+
+    public function testDerivesTheDomainFromTheUrlHostAndStripsWww(): void
+    {
+        $usage = WebSearchUsage::fromProviderData([
+            ['url' => 'https://WWW.Example.ORG/a/b?c=d', 'title' => 'Example'],
+        ], 1, []);
+
+        $this->assertSame('example.org', $usage->getCitations()[0]['domain']);
+    }
+
+    /**
+     * Google supplies the publisher domain separately because its URL is a
+     * redirect, so a provider-supplied domain must win over the URL host.
+     */
+    public function testKeepsAProviderSuppliedDomain(): void
+    {
+        $usage = WebSearchUsage::fromProviderData([
+            [
+                'url' => 'https://vertexaisearch.cloud.google.com/grounding-api-redirect/abc',
+                'title' => 'uefa.com',
+                'domain' => 'UEFA.com',
+            ],
+        ], 1, []);
+
+        $citation = $usage->getCitations()[0];
+
+        $this->assertSame('uefa.com', $citation['domain']);
+        $this->assertSame(
+            'https://vertexaisearch.cloud.google.com/grounding-api-redirect/abc',
+            $citation['url'],
+            'the redirect URL is preserved rather than replaced with a fabricated publisher URL'
+        );
+    }
+
+    /**
+     * Regression guard. An empty `domain` key is a deliberate "no trustworthy
+     * publisher domain", which Google emits when its citation URL is only a
+     * redirect. Deriving the domain from that URL anyway would label the source
+     * `vertexaisearch.cloud.google.com` — Google's host, not the publisher's.
+     */
+    public function testRespectsAnExplicitlyEmptyDomainInsteadOfDerivingFromTheUrl(): void
+    {
+        $usage = WebSearchUsage::fromProviderData([
+            [
+                'url' => 'https://vertexaisearch.cloud.google.com/grounding-api-redirect/abc',
+                'title' => 'Who won Euro 2024 - full report',
+                'domain' => '',
+            ],
+        ], 1, []);
+
+        $this->assertSame('', $usage->getCitations()[0]['domain']);
+    }
+
+    /**
+     * The counterpart: a citation that omits the key entirely does get the host
+     * derived from its URL. This is how Anthropic and OpenAI citations work.
+     */
+    public function testDerivesTheDomainWhenTheKeyIsAbsent(): void
+    {
+        $usage = WebSearchUsage::fromProviderData([
+            ['url' => 'https://matomo.org/blog/x', 'title' => 'Matomo Blog'],
+        ], 1, []);
+
+        $this->assertSame('matomo.org', $usage->getCitations()[0]['domain']);
+    }
+
+    public function testNormalisesAProviderSuppliedDomainWithWwwPrefix(): void
+    {
+        $usage = WebSearchUsage::fromProviderData([
+            ['url' => 'https://example.org/a', 'title' => 'Example', 'domain' => 'WWW.Example.ORG.'],
+        ], 1, []);
+
+        $this->assertSame('example.org', $usage->getCitations()[0]['domain']);
+    }
+
+    public function testDeduplicatesAndTrimsQueries(): void
+    {
+        $usage = WebSearchUsage::fromProviderData([], 2, ['  best analytics  ', 'best analytics', '']);
+
+        $this->assertSame(['best analytics'], $usage->getQueries());
+    }
+
+    /**
+     * The providers disagree on what they report, so any positive evidence has to
+     * count — otherwise spend that really happened would be reported as no search.
+     *
+     * @dataProvider getUsedEvidence
+     * @param list<array{url?: mixed, title?: mixed, domain?: mixed}> $citations
+     * @param list<string> $queries
+     */
+    public function testWasUsedIsTrueOnAnyPositiveEvidence(array $citations, ?int $requestCount, array $queries): void
+    {
+        $this->assertTrue(WebSearchUsage::fromProviderData($citations, $requestCount, $queries)->wasUsed());
+    }
+
+    /**
+     * @return iterable<string, array{list<array<string, mixed>>, int|null, list<string>}>
+     */
+    public function getUsedEvidence(): iterable
+    {
+        // OpenAI can cite without echoing the query it used.
+        yield 'citations only' => [[['url' => 'https://matomo.org']], null, []];
+        // Google can report a query whose chunk yielded no usable URL.
+        yield 'queries only' => [[], null, ['best analytics']];
+        // Anthropic counts a search that returned an error or nothing usable.
+        yield 'request count only' => [[], 1, []];
+    }
+
+    public function testWasUsedIsFalseWhenTheModelDidNotSearch(): void
+    {
+        $usage = WebSearchUsage::fromProviderData([], 0, []);
+
+        $this->assertFalse($usage->wasUsed());
+        $this->assertSame(0, $usage->getRequestCount(), 'a reported zero is not the same as "cannot report"');
+    }
+
+    public function testToArrayShape(): void
+    {
+        $usage = WebSearchUsage::fromProviderData(
+            [['url' => 'https://matomo.org/blog', 'title' => 'Matomo']],
+            1,
+            ['best analytics']
+        );
+
+        $this->assertSame([
+            'citations' => [
+                ['url' => 'https://matomo.org/blog', 'title' => 'Matomo', 'domain' => 'matomo.org'],
+            ],
+            'requestCount' => 1,
+            'queries' => ['best analytics'],
+        ], $usage->toArray());
+    }
+}

--- a/plugins/AIProviders/tests/Unit/WebSearchUsageTest.php
+++ b/plugins/AIProviders/tests/Unit/WebSearchUsageTest.php
@@ -141,6 +141,40 @@ class WebSearchUsageTest extends TestCase
         $this->assertSame('example.org', $usage->getCitations()[0]['domain']);
     }
 
+    public function testKeepsWwwWhenStrippingItWouldLeaveABareSuffix(): void
+    {
+        $usage = WebSearchUsage::fromProviderData(
+            [['url' => 'https://www.com/a']],
+            1,
+            []
+        );
+
+        $this->assertSame('www.com', $usage->getCitations()[0]['domain']);
+    }
+
+    public function testCapsUntrustedTitleAndQueryLength(): void
+    {
+        $usage = WebSearchUsage::fromProviderData(
+            [['url' => 'https://example.org/a', 'title' => str_repeat('t', 400)]],
+            1,
+            [str_repeat('q', 400)]
+        );
+
+        $this->assertSame(300, mb_strlen($usage->getCitations()[0]['title']));
+        $this->assertSame(300, mb_strlen($usage->getQueries()[0]));
+    }
+
+    public function testDropsAnAbsurdlyLongUrl(): void
+    {
+        $usage = WebSearchUsage::fromProviderData(
+            [['url' => 'https://example.org/' . str_repeat('a', 2100)]],
+            1,
+            []
+        );
+
+        $this->assertSame([], $usage->getCitations());
+    }
+
     public function testDeduplicatesAndTrimsQueries(): void
     {
         $usage = WebSearchUsage::fromProviderData([], 2, ['  best analytics  ', 'best analytics', '']);
@@ -180,22 +214,5 @@ class WebSearchUsageTest extends TestCase
 
         $this->assertFalse($usage->wasUsed());
         $this->assertSame(0, $usage->getRequestCount(), 'a reported zero is not the same as "cannot report"');
-    }
-
-    public function testToArrayShape(): void
-    {
-        $usage = WebSearchUsage::fromProviderData(
-            [['url' => 'https://matomo.org/blog', 'title' => 'Matomo']],
-            1,
-            ['best analytics']
-        );
-
-        $this->assertSame([
-            'citations' => [
-                ['url' => 'https://matomo.org/blog', 'title' => 'Matomo', 'domain' => 'matomo.org'],
-            ],
-            'requestCount' => 1,
-            'queries' => ['best analytics'],
-        ], $usage->toArray());
     }
 }


### PR DESCRIPTION
### Description                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                   
  Ticket: ID-247                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                   
  Implements provider-side web search (grounding) in `AIProviders`. `AIRequest::withWebSearchEnabled()` was advisory and is now honoured.                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                   
  - Anthropic, Google and OpenAI run the provider's server-side search; the model still decides whether a prompt needs one.                                                                                                                                                                                        
  - `AIProviderResponse` reports what actually happened: `wasWebSearchUsed()`, `getWebSearchCitations()` (`url`/`title`/`domain`), `getWebSearchRequestCount()`, `getWebSearchQueries()`. The new `WebSearchUsage`                                                                                                 
  normalises the three provider shapes; URLs are http(s)-only, titles and queries are length-capped and documented as untrusted.                                                                                                                                                                                   
  - Providers without search (Bedrock, custom) reject a grounded request with `AIProviderClientException` instead of answering ungrounded. `AIProviderService::canUseWebSearch()` and a `supportsWebSearch` status key                                                                                             
  let a caller check before spending.                                                                                                                                                                                                                                                                              
  - `AIRequest::withTimeoutSeconds()`; grounded completions default to 120s and are intended for CLI and scheduled tasks.                                                                                                                                                                                          
  - OpenAI grounded completions use the Responses API (`web_search` is not available on chat completions) with `store: false`. Ungrounded completions are unchanged.                                                                                                                                               
  - Google rejects web search combined with JSON mode: Gemini accepts the request and then never searches (verified live).                                                                                                                                No changes this session                                  
  - Stop reasons: Google's `finishReason` is mapped onto the vocabulary the conversation path uses; grounded OpenAI reports `stop`/`length` like its ungrounded path.                                                                                                                                              
  - Compatibility: no breaking changes. The `AIProviderResponse` positional constructor shape from 5.13.0 still works. `isWebSearchEnabled()`, the `webSearchEnabled` array key, the `$webSearchEnabled` constructor                                                                                               
  parameter and the `isWebSearchUsed()` provider hook are deprecated (removal in Matomo 6), see CHANGELOG.                                                                                                                                                                                                         
  - Grounding is not a marginal cost: every provider bills per search plus retrieved page content as input tokens. Caps: Anthropic `max_uses: 5`, OpenAI `search_context_size: medium`, Google none.                                                                                                               
  - Verified live against Anthropic and Google. The OpenAI grounded path is covered by mocked unit and integration tests only; no OpenAI credits were available to run it.                                                                                                                                         
                                                                                                                                                                                                                                                                                                                   
  ### Checklist                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                   
  - [✔] I have understood, reviewed, and tested all AI outputs before use                                                                                                                                                                                                                                          
  - [✔] All AI instructions respect security, IP, and privacy rules                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                   
  ### Review                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                   
  - [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)                                                                                                                                                                                                  
  - [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or                                                                                                
  possible interactions with other Matomo subsystems)                                                                                                                                                                                                                                                              
  - [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)                                                                                                
  - [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)                                                                                                                                                                                                                    
  - [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)                                                                                                                                                                                           
  - [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)                                                                                                                                                                                                              
  - [x] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)                                                                                                                                                                         
  - [x] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)                                                                                                                                                                                    
  - [x] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)                                                                                                                                                                    
  - [x] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)